### PR TITLE
Several tweaks for compiling OpenCascade plugin:

### DIFF
--- a/src/osgPlugins/iges/ReaderWriterIGES.cpp
+++ b/src/osgPlugins/iges/ReaderWriterIGES.cpp
@@ -66,7 +66,6 @@
 #include <TDF_LabelSequence.hxx>
 #include <TDF_ChildIterator.hxx>
 
-#include <XSDRAW.hxx>
 #include <Quantity_Color.hxx>
 
 // osg headers

--- a/src/osgPlugins/iges/ReaderWriterIGES.h
+++ b/src/osgPlugins/iges/ReaderWriterIGES.h
@@ -24,9 +24,11 @@
 /// \brief header file for creating osgdb plugin for IGES format
 /// \author Abhishek Bansal, Engineer Graphics, vizExperts India Pvt. Ltd. 
 
+#ifdef WIN32
 /// \brief preproccessor macro required for compilation with open cascade
 /// \todo not sure what it does
 #define WNT
+#endif
 
 #include <TDF_LabelSequence.hxx>
 


### PR DESCRIPTION
* Remove unneeded XSDRAW.hxx header inclusion.
* Define WNT only on windows, because it is used for choosing between
  win threads or pthreads.