### PR TITLE
Submissions2c

### DIFF
--- a/src/osg/TextureBuffer.cpp
+++ b/src/osg/TextureBuffer.cpp
@@ -35,7 +35,9 @@ TextureBuffer::TextureBuffer(const TextureBuffer& text,const CopyOp& copyop):
     Texture(text,copyop),
     _textureWidth(text._textureWidth)
 {
-    setBufferData(osg::clone(text._bufferData.get(), copyop));
+    if (text._bufferData.valid()) {
+        setBufferData(osg::clone(text._bufferData.get(), copyop));
+    }
 }
 
 TextureBuffer::~TextureBuffer()

--- a/src/osgVolume/Property.cpp
+++ b/src/osgVolume/Property.cpp
@@ -102,7 +102,7 @@ ScalarProperty::ScalarProperty(const std::string& scalarName, float value)
 ScalarProperty::ScalarProperty(const ScalarProperty& sp, const osg::CopyOp& copyop):
     Property(sp,copyop)
 {
-    _uniform = new osg::Uniform(sp._uniform->getName().c_str(), getValue());
+    _uniform = new osg::Uniform(*sp._uniform.get(), copyop);
 
 }
 


### PR DESCRIPTION
from a synthetic test program I found that calling clone() on a new osgVolume::Scalarproperty and osg::TextureBuffer caused a crash. These functions are probably never used, but I think it would be better if the bug is fixed anyway.