### PR TITLE
improve stats display

### DIFF
--- a/src/osgViewer/StatsHandler.cpp
+++ b/src/osgViewer/StatsHandler.cpp
@@ -668,6 +668,7 @@ struct BlockDrawCallback : public virtual osg::Drawable::DrawCallback
                 (*vertices)[vi++].x() = _xPos + (beginValue - referenceTime) * _statsHandler->getBlockMultiplier();
                 (*vertices)[vi++].x() = _xPos + (beginValue - referenceTime) * _statsHandler->getBlockMultiplier();
                 (*vertices)[vi++].x() = _xPos + (endValue - referenceTime) * _statsHandler->getBlockMultiplier();
+                if (endValue - beginValue < .0005) endValue = beginValue + .0005;
                 (*vertices)[vi++].x() = _xPos + (endValue - referenceTime) * _statsHandler->getBlockMultiplier();
             }
         }


### PR DESCRIPTION
a tiny change I made while working on affinity and threads: a minimum size for the stat bar top with, to make even very small bars visible. 
![stats](https://cloud.githubusercontent.com/assets/19814874/21393645/a7510e22-c795-11e6-9317-3fc6440de516.png)
