### PR TITLE
visual studio 2015 warning fixes:

### DIFF
--- a/src/osgPlugins/dae/daeRAnimations.cpp
+++ b/src/osgPlugins/dae/daeRAnimations.cpp
@@ -467,14 +467,14 @@ void daeReader::processAnimationMap(const TargetChannelPartMap& tcm, osgAnimatio
             else if (MatrixCubicBezierKeyframeContainer* cbkfCntr =
                 dynamic_cast<MatrixCubicBezierKeyframeContainer*>(channelPart->keyframes.get()))
             {
-                osgAnimation::MatrixKeyframeContainer* kfCntr = new osgAnimation::MatrixKeyframeContainer;
+                osgAnimation::MatrixKeyframeContainer* cbCntr = new osgAnimation::MatrixKeyframeContainer;
                 for (size_t i = 0; i < cbkfCntr->size(); ++i)
                 {
                     const MatrixCubicBezierKeyframe& cbkf = cbkfCntr->at(i);
-                    kfCntr->push_back(osgAnimation::MatrixKeyframe(cbkf.getTime(), cbkf.getValue().getPosition()));
+                    cbCntr->push_back(osgAnimation::MatrixKeyframe(cbkf.getTime(), cbkf.getValue().getPosition()));
                 }
                 osgAnimation::MatrixLinearChannel* channel = new osgAnimation::MatrixLinearChannel;
-                channel->getOrCreateSampler()->setKeyframeContainer(kfCntr);
+                channel->getOrCreateSampler()->setKeyframeContainer(cbCntr);
                 pOsgAnimationChannel = channel;
             }
         }

--- a/src/osgPlugins/dae/daeReader.cpp
+++ b/src/osgPlugins/dae/daeReader.cpp
@@ -185,9 +185,9 @@ bool daeReader::processDocument( const std::string& fileURI)
         // identify every node as a joint, making it meaningless.
         std::vector<domInstance_controller*> instanceControllers;
         database->typeLookup(instanceControllers);
-        for (size_t i = 0; i < instanceControllers.size(); ++i)
+        for (size_t controller = 0; controller < instanceControllers.size(); ++controller)
         {
-            domInstance_controller* pInstanceController = instanceControllers[i];
+            domInstance_controller* pInstanceController = instanceControllers[controller];
 
             domController *pDomController = daeSafeCast<domController>(getElementFromURI(pInstanceController->getUrl()));
             if (!pDomController)


### PR DESCRIPTION
OpenSceneGraph\src\osgPlugins\dae\daeRAnimations.cpp(470): warning C4456: declaration of 'kfCntr' hides previous local declaration
  OpenSceneGraph\src\osgPlugins\dae\daeRAnimations.cpp(452): note: see declaration of 'kfCntr'
OpenSceneGraph\src\osgPlugins\dae\daeReader.cpp(202): warning C4456: declaration of 'i' hides previous local declaration
  OpenSceneGraph\src\osgPlugins\dae\daeReader.cpp(188): note: see declaration of 'i'
OpenSceneGraph\src\osgPlugins\dae\daeReader.cpp(226): warning C4456: declaration of 'i' hides previous local declaration
  OpenSceneGraph\src\osgPlugins\dae\daeReader.cpp(188): note: see declaration of 'i'
OpenSceneGraph\src\osgPlugins\dae\daeReader.cpp(243): warning C4456: declaration of 'i' hides previous local declaration
  OpenSceneGraph\src\osgPlugins\dae\daeReader.cpp(188): note: see declaration of 'i'
OpenSceneGraph\src\osgPlugins\dae\daeReader.cpp(253): warning C4456: declaration of 'i' hides previous local declaration
  OpenSceneGraph\src\osgPlugins\dae\daeReader.cpp(188): note: see declaration of 'i'