### PR TITLE
fix bug in SmoothingVisitor tripped by bunny.ply

### DIFF
--- a/src/osgUtil/SmoothingVisitor.cpp
+++ b/src/osgUtil/SmoothingVisitor.cpp
@@ -659,14 +659,16 @@ static void smooth_new(osg::Geometry& geom, double creaseAngle)
         // fsef.listProblemVertices();
         fsef.updateGeometry();
 
+        vertices = dynamic_cast<osg::Vec3Array*>(geom.getVertexArray());
+        normals = dynamic_cast<osg::Vec3Array*>(geom.getNormalArray());
         osg::TriangleIndexFunctor<SmoothTriangleIndexFunctor> stif2;
         if (stif2.set(vertices, normals))
         {
             // accumulate all the normals
-            geom.accept(stif);
+            geom.accept(stif2);
 
             // normalize the normals
-            stif.normalize();
+            stif2.normalize();
         }
 
     }


### PR DESCRIPTION
after duplicating the vertices to allow for multiple normals the indices of the new mesh (with duplicated vertices) were used with the vertices of the old mesh, causing a vector subscript out of range error.
Regards, Laurens.