### PR TITLE
Use CodeDocs for Doxygen documentation

### DIFF
--- a/.codedocs
+++ b/.codedocs
@@ -1,0 +1,14 @@
+# CodeDocs.xyz Configuration File
+
+DOXYFILE = doc/Doxyfiles/doxyfile.cmake
+
+PROJECT_NUMBER         =
+PROJECT_LOGO           = examples/osgAndroidExampleGLES1/res/drawable-hdpi/osg.png
+INPUT                  = include \
+                         src \
+                         applications \
+                         examples
+STRIP_FROM_PATH        = include/
+HTML_FOOTER            =
+SEARCHENGINE           = YES
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/openscenegraph/OpenSceneGraph.svg?branch=master)](https://travis-ci.org/openscenegraph/OpenSceneGraph)
 [![Coverity Status](https://scan.coverity.com/projects/9159/badge.svg)](https://scan.coverity.com/projects/openscenegraph-openscenegraph)
+[![Documentation](https://codedocs.xyz/openscenegraph/OpenSceneGraph.svg)](https://codedocs.xyz/openscenegraph/OpenSceneGraph/)
 
 ### Introduction
 


### PR DESCRIPTION
This PR adds a configuration file for [CodeDocs.xyz](https://codedocs.xyz/) a GitHub integration that generates and hosts Doxygen documentation (Disclosure, I am one of the CodeDocs creators, and longtime OpenSceneGraph user). Like Travis-CI it will regenerate after each update to the repo.

I have this working on my fork of OpenSceneGraph now, and you can see the results [here](https://codedocs.xyz/CodeDocs/OpenSceneGraph/). The PR also adds a badge to the README.md, which you can see an example of, again, in my [fork](https://github.com/CodeDocs/OpenSceneGraph/).

Finally, for this to work, someone with access to the 'openscenegraph' GitHub account will have to login to CodeDocs and enable OpenSceneGraph.

I hope this is useful, I think it is a nice way to have always updated Doxygen documentation available for OpenSceneGraph.