### PR TITLE
Added missing stdexcept header, fixes #61

### DIFF
--- a/src/osgPlugins/dae/daeWriter.cpp
+++ b/src/osgPlugins/dae/daeWriter.cpp
@@ -19,6 +19,7 @@
 #include <dom/domConstants.h>
 
 #include <sstream>
+#include <stdexcept>
 #include <osgDB/ConvertUTF>
 #include <limits>
 


### PR DESCRIPTION
As the title says this will fix the build on some more pedantic systems.
See also #61 which is fixed by this one.