### PR TITLE
Fix flow control issue in StateSet::compileGLObjects

### DIFF
--- a/src/osg/StateSet.cpp
+++ b/src/osg/StateSet.cpp
@@ -1443,7 +1443,7 @@ void StateSet::setThreadSafeRefUnref(bool threadSafe)
 void StateSet::compileGLObjects(State& state) const
 {
     bool checkForGLErrors = state.getCheckForGLErrors()==osg::State::ONCE_PER_ATTRIBUTE;
-    if (checkForGLErrors && state.checkGLErrors("before StateSet::compileGLObejcts()"))
+    if (checkForGLErrors) state.checkGLErrors("before StateSet::compileGLObejcts()");
 
     for(AttributeList::const_iterator itr = _attributeList.begin();
         itr!=_attributeList.end();


### PR DESCRIPTION
Fix a typo in StateSet::compileGLObjects that caused compilation of attributes to not be executed unless checkForGLErrors is true.

Regression introduced with commit 99cb8ebacf2485ccb704c66865ab09a2e7190256