### PR TITLE
fix visual studio 2015 warning C4250

### DIFF
--- a/include/osgViewer/ViewerEventHandlers
+++ b/include/osgViewer/ViewerEventHandlers
@@ -512,6 +512,8 @@ public:
 
     META_Object(osgViewer, InteractiveImageHandler);
 
+    virtual const EventHandler* asEventHandler() const { return osgGA::EventHandler::asEventHandler(); }
+
     virtual NodeCallback* asNodeCallback() { return osg::NodeCallback::asNodeCallback(); }
     virtual const NodeCallback* asNodeCallback() const { return osg::NodeCallback::asNodeCallback(); }
 

--- a/include/osgVolume/Property
+++ b/include/osgVolume/Property
@@ -487,6 +487,8 @@ class OSGVOLUME_EXPORT PropertyAdjustmentCallback : public osgGA::GUIEventHandle
 
         META_Object(osgVolume, PropertyAdjustmentCallback);
 
+        virtual const EventHandler* asEventHandler() const { return osgGA::EventHandler::asEventHandler(); }
+
         virtual NodeCallback* asNodeCallback() { return osg::NodeCallback::asNodeCallback(); }
         virtual const NodeCallback* asNodeCallback() const { return osg::NodeCallback::asNodeCallback(); }
 


### PR DESCRIPTION
Hi Robert,
recent changes to Callback and Eventhandler cause a warning in visual studio
warning C4250: 'osgViewer::InteractiveImageHandler': inherits 'osgGA::EventHandler::osgGA::EventHandler::asEventHandler' via dominance
warning C4250: 'osgVolume::PropertyAdjustmentCallback': inherits 'osgGA::EventHandler::osgGA::EventHandler::asEventHandler' via dominance

the log message in git for the change:
Date: 10/6/2016 7:27:23 PM
Message: Fixed crash and double call bug in handle event callbacks attached to Drawable

Regards, Laurens.
