### PR TITLE
Additional info when fail to load images

### DIFF
--- a/src/osgDB/InputStream.cpp
+++ b/src/osgDB/InputStream.cpp
@@ -843,7 +843,7 @@ osg::ref_ptr<osg::Image> InputStream::readImage(bool readFromExternal)
         }
         else
         {
-            if (!rr.success()) OSG_WARN << rr.statusMessage() << std::endl;
+           if (!rr.success()) OSG_WARN << "InputStream::readImage(): " << rr.statusMessage() << ", filename: " << name << std::endl;
         }
 
         if ( !image && _forceReadingImage ) image = new osg::Image;


### PR DESCRIPTION
I've added some info when readImage() fails to load a file, following the style of the other error messages.
Previously the code was just printing "File not found", without mentioning which function generated the error and which file failed to load, which wasn't informative.
