### PR TITLE
macOS CoreProfile

### DIFF
--- a/examples/osgsimplegl3/osgsimplegl3.cpp
+++ b/examples/osgsimplegl3/osgsimplegl3.cpp
@@ -16,7 +16,7 @@
 #include <osg/StateSet>
 #include <osg/Program>
 #include <osg/Shader>
-
+#include <osgUtil/Optimizer>
 
 void configureShaders( osg::StateSet* stateSet )
 {
@@ -73,6 +73,10 @@ int main( int argc, char** argv )
         osg::notify( osg::FATAL ) << "Unable to load model from command line." << std::endl;
         return( 1 );
     }
+
+    osgUtil::Optimizer optimizer;
+    optimizer.optimize(root.get(), osgUtil::Optimizer::ALL_OPTIMIZATIONS  | osgUtil::Optimizer::TESSELLATE_GEOMETRY);
+
     configureShaders( root->getOrCreateStateSet() );
 
     const int width( 800 ), height( 450 );

--- a/src/osgViewer/GraphicsWindowCocoa.mm
+++ b/src/osgViewer/GraphicsWindowCocoa.mm
@@ -1202,6 +1202,11 @@ bool GraphicsWindowCocoa::realizeImplementation()
         attr[i++] = static_cast<NSOpenGLPixelFormatAttribute>(_traits->samples);
     }
 
+#ifdef OSG_GL3_AVAILABLE
+    attr[i++] = NSOpenGLPFAOpenGLProfile;
+    attr[i++] = NSOpenGLProfileVersion3_2Core;
+    OSG_DEBUG << "GraphicsWindowCocoa::realizeImplementation :: set up for GL3 Core Profile"<< std::endl;
+#endif
 
     attr[i++] = NSOpenGLPFAAccelerated;
     attr[i] = static_cast<NSOpenGLPixelFormatAttribute>(0);


### PR DESCRIPTION
This PR contains requested  parts of #92 previous PR concerning the osgsimplegl3 sample and the selection of the correct GL Profile when compiling with GL3 or Core Profile in GraphicsWindowCocoa.mm