### PR TITLE
CleanUpOperation added to Viewer

### DIFF
--- a/include/osgViewer/ViewerBase
+++ b/include/osgViewer/ViewerBase
@@ -193,6 +193,11 @@ class OSGVIEWER_EXPORT ViewerBase : public virtual osg::Object
         /** Get the graphics operation to call on realization of the viewers graphics windows.*/
         osg::Operation* getRealizeOperation() { return _realizeOperation.get(); }
 
+        /** Set the graphics operation to call before the viewers graphics contexts close.*/
+        void setCleanUpOperation(osg::Operation* op) { _cleanUpOperation = op; }
+
+        /** Get the graphics operation to call before the viewers graphics contexts close.*/
+        osg::Operation* getCleanUpOperation() { return _cleanUpOperation.get(); }
 
         /** Set the incremental compile operation.
           * Used to manage the OpenGL object compilation and merging of subgraphs in a way that avoids overloading
@@ -336,6 +341,7 @@ protected:
         osg::ref_ptr<osgUtil::UpdateVisitor>                _updateVisitor;
 
         osg::ref_ptr<osg::Operation>                        _realizeOperation;
+        osg::ref_ptr<osg::Operation>                        _cleanUpOperation;
         osg::ref_ptr<osgUtil::IncrementalCompileOperation>  _incrementalCompileOperation;
 
         osg::observer_ptr<osg::GraphicsContext>             _currentContext;

--- a/src/osgViewer/CompositeViewer.cpp
+++ b/src/osgViewer/CompositeViewer.cpp
@@ -126,7 +126,19 @@ CompositeViewer::~CompositeViewer()
         citr != contexts.end();
         ++citr)
     {
-        (*citr)->close();
+        osg::GraphicsContext* gc = *citr;
+
+        // Run destroy operation on each context before closing it
+        if (_cleanUpOperation.valid() && gc->valid())
+        {
+            gc->makeCurrent();
+
+            (*_cleanUpOperation)(gc);
+
+            gc->releaseContext();
+        }
+
+        gc->close();
     }
 
     OSG_INFO<<"finished CompositeViewer::~CompositeViewer()"<<std::endl;

--- a/src/osgViewer/Viewer.cpp
+++ b/src/osgViewer/Viewer.cpp
@@ -238,7 +238,19 @@ Viewer::~Viewer()
         citr != contexts.end();
         ++citr)
     {
-        (*citr)->close();
+        osg::GraphicsContext* gc = *citr;
+
+        // Run destroy operation on each context before closing it
+        if (_cleanUpOperation.valid() && gc->valid())
+        {
+            gc->makeCurrent();
+
+            (*_cleanUpOperation)(gc);
+
+            gc->releaseContext();
+        }
+
+        gc->close();
     }
 
     //OSG_NOTICE<<"finish Viewer::~Viewer()"<<std::endl;
@@ -275,6 +287,7 @@ void Viewer::take(osg::View& rhs)
         _updateVisitor = rhs_viewer->_updateVisitor;
 
         _realizeOperation = rhs_viewer->_realizeOperation;
+        _cleanUpOperation = rhs_viewer->_cleanUpOperation;
         _currentContext = rhs_viewer->_currentContext;
 
 
@@ -287,6 +300,7 @@ void Viewer::take(osg::View& rhs)
         rhs_viewer->_updateOperations = 0;
         rhs_viewer->_updateVisitor = 0;
         rhs_viewer->_realizeOperation = 0;
+        rhs_viewer->_cleanUpOperation = 0;
         rhs_viewer->_currentContext = 0;
 
     }


### PR DESCRIPTION
Sometimes there is need to do cleanup with valid graphic contexts before destroying these contexts. The added operation runs a graphics operation on each context before closing them.