### PR TITLE
VS2015 fix a few cases of warning C4589: Constructor of abstract clas…

### DIFF
--- a/src/osgAnimation/AnimationManagerBase.cpp
+++ b/src/osgAnimation/AnimationManagerBase.cpp
@@ -63,8 +63,6 @@ void AnimationManagerBase::operator()(osg::Node* node, osg::NodeVisitor* nv)
 
 
 AnimationManagerBase::AnimationManagerBase(const AnimationManagerBase& b, const osg::CopyOp& copyop) :
-    osg::Object(b, copyop),
-    osg::Callback(b, copyop),
     osg::NodeCallback(b,copyop) // TODO check this
 {
     const AnimationList& animationList = b.getAnimationList();

--- a/src/osgGA/CameraManipulator.cpp
+++ b/src/osgGA/CameraManipulator.cpp
@@ -21,8 +21,6 @@ CameraManipulator::CameraManipulator()
 
 
 CameraManipulator::CameraManipulator(const CameraManipulator& mm, const CopyOp& copyOp):
-     osg::Object(mm,copyOp),
-     osg::Callback(mm,copyOp),
      inherited(mm, copyOp),
      _intersectTraversalMask(mm._intersectTraversalMask),
      _autoComputeHomePosition(mm._autoComputeHomePosition),

--- a/src/osgGA/StandardManipulator.cpp
+++ b/src/osgGA/StandardManipulator.cpp
@@ -48,8 +48,6 @@ StandardManipulator::StandardManipulator( int flags )
 
 /// Constructor.
 StandardManipulator::StandardManipulator( const StandardManipulator& uim, const CopyOp& copyOp ):
-      osg::Object(uim,copyOp),
-      osg::Callback(uim,copyOp),
       inherited( uim, copyOp ),
       _thrown( uim._thrown ),
       _allowThrow( uim._allowThrow ),


### PR DESCRIPTION
Constructor of abstract class 'X' ignores initializer for virtual base class
apparently I missed these warnings in previous attempts to get a clean compile.