### PR TITLE
Improve OSG_NOTIFY macro

### DIFF
--- a/include/osg/Notify
+++ b/include/osg/Notify
@@ -79,7 +79,7 @@ extern OSG_EXPORT std::ostream& notify(const NotifySeverity severity);
 
 inline std::ostream& notify(void) { return notify(osg::INFO); }
 
-#define OSG_NOTIFY(level) if (osg::isNotifyEnabled(level)) osg::notify(level)
+#define OSG_NOTIFY(level) osg::notify(level)
 #define OSG_ALWAYS OSG_NOTIFY(osg::ALWAYS)
 #define OSG_FATAL OSG_NOTIFY(osg::FATAL)
 #define OSG_WARN OSG_NOTIFY(osg::WARN)


### PR DESCRIPTION
The current notification macros do not work (at least when compiled with Visual Studio) if used in if-else clauses without braces.

In the commit I've simply removed from the OSG_NOTIFY macro definition the isNotifyEnabled() check.
The same test is performed anyway in the notify() method called by the macro, and as added value the macro works fine in if/else clauses without braces.

To test the old and new behavior, I attach a modified version of osgversion application, with the macros locally redefined to reduce the compilation time.
[osgversion.zip](https://github.com/openscenegraph/OpenSceneGraph/files/701698/osgversion.zip)
This is just to show the purpose of the PR and not to be included in the commit.

