### PR TITLE
added alternative to middle-mouse button in manipulator

### DIFF
--- a/src/osgGA/StandardManipulator.cpp
+++ b/src/osgGA/StandardManipulator.cpp
@@ -438,11 +438,14 @@ bool StandardManipulator::performMovement()
 
     // call appropriate methods
     unsigned int buttonMask = _ga_t1->getButtonMask();
+    unsigned int ModKeyMask = _ga_t1->getModKeyMask();
     if( buttonMask == GUIEventAdapter::LEFT_MOUSE_BUTTON )
     {
         return performMovementLeftMouseButton( eventTimeDelta, dx, dy );
     }
     else if( buttonMask == GUIEventAdapter::MIDDLE_MOUSE_BUTTON ||
+             ( buttonMask == GUIEventAdapter::RIGHT_MOUSE_BUTTON &&
+               ModKeyMask & GUIEventAdapter::MODKEY_CTRL ) ||
             buttonMask == (GUIEventAdapter::LEFT_MOUSE_BUTTON | GUIEventAdapter::RIGHT_MOUSE_BUTTON) )
     {
         return performMovementMiddleMouseButton( eventTimeDelta, dx, dy );


### PR DESCRIPTION
I added CTRL + RIGHT-MOUSE-CLICK to the standard manipulator as
an alternative to MIDDLE-MOUSE-CLICK because a 3 Button Mouse
not always available, e.g. on MacOS. I tested this with the
osgAtlasSimbicon example.