### PR TITLE
RigTransformHardware fix: warn; don't crash if MAX_MATRIX not found

### DIFF
--- a/src/osgAnimation/RigTransformHardware.cpp
+++ b/src/osgAnimation/RigTransformHardware.cpp
@@ -251,10 +251,16 @@ bool RigTransformHardware::init(RigGeometry& geom)
     std::string str = _shader->getShaderSource();
     std::string toreplace = std::string("MAX_MATRIX");
     std::size_t start = str.find(toreplace);
-    std::stringstream ss;
-    ss << getMatrixPaletteUniform()->getNumElements();
-    str.replace(start, toreplace.size(), ss.str());
-    _shader->setShaderSource(str);
+    if (std::string::npos != start) {
+        std::stringstream ss;
+        ss << getMatrixPaletteUniform()->getNumElements();
+        str.replace(start, toreplace.size(), ss.str());
+        _shader->setShaderSource(str);
+    }
+    else
+    {
+        OSG_WARN << "MAX_MATRIX not found in Shader! " << str << std::endl;
+    }
     OSG_INFO << "Shader " << str << std::endl;
     }
 


### PR DESCRIPTION
I don't remember exactly how I managed to get this to crash, maybe the shader source was loaded from cache or something like that.