### PR TITLE
added copyconstructor for osgAnimation::BasicAnimationManager

### DIFF
--- a/include/osgAnimation/BasicAnimationManager
+++ b/include/osgAnimation/BasicAnimationManager
@@ -29,6 +29,7 @@ namespace osgAnimation
         META_Object(osgAnimation, BasicAnimationManager);
 
         BasicAnimationManager();
+        BasicAnimationManager(const BasicAnimationManager& b, const osg::CopyOp& copyop = osg::CopyOp::SHALLOW_COPY);
         BasicAnimationManager(const AnimationManagerBase& b, const osg::CopyOp& copyop = osg::CopyOp::SHALLOW_COPY);
         virtual ~BasicAnimationManager();
 

--- a/src/osgAnimation/BasicAnimationManager.cpp
+++ b/src/osgAnimation/BasicAnimationManager.cpp
@@ -22,6 +22,14 @@ BasicAnimationManager::BasicAnimationManager()
 {
 }
 
+BasicAnimationManager::BasicAnimationManager(const BasicAnimationManager& b, const osg::CopyOp& copyop) : 
+    osg::Object(b, copyop),
+    osg::Callback(b, copyop),
+    AnimationManagerBase(b,copyop,
+    _lastUpdate(0.0)
+{
+}
+
 BasicAnimationManager::BasicAnimationManager(const AnimationManagerBase& b, const osg::CopyOp& copyop)
 : AnimationManagerBase(b,copyop)
 , _lastUpdate(0.0)


### PR DESCRIPTION
unlike the version in the (too large) pull request "Submissions2" I added the copy constructor, leaving the version taking an AnimationManagerBase intact (because it's used in example_osganimationviewer).