### PR TITLE
Mods to make GL3 profile work on MacOSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,6 +472,7 @@ IF (OSG_GL3_AVAILABLE)
     IF (APPLE)
         SET(OPENGL_HEADER1 "#include <OpenGL/gl.h>" CACHE STRING "#include<> line for OpenGL Header")
         SET(OPENGL_HEADER2 "#include <OpenGL/gl3.h>" CACHE STRING "#include<> line for additional OpenGL Headers if required")
+        ADD_DEFINITIONS(-DGL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED)
     ELSE()
 
         IF (OPENGL_PROFILE STREQUAL "GLCORE")

--- a/examples/osgsimplegl3/osgsimplegl3.cpp
+++ b/examples/osgsimplegl3/osgsimplegl3.cpp
@@ -10,6 +10,7 @@
 
 #include <osgViewer/Viewer>
 #include <osgDB/ReadFile>
+#include <osgUtil/Optimizer>
 #include <osg/GraphicsContext>
 #include <osg/Camera>
 #include <osg/Viewport>
@@ -73,6 +74,11 @@ int main( int argc, char** argv )
         osg::notify( osg::FATAL ) << "Unable to load model from command line." << std::endl;
         return( 1 );
     }
+
+
+    osgUtil::Optimizer optimizer;
+    optimizer.optimize(root.get(), osgUtil::Optimizer::ALL_OPTIMIZATIONS|osgUtil::Optimizer::TESSELLATE_GEOMETRY);
+
     configureShaders( root->getOrCreateStateSet() );
 
     const int width( 800 ), height( 450 );
@@ -118,7 +124,7 @@ OSG currently support OpenGL 3.x on Windows. This comment block describes the
 necessary configuration steps.
 
 Get the draft gl3.h header file from OpenGL.org and put it in a folder called
-“GL3” somewhere on your hard drive. OSG includes this header as <GL3/gl3.h>. Get
+"GL3" somewhere on your hard drive. OSG includes this header as <GL3/gl3.h>. Get
 gl3.h from here:
 http://www.opengl.org/registry/
 

--- a/include/osg/BufferObject
+++ b/include/osg/BufferObject
@@ -247,6 +247,7 @@ class OSG_EXPORT GLBufferObject : public Referenced
 
         unsigned int            _contextID;
         GLuint                  _glObjectID;
+        GLuint                  _glVaoID;
 
         BufferObjectProfile     _profile;
         unsigned int            _allocatedSize;

--- a/src/OpenThreads/qt/CMakeLists.txt
+++ b/src/OpenThreads/qt/CMakeLists.txt
@@ -77,5 +77,5 @@ if(MSVC)
         DESTINATION bin
         COMPONENT libopenthreads
     )
-)
+endif()
 #commented out# INCLUDE(ModuleInstall OPTIONAL)

--- a/src/osg/BufferObject.cpp
+++ b/src/osg/BufferObject.cpp
@@ -68,6 +68,10 @@ GLBufferObject::GLBufferObject(unsigned int contextID, BufferObject* bufferObjec
 
     if (glObjectID==0)
     {
+#if defined(OSG_GL3_AVAILABLE) && defined(__APPLE__)
+        _extensions->glGenVertexArrays(1, &_glVaoID );
+        _extensions->glBindVertexArray( _glVaoID );
+#endif
         _extensions->glGenBuffers(1, &_glObjectID);
     }
 
@@ -243,7 +247,10 @@ void GLBufferObject::deleteGLObject()
     {
         _extensions->glDeleteBuffers(1, &_glObjectID);
         _glObjectID = 0;
-
+#if defined(OSG_GL3_AVAILABLE) && defined(__APPLE__)
+        _extensions->glDeleteVertexArrays(1, &_glVaoID );
+        _glVaoID = 0;
+#endif
         _allocatedSize = 0;
         _bufferEntries.clear();
     }

--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -25,6 +25,9 @@ Geometry::Geometry():
     _supportsVertexBufferObjects = true;
     // temporary test
     // setSupportsDisplayList(false);
+#ifndef OSG_GL_FIXED_FUNCTION_AVAILABLE
+    _useVertexBufferObjects = true;
+#endif
 }
 
 Geometry::Geometry(const Geometry& geometry,const CopyOp& copyop):
@@ -40,6 +43,9 @@ Geometry::Geometry(const Geometry& geometry,const CopyOp& copyop):
     // temporary test
     // setSupportsDisplayList(false);
 
+#ifndef OSG_GL_FIXED_FUNCTION_AVAILABLE
+    _useVertexBufferObjects = true;
+#endif
     for(PrimitiveSetList::const_iterator pitr=geometry._primitives.begin();
         pitr!=geometry._primitives.end();
         ++pitr)

--- a/src/osgUtil/SceneView.cpp
+++ b/src/osgUtil/SceneView.cpp
@@ -310,7 +310,9 @@ void SceneView::init()
 
     // force the initialization of the OpenGL extension string
     // to try and work around a Windows NVidia driver bug circa Oct 2006.
+#ifndef __APPLE__
     osg::isGLExtensionSupported(_renderInfo.getState()->getContextID(),"");
+#endif
 
     if (_camera.valid() && _initVisitor.valid())
     {

--- a/src/osgViewer/GraphicsWindowCocoa.mm
+++ b/src/osgViewer/GraphicsWindowCocoa.mm
@@ -12,6 +12,7 @@
  */
 
 #include <iostream>
+#include <osg/GL>
 #include <osgViewer/api/Cocoa/PixelBufferCocoa>
 #include <osgViewer/api/Cocoa/GraphicsWindowCocoa>
 
@@ -1202,6 +1203,11 @@ bool GraphicsWindowCocoa::realizeImplementation()
         attr[i++] = static_cast<NSOpenGLPixelFormatAttribute>(_traits->samples);
     }
 
+#ifdef OSG_GL3_AVAILABLE
+    attr[i++] = NSOpenGLPFAOpenGLProfile;
+    attr[i++] = NSOpenGLProfileVersion3_2Core;
+    OSG_INFO << "GraphicsWindowCocoa::realizeImplementation set up for GL3"<< std::endl;
+#endif
 
     attr[i++] = NSOpenGLPFAAccelerated;
     attr[i] = static_cast<NSOpenGLPixelFormatAttribute>(0);

--- a/src/osgViewer/PixelBufferCocoa.mm
+++ b/src/osgViewer/PixelBufferCocoa.mm
@@ -56,6 +56,12 @@ bool PixelBufferCocoa::realizeImplementation()
         attr[i++] = static_cast<NSOpenGLPixelFormatAttribute>(_traits->samples);
     }
 
+#ifdef OSG_GL3_AVAILABLE
+    attr[i++] = NSOpenGLPFAOpenGLProfile;
+    attr[i++] = NSOpenGLProfileVersion3_2Core;
+    OSG_INFO << "PixelBufferCocoa::realizeImplementation set up for GL3"<< std::endl;
+#endif
+
     attr[i++] = NSOpenGLPFAPixelBuffer; // for pbuffer usage
     attr[i++] = NSOpenGLPFAAccelerated;
     attr[i] = static_cast<NSOpenGLPixelFormatAttribute>(0);


### PR DESCRIPTION
Following some (old) thread on GL3 and Mac, I managed to get it working with the osgsimplegl3 sample (I added an Optimizer to tessellate since Polygons and Quads don't get handled anymore by OpenGL )

The path followed is to attach VBO to VAO on Mac GL3 profile.

I added _useVertexBufferObjects=true when fixed pipeline isn't available to geometries.