### PR TITLE
Updates osgAnimation

### DIFF
--- a/include/osg/Array
+++ b/include/osg/Array
@@ -42,6 +42,7 @@
 #include <osg/Vec4d>
 #include <osg/Matrix>
 #include <osg/Matrixd>
+#include <osg/Quat>
 
 #include <osg/BufferObject>
 
@@ -109,7 +110,9 @@ class OSG_EXPORT Array : public BufferData
             Vec4dArrayType    = 32,
 
             MatrixArrayType   = 33,
-            MatrixdArrayType  = 34
+            MatrixdArrayType  = 34,
+
+            QuatArrayType     = 35
         };
 
         enum Binding
@@ -434,6 +437,8 @@ typedef TemplateArray<Vec4d,Array::Vec4dArrayType,4,GL_DOUBLE>                  
 typedef TemplateArray<Matrixf,Array::MatrixArrayType,16,GL_FLOAT>               MatrixfArray;
 typedef TemplateArray<Matrixd,Array::MatrixdArrayType,16,GL_DOUBLE>             MatrixdArray;
 
+typedef TemplateArray<Quat,Array::QuatArrayType,4,GL_DOUBLE>                    QuatArray;
+
 
 class ArrayVisitor
 {
@@ -600,6 +605,8 @@ class ValueVisitor
 
         virtual void apply(Matrixf&) {}
         virtual void apply(Matrixd&) {}
+
+        virtual void apply(Quat&) {}
 };
 
 class ConstValueVisitor
@@ -654,6 +661,8 @@ class ConstValueVisitor
 
         virtual void apply(const Matrixf&) {}
         virtual void apply(const Matrixd&) {}
+
+        virtual void apply(const Quat&) {}
 };
 
 template<typename T, Array::Type ARRAYTYPE, int DataSize, int DataType>

--- a/include/osg/Quat
+++ b/include/osg/Quat
@@ -31,7 +31,11 @@ class OSG_EXPORT Quat
 
     public:
 
+        /** Data type of vector components.*/
         typedef double value_type;
+
+        /** Number of vector components. */
+        enum { num_components = 4 };
 
         value_type  _v[4];    // a four-vector
 

--- a/include/osgAnimation/Animation
+++ b/include/osgAnimation/Animation
@@ -70,6 +70,7 @@ namespace osgAnimation
          */
         void computeDuration();
         double getDuration() const;
+        double computeDurationFromChannels() const;
 
         void setWeight (float weight);
         float getWeight() const;
@@ -86,8 +87,6 @@ namespace osgAnimation
     protected:
 
         ~Animation() {}
-
-        double computeDurationFromChannels() const;
 
         double _duration;
         double _originalDuration;

--- a/include/osgAnimation/Keyframe
+++ b/include/osgAnimation/Keyframe
@@ -68,6 +68,7 @@ namespace osgAnimation
     public:
         KeyframeContainer() {}
         virtual unsigned int size() const = 0;
+        virtual unsigned int linearInterpolationDeduplicate() = 0;
     protected:
         ~KeyframeContainer() {}
         std::string _name;
@@ -83,7 +84,39 @@ namespace osgAnimation
         typedef TemplateKeyframe<T> KeyType;
         typedef typename osg::MixinVector< TemplateKeyframe<T> > VectorType;
         virtual unsigned int size() const { return (unsigned int)osg::MixinVector<TemplateKeyframe<T> >::size(); }
+        virtual unsigned int linearInterpolationDeduplicate() {
+            if(size() <= 1) {
+                return 0;
+            }
 
+            typename VectorType::iterator keyframe = VectorType::begin(),
+                                            previous = VectorType::begin();
+            // 1. find number of consecutives identical keyframes
+            std::vector<unsigned int> intervalSizes;
+            unsigned int intervalSize = 1;
+            for(++ keyframe ; keyframe != VectorType::end() ; ++ keyframe, ++ previous, ++ intervalSize) {
+                if(!(previous->getValue() == keyframe->getValue())) {
+                    intervalSizes.push_back(intervalSize);
+                    intervalSize = 0;
+                }
+            }
+            intervalSizes.push_back(intervalSize);
+
+            // 2. build deduplicated list of keyframes
+            unsigned int cumul = 0;
+            VectorType deduplicated;
+            for(std::vector<unsigned int>::iterator iterator = intervalSizes.begin() ; iterator != intervalSizes.end() ; ++ iterator) {
+                deduplicated.push_back((*this)[cumul]);
+                if(*iterator > 1) {
+                    deduplicated.push_back((*this)[cumul + (*iterator) - 1]);
+                }
+                cumul += *iterator;
+            }
+
+            unsigned int count = size() - deduplicated.size();
+            this->swap(deduplicated);
+            return count;
+        }
     };
 
     template <>

--- a/src/osgAnimation/RigGeometry.cpp
+++ b/src/osgAnimation/RigGeometry.cpp
@@ -24,7 +24,7 @@ osg::BoundingBox RigComputeBoundingBoxCallback::computeBound(const osg::Drawable
 {
     const osgAnimation::RigGeometry& rig = dynamic_cast<const osgAnimation::RigGeometry&>(drawable);
 
-    // if a valid inital bounding box is set we use it without asking more
+    // if a valid initial bounding box is set we use it without asking more
     if (rig.getInitialBound().valid())
         return rig.getInitialBound();
 

--- a/src/osgWrappers/serializers/osgAnimation/UpdateMorph.cpp
+++ b/src/osgWrappers/serializers/osgAnimation/UpdateMorph.cpp
@@ -11,6 +11,7 @@ REGISTER_OBJECT_WRAPPER( osgAnimation_UpdateMorph,
                          osgAnimation::UpdateMorph,
                          "osg::Object osg::Callback osg::NodeCallback osgAnimation::UpdateMorph" )
 {
+    ADD_VECTOR_SERIALIZER( TargetNames, osgAnimation::UpdateMorph::TargetNames, osgDB::BaseSerializer::RW_STRING, 1 );
 }
 
 #undef OBJECT_CAST


### PR DESCRIPTION
This updates is mainly for the gles plugint to work correctly.

* adds Quaternion array
* reintroduces `KeyframeContainer::linearInterpolationDeduplicate`
* fixes MorphGeometry OSG serialization (target names)