### PR TITLE
hyperthreading detection for windows, distribute threads over actual cores.

### DIFF
--- a/include/OpenThreads/Thread
+++ b/include/OpenThreads/Thread
@@ -33,7 +33,14 @@ namespace OpenThreads {
  *  Note, systems where no support exists for querying the number of processors, 1 is returned.
  *
  */
-extern OPENTHREAD_EXPORT_DIRECTIVE int GetNumberOfProcessors();
+extern OPENTHREAD_EXPORT_DIRECTIVE unsigned int GetNumberOfProcessors();
+/**
+ *  Get the number of pysical processor cores and the number of threads per processor
+ *
+ *  Note, systems where no support exists for querying the number threads, GetNumberOfProcessors() and 1 is returned.
+ *
+ */
+extern OPENTHREAD_EXPORT_DIRECTIVE unsigned int GetNumberOfHtProcessors(unsigned int *HtCount);
 
 /**
  *  Set the processor affinity of current thread.

--- a/src/OpenThreads/pthreads/PThread.cpp
+++ b/src/OpenThreads/pthreads/PThread.cpp
@@ -979,7 +979,7 @@ int Thread::microSleep(unsigned int microsec)
 //
 // Description:  Get the number of processors
 //
-int OpenThreads::GetNumberOfProcessors()
+unsigned int OpenThreads::GetNumberOfProcessors()
 {
 #if defined(__linux__) || defined(__GNU__)
    long ret = sysconf(_SC_NPROCESSORS_ONLN);
@@ -1010,3 +1010,7 @@ int OpenThreads::GetNumberOfProcessors()
 #endif
 }
 
+unsigned int OpenThreads::GetNumberOfHtProcessors(unsigned int *HtCount) {
+    *HtCount = 1;//assume no hyperthreading
+    return GetNumberOfProcessors();
+}


### PR DESCRIPTION
Hi Robert,
the windows version of SetProcessorAffinityOfCurrentThread now works on the main thread too, and results in a performance drop for my windows machine (with hyperthreading enabled), because the main thread is bound to core0/thread0 an graphics to core0/thread1. As main and graphics actually overlap, this has a performance penalty. I implemented a simple workaround for windows, assigning the actual core - and leaving the thread choice to the os.
I cannot find a decent solution for linux. I managed to get the cpuid opcode to return some result describing the capabilities of the cpu, but not to tell me if hyperthreading actually is enabled. So for now I have left this with a fallback implementation.
Regards, Laurens.