### PR TITLE
streamline DatabasePager::requiresUpdateSceneGraph()

### DIFF
--- a/include/osgDB/DatabasePager
+++ b/include/osgDB/DatabasePager
@@ -244,6 +244,9 @@ class OSGDB_EXPORT DatabasePager : public osg::NodeVisitor::DatabaseRequestHandl
           * Note, must only be called from single thread update phase. */
         virtual void updateSceneGraph(const osg::FrameStamp& frameStamp);
 
+        /** Return true if there are ... . */
+        bool requiresRedraw() const;
+
         /** Report how many items are in the _fileRequestList queue */
         unsigned int getFileRequestListSize() const { return static_cast<unsigned int>(_fileRequestQueue->size() + _httpRequestQueue->size()); }
 

--- a/include/osgViewer/Scene
+++ b/include/osgViewer/Scene
@@ -49,6 +49,7 @@ class OSGVIEWER_EXPORT Scene : public osg::Referenced
 
         virtual void updateSceneGraph(osg::NodeVisitor& updateVisitor);
 
+        virtual bool requiresRedraw() const;
 
         /** Get the Scene object that has the specified node assigned to it.
           * return 0 if no Scene has yet been assigned the specified node.*/

--- a/src/osgDB/DatabasePager.cpp
+++ b/src/osgDB/DatabasePager.cpp
@@ -1371,10 +1371,7 @@ bool DatabasePager::getRequestsInProgress() const
 {
     if (getFileRequestListSize()>0) return true;
 
-    if (getDataToCompileListSize()>0)
-    {
-        return true;
-    }
+    if (getDataToCompileListSize()>0) return true;
 
     if (getDataToMergeListSize()>0) return true;
 
@@ -1595,7 +1592,11 @@ void DatabasePager::setDatabasePagerThreadPause(bool pause)
 
 bool DatabasePager::requiresUpdateSceneGraph() const
 {
-    return !(_dataToMergeList->empty());
+    if (getDataToCompileListSize()>0) return true;
+
+    if (getDataToMergeListSize()>0) return true;
+
+    return false;
 }
 
 void DatabasePager::updateSceneGraph(const osg::FrameStamp& frameStamp)

--- a/src/osgDB/DatabasePager.cpp
+++ b/src/osgDB/DatabasePager.cpp
@@ -1592,8 +1592,6 @@ void DatabasePager::setDatabasePagerThreadPause(bool pause)
 
 bool DatabasePager::requiresUpdateSceneGraph() const
 {
-    if (getDataToCompileListSize()>0) return true;
-
     if (getDataToMergeListSize()>0) return true;
 
     return false;
@@ -1637,6 +1635,12 @@ void DatabasePager::updateSceneGraph(const osg::FrameStamp& frameStamp)
 #endif
 }
 
+bool DatabasePager::requiresRedraw() const
+{
+    if (getDataToCompileListSize()>0) return true;
+
+    return false;
+}
 
 void DatabasePager::addLoadedDataToSceneGraph(const osg::FrameStamp &frameStamp)
 {

--- a/src/osgPresentation/SlideEventHandler.cpp
+++ b/src/osgPresentation/SlideEventHandler.cpp
@@ -1712,9 +1712,11 @@ bool SlideEventHandler::checkNeedToDoFrame()
         if (_viewer->getRequestRedraw()) return true;
         if (_viewer->getRequestContinousUpdate()) return true;
 
-        // If the database pager is going to update the scene the render flag is
-        // set so that the updates show up
-        if(_viewer->getDatabasePager()->requiresUpdateSceneGraph() || _viewer->getDatabasePager()->getRequestsInProgress()) return true;
+        // check if the database pager needs to update the scene
+        if (_viewer->getDatabasePager()->requiresUpdateSceneGraph()) return true;
+
+        // check if the image pager needs to update the scene
+        if (_viewer->getImagePager()->requiresUpdateSceneGraph()) return true;
 
         // if there update callbacks then we need to do frame.
         if (_viewer->getCamera()->getUpdateCallback()) return true;
@@ -1725,7 +1727,7 @@ bool SlideEventHandler::checkNeedToDoFrame()
             {
                 if (_slideSwitch->getChild(_activeLayer)->getNumChildrenRequiringUpdateTraversal()>0) return true;
             }
-            else if (_viewer->getSceneData()!=0 && _viewer->getSceneData()->getNumChildrenRequiringUpdateTraversal()>0) return true;
+            else if (_viewer->getSceneData()!=0 && (_viewer->getSceneData()->getUpdateCallback() || (_viewer->getSceneData()->getNumChildrenRequiringUpdateTraversal()>0))) return true;
 
             if (_autoSteppingActive)
             {
@@ -1753,4 +1755,3 @@ bool SlideEventHandler::checkNeedToDoFrame()
         return true;
     }
 }
-

--- a/src/osgViewer/Scene.cpp
+++ b/src/osgViewer/Scene.cpp
@@ -116,7 +116,7 @@ void Scene::setImagePager(osgDB::ImagePager* ip)
 bool Scene::requiresUpdateSceneGraph() const
 {
     // check if the database pager needs to update the scene
-    if (getDatabasePager()->requiresUpdateSceneGraph() || getDatabasePager()->getRequestsInProgress()) return true;
+    if (getDatabasePager()->requiresUpdateSceneGraph()) return true;
 
     // check if the image pager needs to update the scene
     if (getImagePager()->requiresUpdateSceneGraph()) return true;

--- a/src/osgViewer/Scene.cpp
+++ b/src/osgViewer/Scene.cpp
@@ -150,6 +150,14 @@ void Scene::updateSceneGraph(osg::NodeVisitor& updateVisitor)
     }
 }
 
+bool Scene::requiresRedraw() const
+{
+    // check if the database pager needs a redraw
+    if (getDatabasePager()->requiresRedraw()) return true;
+
+    return false;
+}
+
 
 Scene* Scene::getScene(osg::Node* node)
 {

--- a/src/osgViewer/View.cpp
+++ b/src/osgViewer/View.cpp
@@ -1135,7 +1135,7 @@ bool View::requiresUpdateSceneGraph() const
     // check if there are camera update callbacks
     if (_camera->getUpdateCallback()) return true;
 
-    // check if there scene requires an update traversal
+    // check if the scene requires an update traversal
     if (_scene.valid() && _scene->requiresUpdateSceneGraph()) return true;
 
     return false;

--- a/src/osgViewer/View.cpp
+++ b/src/osgViewer/View.cpp
@@ -1138,6 +1138,10 @@ bool View::requiresUpdateSceneGraph() const
     // check if the scene requires an update traversal
     if (_scene.valid() && _scene->requiresUpdateSceneGraph()) return true;
 
+    // check if the scene requires a redraw
+    // FIXME...
+    if (_scene.valid() && _scene->requiresRedraw()) return true;
+
     return false;
 }
 


### PR DESCRIPTION
would trigger unnecessary redraws when there were pending file requests or active database threads

tested ok with and without IncrementalCompileOperation