### PR TITLE
initial travis file, support for ubuntu trusty and osx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+matrix:
+  fast_finish: true
+  include:
+    #Linux build
+    - os: linux
+      dist: trusty
+      language: cpp
+      env:
+         #- LLVM_VERSION=3.8
+      sudo: false
+      cache:
+        apt: true
+        directories:
+          - $HOME/.ccache
+      compiler: 
+          #- clang 
+          - g++
+      addons:
+        apt:
+          sources:
+            #- llvm-toolchain-precise-3.8
+            - ubuntu-toolchain-r-test
+          packages:
+            #- clang-3.8
+            - g++
+            - cmake
+    # OSX build
+    - os: osx
+      language: cpp
+
+script:
+   - mkdir build
+   - cd build
+   - travis_wait 60 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../product -DBUILD_OSG_EXAMPLES=ON ..
+   - make install -j3
+


### PR DESCRIPTION
You only need to login in travis and activate it for the osg github repo. There are only a few options in settings so it is pretty straight forward. Ping me if you have any problem setting it up. 