### PR TITLE
assign free vcores to DatabasePager

### DIFF
--- a/src/osgViewer/ViewerBase.cpp
+++ b/src/osgViewer/ViewerBase.cpp
@@ -184,14 +184,15 @@ void ViewerBase::configureAffinity()
 
         OSG_NOTICE<<"  databasePagers = "<<databasePagers.size()<<std::endl;
 
-        availableProcessor = availableProcessors[availableProcessor % availableProcessors.size()];
-
         OpenThreads::Affinity databasePagerAffinity;
+        //if any free CPU's remain, assign the databasePagers to those
+        for (; availableProcessor < availableProcessors.size(); ++availableProcessor) databasePagerAffinity.add(availableProcessors[availableProcessor]);
+
         for(DatabasePagers::iterator itr = databasePagers.begin();
             itr != databasePagers.end();
             ++itr)
         {
-            (*itr)->setProcessorAffinity(OpenThreads::Affinity(availableProcessor, numProcessors-availableProcessor));
+            (*itr)->setProcessorAffinity(databasePagerAffinity);
         }
     }
 }


### PR DESCRIPTION
-- repeating the relevant parts of the discussion on the previous PR:
Robert Osfield notifications@github.com Oct 14 (3 days ago)
to openscenegraph., me, Author 

> I think these issues are best split into separate PR's. 
> The third change w.r.t mask for the database pager, I didn't use the same evens, odds layout of cores used for the other threads as the consequence of hyper threading affecting database paging isn't significant - these are threads that have high IO latency so having a core a bit more contended isn't a big deal. So I allowed the database pager threads to occupy all the remaining threads, without risking sitting on cores that the main or cull/draw sit upon.

for the databasePagers: After assigning main - cull -cull - gpu threads to vcores 0,2,4 and 6 
the databasepagers got an affiniymask for vcores 1,2,3,4. 
The PR changes that to the free vcores: 1,3,5,7 - as I think this was the intention. I am not at all sure
this is the best solution, a lower priority might cause less frame drops, but I do not have a test ready to test this.
Regards, Laurens.
