### PR TITLE
Attempt to fix broken DLL exports from osgDB

### DIFF
--- a/include/osgDB/fstream
+++ b/include/osgDB/fstream
@@ -31,27 +31,27 @@ namespace osgDB
 
 void OSGDB_EXPORT open(std::fstream& fs, const char* filename,std::ios_base::openmode mode);
 
-class OSGDB_EXPORT ifstream : public std::ifstream
+class ifstream : public std::ifstream
 {
 public:
-    ifstream();
-    explicit ifstream(const char* filename,
+    OSGDB_EXPORT ifstream();
+    OSGDB_EXPORT explicit ifstream(const char* filename,
         std::ios_base::openmode mode = std::ios_base::in);
-    ~ifstream();
+    OSGDB_EXPORT ~ifstream();
 
-    void open(const char* filename,
+    void OSGDB_EXPORT open(const char* filename,
         std::ios_base::openmode mode = std::ios_base::in);
 };
 
-class OSGDB_EXPORT ofstream : public std::ofstream
+class ofstream : public std::ofstream
 {
 public:
-    ofstream();
-    explicit ofstream(const char* filename,
+    OSGDB_EXPORT ofstream();
+    OSGDB_EXPORT explicit ofstream(const char* filename,
         std::ios_base::openmode mode = std::ios_base::out);
-    ~ofstream();
+    OSGDB_EXPORT ~ofstream();
 
-    void open(const char* filename,
+    void OSGDB_EXPORT open(const char* filename,
         std::ios_base::openmode mode = std::ios_base::out);
 };
 


### PR DESCRIPTION
Only export the osgDB method implementations, instead of the entire
class, and hence avoid exporting symbols from the base class, which
then conflict with other compilation units when linking.

This avoids the need for /FORCE:MULTIPLE linker option with MSVC.