### PR TITLE
Fix IncrementalCompileOperation leaking program state

### DIFF
--- a/src/osgUtil/IncrementalCompileOperation.cpp
+++ b/src/osgUtil/IncrementalCompileOperation.cpp
@@ -725,7 +725,15 @@ void IncrementalCompileOperation::operator () (osg::GraphicsContext* context)
         }
     }
 
-    //glFush();
+    osg::State* state = context->getState();
+    if (state->getLastAppliedProgramObject())
+    {
+        osg::GLExtensions* extensions = state->get<osg::GLExtensions>();
+        extensions->glUseProgram(0);
+        state->setLastAppliedProgramObject(0);
+    }
+
+    //glFlush();
     //glFinish();
 }
 


### PR DESCRIPTION
The IncrementalCompileOperation when compiling programs sets the GL state's current program object, but does not reset this state afterwards. A scene graph with no shaders would incorrectly render *with* a shader if you compiled some shaders in the background with the IncrementalCompileOperation.

Note that prior to OSG 3.5.4, this bug wasn't visible because it was masked by another bug - no program objects were compiled at all, see commits 8f68da89d7fb75264fde742d59ea888415b489a6 & 06cb31a3d265a63c6db693120abec3c9fac591f3.

Side note: is there any reason why we do

<pre>
    _program->apply(*compileInfo.getState());
</pre>
Instead of
<pre>
    _program->compile(*compileInfo.getState());
</pre>
Is that to workaround drivers that want to defer the compilation until the program is actually used? In that case, I don't think just setting the program object will do it, you'd need to draw something with it as well.

As a cleaner fix I'd propose changing apply() to compile(), unless we've got any test data that suggests using apply() would make a difference.