### PR TITLE
VAO id is a GLuint

### DIFF
--- a/include/osg/VertexArrayState
+++ b/include/osg/VertexArrayState
@@ -168,7 +168,7 @@ public:
 
         inline void unbindVertexArrayObject() const { _ext->glBindVertexArray (0); }
 
-        GLint getVertexArrayObject() const { return _vertexArrayObject; }
+        GLuint getVertexArrayObject() const { return _vertexArrayObject; }
 
 
         void setRequiresSetArrays(bool flag) { _requiresSetArrays = flag; }


### PR DESCRIPTION
There is an implicit cast to GLint in the getter which I guess is not intentional.
