### PR TITLE
Bind only if VertxArrayObject has been generated

### DIFF
--- a/include/osg/Drawable
+++ b/include/osg/Drawable
@@ -527,7 +527,6 @@ inline void Drawable::draw(RenderInfo& renderInfo) const
         return;
     }
 
-    // TODO, add check against whether VAO is active and supported
     if (state.getCurrentVertexArrayState()) state.getCurrentVertexArrayState()->bindVertexArrayObject();
 
 

--- a/include/osg/VertexArrayState
+++ b/include/osg/VertexArrayState
@@ -164,7 +164,7 @@ public:
 
         void deleteVertexArrayObject();
 
-        inline void bindVertexArrayObject() const { _ext->glBindVertexArray (_vertexArrayObject); }
+        inline void bindVertexArrayObject() const { if (_vertexArrayObject != 0) _ext->glBindVertexArray (_vertexArrayObject); }
 
         inline void unbindVertexArrayObject() const { _ext->glBindVertexArray (0); }
 
@@ -187,7 +187,6 @@ public:
         osg::ref_ptr<osg::GLExtensions> _ext;
 
         bool                            _isVertexBufferObjectSupported;
-
         GLuint                          _vertexArrayObject;
 
 


### PR DESCRIPTION
Hi,

the current code of the `vertex_array_object` branch calls `glBindVertexArray​(0)`, which in the core profile is an immutable state, so it still works in the compatibility mode by accident.
It happens in the line, which is already marked with a TODO.

My suggestion to fix it by some defensive programming: The idea being, that the id `0` is the default state and is never generated by `glGenVertexArrays​`.
You can reach the default state only by `VertexArrayState::unbindVertexArrayObject()` and not also by `VertexArrayState va; va.bindVertexArrayObject()`, which seems to me a questionable way to do it.

The current state breaks code as the given [Example](https://github.com/fwiesel/vertexarrayfunctest/blob/master/main.cpp), where the `VAO` is created in a camera `DrawCallback` outside the draw function, which otherwise still on the stable OSG version.

Cheers,
  Fabian