### PR TITLE
Visual Studio 2015: disable C4589: Constructor of abstract class X ignores initializer for virtual base class Y

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1056,7 +1056,13 @@ ELSEIF(MSVC)
         #C4100 'identifier' : unreferenced formal parameter
         #C4127 Error Message conditional expression is constant
         #C4706 assignment within conditional expression
+    IF (MSVC_VERSION GREATER 1800)
+        #VS 14 (Visual Studio 2015) and above
+        #C4589: Constructor of abstract class 'osgGA::CameraManipulator' ignores initializer for virtual base class 'osg::Object'
+        SET(OSG_AGGRESSIVE_WARNING_FLAGS /W4 /wd4589 /wd4706 /wd4127 /wd4100)
+    ELSE()
         SET(OSG_AGGRESSIVE_WARNING_FLAGS /W4 /wd4706 /wd4127 /wd4100)
+    ENDIF()
 ELSEIF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         SET(OSG_AGGRESSIVE_WARNING_FLAGS  -Wall -Wparentheses -Wno-long-long -Wno-import -pedantic -Wreturn-type -Wmissing-braces -Wunknown-pragmas -Wunused -Wno-overloaded-virtual)
 


### PR DESCRIPTION
Hi Robert,
I suggest we disable the warning for visual studio 2015. It's valid C++ and I would prefer to keep the full initializer list (as g++ -Wextra suggests) as template for the derived classes.

Regards, Laurens.