### PR TITLE
Optimizer fixes

### DIFF
--- a/include/osgUtil/Optimizer
+++ b/include/osgUtil/Optimizer
@@ -847,14 +847,11 @@ class OSGUTIL_EXPORT Optimizer
                     BaseOptimizerVisitor(optimizer, STATIC_OBJECT_DETECTION) {}
 
                 virtual void apply(osg::Node& node);
-
-                virtual void apply(osg::Geode& geode);
+                virtual void apply(osg::Drawable& drawable);
 
             protected:
 
                 void applyStateSet(osg::StateSet& stateset);
-
-                void applyDrawable(osg::Drawable& drawable);
 
         };
 

--- a/include/osgUtil/Optimizer
+++ b/include/osgUtil/Optimizer
@@ -73,7 +73,7 @@ class OSGUTIL_EXPORT Optimizer
             COMBINE_ADJACENT_LODS =     (1 << 3),
             SHARE_DUPLICATE_STATE =     (1 << 4),
             MERGE_GEOMETRY =            (1 << 5),
-            CHECK_GEOMETRY =            (1 << 6),
+            CHECK_GEOMETRY =            (1 << 6), // deprecated, currently no-op
             MAKE_FAST_GEOMETRY =        (1 << 7),
             SPATIALIZE_GROUPS =         (1 << 8),
             COPY_SHARED_NODES =         (1 << 9),
@@ -498,20 +498,6 @@ class OSGUTIL_EXPORT Optimizer
             protected:
 
                 bool mergeGeode(osg::Geode& lhs, osg::Geode& rhs);
-
-        };
-
-        class OSGUTIL_EXPORT CheckGeometryVisitor : public BaseOptimizerVisitor
-        {
-            public:
-
-                /// default to traversing all children.
-                CheckGeometryVisitor(Optimizer* optimizer=0):
-                    BaseOptimizerVisitor(optimizer, CHECK_GEOMETRY) {}
-
-                virtual void apply(osg::Geometry& geom);
-
-                void checkGeode(osg::Geode& geode);
 
         };
 

--- a/include/osgUtil/Optimizer
+++ b/include/osgUtil/Optimizer
@@ -360,7 +360,6 @@ class OSGUTIL_EXPORT Optimizer
                 RemoveEmptyNodesVisitor(Optimizer* optimizer=0):
                     BaseOptimizerVisitor(optimizer, REMOVE_REDUNDANT_NODES) {}
 
-                virtual void apply(osg::Geode& geode);
                 virtual void apply(osg::Group& group);
 
                 void removeEmptyNodes();

--- a/include/osgUtil/Optimizer
+++ b/include/osgUtil/Optimizer
@@ -460,8 +460,6 @@ class OSGUTIL_EXPORT Optimizer
 
                 virtual void apply(osg::Node& node);
 
-                virtual void apply(osg::Geode& geode);
-
                 void optimize();
 
             protected:

--- a/include/osgUtil/Optimizer
+++ b/include/osgUtil/Optimizer
@@ -814,8 +814,7 @@ class OSGUTIL_EXPORT Optimizer
                 virtual void reset();
 
                 virtual void apply(osg::Node& node);
-
-                virtual void apply(osg::Geode& geode);
+                virtual void apply(osg::Drawable& node);
 
                 void optimize();
 

--- a/include/osgUtil/Optimizer
+++ b/include/osgUtil/Optimizer
@@ -403,7 +403,7 @@ class OSGUTIL_EXPORT Optimizer
 
         };
 
-        /** Tessellate all geodes, to remove POLYGONS.*/
+        /** Tessellate all Geometries, to remove POLYGONS.*/
         class OSGUTIL_EXPORT TessellateVisitor : public BaseOptimizerVisitor
         {
             public:
@@ -414,7 +414,7 @@ class OSGUTIL_EXPORT Optimizer
                 TessellateVisitor(Optimizer* optimizer=0):
                     BaseOptimizerVisitor(optimizer, TESSELLATE_GEOMETRY) {}
 
-                virtual void apply(osg::Geode& geode);
+                virtual void apply(osg::Geometry& geom);
 
         };
 

--- a/include/osgUtil/Optimizer
+++ b/include/osgUtil/Optimizer
@@ -509,7 +509,7 @@ class OSGUTIL_EXPORT Optimizer
                 CheckGeometryVisitor(Optimizer* optimizer=0):
                     BaseOptimizerVisitor(optimizer, CHECK_GEOMETRY) {}
 
-                virtual void apply(osg::Geode& geode) { checkGeode(geode); }
+                virtual void apply(osg::Geometry& geom);
 
                 void checkGeode(osg::Geode& geode);
 
@@ -523,9 +523,7 @@ class OSGUTIL_EXPORT Optimizer
                 MakeFastGeometryVisitor(Optimizer* optimizer=0):
                     BaseOptimizerVisitor(optimizer, MAKE_FAST_GEOMETRY) {}
 
-                virtual void apply(osg::Geode& geode) { checkGeode(geode); }
-
-                void checkGeode(osg::Geode& geode);
+                virtual void apply(osg::Geometry& geom);
 
         };
 

--- a/include/osgUtil/Optimizer
+++ b/include/osgUtil/Optimizer
@@ -275,7 +275,7 @@ class OSGUTIL_EXPORT Optimizer
                     BaseOptimizerVisitor(optimizer, FLATTEN_STATIC_TRANSFORMS) {}
 
                 virtual void apply(osg::Node& geode);
-                virtual void apply(osg::Geode& geode);
+                virtual void apply(osg::Drawable& drawable);
                 virtual void apply(osg::Billboard& geode);
                 virtual void apply(osg::ProxyNode& node);
                 virtual void apply(osg::PagedLOD& node);

--- a/include/osgUtil/Optimizer
+++ b/include/osgUtil/Optimizer
@@ -626,7 +626,6 @@ class OSGUTIL_EXPORT Optimizer
                         _changeClientImageStorage(changeClientImageStorage), _valueClientImageStorage(valueClientImageStorage),
                         _changeAnisotropy(changeAnisotropy), _valueAnisotropy(valueAnisotropy) {}
 
-                virtual void apply(osg::Geode& node);
                 virtual void apply(osg::Node& node);
 
                 void apply(osg::StateSet& stateset);

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -1173,26 +1173,19 @@ void Optimizer::FlattenStaticTransformsVisitor::apply(osg::PagedLOD& node)
     traverse(node);
 }
 
-
-void Optimizer::FlattenStaticTransformsVisitor::apply(osg::Geode& geode)
+void Optimizer::FlattenStaticTransformsVisitor::apply(osg::Drawable& drawable)
 {
-    if (!_transformStack.empty())
+    osg::Geometry *geometry = drawable.asGeometry();
+    if((geometry) && (isOperationPermissibleForObject(&drawable)))
     {
-        for(unsigned int i=0;i<geode.getNumDrawables();++i)
-        {
-            osg::Geometry *geometry = geode.getDrawable(i)->asGeometry();
-            if((geometry) && (isOperationPermissibleForObject(&geode)) && (isOperationPermissibleForObject(geometry)))
-            {
-                if(geometry->getVertexArray() && geometry->getVertexArray()->referenceCount() > 1) {
-                    geometry->setVertexArray(dynamic_cast<osg::Array*>(geometry->getVertexArray()->clone(osg::CopyOp::DEEP_COPY_ALL)));
-                }
-                if(geometry->getNormalArray() && geometry->getNormalArray()->referenceCount() > 1) {
-                    geometry->setNormalArray(dynamic_cast<osg::Array*>(geometry->getNormalArray()->clone(osg::CopyOp::DEEP_COPY_ALL)));
-                }
-            }
-            _drawableSet.insert(geode.getDrawable(i));
+        if(geometry->getVertexArray() && geometry->getVertexArray()->referenceCount() > 1) {
+            geometry->setVertexArray(dynamic_cast<osg::Array*>(geometry->getVertexArray()->clone(osg::CopyOp::DEEP_COPY_ALL)));
+        }
+        if(geometry->getNormalArray() && geometry->getNormalArray()->referenceCount() > 1) {
+            geometry->setNormalArray(dynamic_cast<osg::Array*>(geometry->getNormalArray()->clone(osg::CopyOp::DEEP_COPY_ALL)));
         }
     }
+    _drawableSet.insert(&drawable);
 }
 
 void Optimizer::FlattenStaticTransformsVisitor::apply(osg::Billboard& billboard)

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -4405,28 +4405,16 @@ void Optimizer::StaticObjectDetectionVisitor::apply(osg::Node& node)
     traverse(node);
 }
 
-void Optimizer::StaticObjectDetectionVisitor::apply(osg::Geode& geode)
+void Optimizer::StaticObjectDetectionVisitor::apply(osg::Drawable& drawable)
 {
-    if (geode.getStateSet()) applyStateSet(*geode.getStateSet());
+    if (drawable.getStateSet()) applyStateSet(*drawable.getStateSet());
 
-    for(unsigned int i=0; i<geode.getNumDrawables(); ++i)
-    {
-        applyDrawable(*geode.getDrawable(i));
-    }
+    drawable.computeDataVariance();
 }
 
 void Optimizer::StaticObjectDetectionVisitor::applyStateSet(osg::StateSet& stateset)
 {
     stateset.computeDataVariance();
-}
-
-
-void Optimizer::StaticObjectDetectionVisitor::applyDrawable(osg::Drawable& drawable)
-{
-
-    if (drawable.getStateSet()) applyStateSet(*drawable.getStateSet());
-
-    drawable.computeDataVariance();
 }
 
 

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -1329,23 +1329,6 @@ bool Optimizer::CombineStaticTransformsVisitor::removeTransforms(osg::Node* node
 // RemoveEmptyNodes.
 ////////////////////////////////////////////////////////////////////////////
 
-void Optimizer::RemoveEmptyNodesVisitor::apply(osg::Geode& geode)
-{
-    for(int i=geode.getNumDrawables()-1;i>=0;--i)
-    {
-        osg::Geometry* geom = geode.getDrawable(i)->asGeometry();
-        if (geom && geom->empty() && isOperationPermissibleForObject(geom))
-        {
-           geode.removeDrawables(i,1);
-        }
-    }
-
-    if (geode.getNumParents()>0)
-    {
-        if (geode.getNumDrawables()==0 && isOperationPermissibleForObject(&geode)) _redundantNodeList.insert(&geode);
-    }
-}
-
 void Optimizer::RemoveEmptyNodesVisitor::apply(osg::Group& group)
 {
     if (group.getNumParents()>0)

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -1732,39 +1732,25 @@ struct LessGeometryPrimitiveType
     }
 };
 
-void Optimizer::CheckGeometryVisitor::checkGeode(osg::Geode& geode)
+void Optimizer::CheckGeometryVisitor::apply(osg::Geometry& geom)
 {
-    if (isOperationPermissibleForObject(&geode))
+    if (isOperationPermissibleForObject(&geom))
     {
-        for(unsigned int i=0;i<geode.getNumDrawables();++i)
-        {
-            osg::Geometry* geom = geode.getDrawable(i)->asGeometry();
-            if (geom && isOperationPermissibleForObject(geom))
-            {
 #ifdef GEOMETRYDEPRECATED
-                geom1829
-                ->computeCorrectBindingsAndArraySizes();
+        geom
+        .computeCorrectBindingsAndArraySizes();
 #endif
-            }
-        }
     }
 }
 
-void Optimizer::MakeFastGeometryVisitor::checkGeode(osg::Geode& geode)
+void Optimizer::MakeFastGeometryVisitor::apply(osg::Geometry& geom)
 {
     // GeometryDeprecated CAN REMOVED
-    if (isOperationPermissibleForObject(&geode))
+    if (isOperationPermissibleForObject(&geom))
     {
-        for(unsigned int i=0;i<geode.getNumDrawables();++i)
+        if (geom.checkForDeprecatedData())
         {
-            osg::Geometry* geom = geode.getDrawable(i)->asGeometry();
-            if (geom && isOperationPermissibleForObject(geom))
-            {
-                if (geom->checkForDeprecatedData())
-                {
-                    geom->fixDeprecatedData();
-                }
-            }
+            geom.fixDeprecatedData();
         }
     }
 }

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -405,17 +405,10 @@ void Optimizer::optimize(osg::Node* node, unsigned int options)
 ////////////////////////////////////////////////////////////////////////////
 // Tessellate geometry - eg break complex POLYGONS into triangles, strips, fans..
 ////////////////////////////////////////////////////////////////////////////
-void Optimizer::TessellateVisitor::apply(osg::Geode& geode)
+void Optimizer::TessellateVisitor::apply(osg::Geometry &geom)
 {
-    for(unsigned int i=0;i<geode.getNumDrawables();++i)
-    {
-        osg::Geometry* geom = dynamic_cast<osg::Geometry*>(geode.getDrawable(i));
-        if (geom) {
-            osgUtil::Tessellator Tessellator;
-            Tessellator.retessellatePolygons(*geom);
-        }
-    }
-    traverse(geode);
+    osgUtil::Tessellator Tessellator;
+    Tessellator.retessellatePolygons(geom);
 }
 
 

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -1372,7 +1372,7 @@ void Optimizer::RemoveEmptyNodesVisitor::removeEmptyNodes()
                     strcmp(parent->className(),"MultiSwitch")!=0)
                 {
                     parent->removeChild(nodeToRemove.get());
-                    if (parent->getNumChildren()==0) newEmptyGroups.insert(*pitr);
+                    if (parent->getNumChildren()==0 && isOperationPermissibleForObject(parent)) newEmptyGroups.insert(parent);
                 }
             }
         }

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -2968,33 +2968,6 @@ void Optimizer::TextureVisitor::apply(osg::Node& node)
     traverse(node);
 }
 
-void Optimizer::TextureVisitor::apply(osg::Geode& geode)
-{
-    if (!isOperationPermissibleForObject(&geode)) return;
-
-    osg::StateSet* ss = geode.getStateSet();
-
-    if (ss && isOperationPermissibleForObject(ss))
-    {
-        apply(*ss);
-    }
-
-    for(unsigned int i=0;i<geode.getNumDrawables();++i)
-    {
-        osg::Drawable* drawable = geode.getDrawable(i);
-        if (drawable)
-        {
-            ss = drawable->getStateSet();
-            if (ss &&
-               isOperationPermissibleForObject(drawable) &&
-               isOperationPermissibleForObject(ss))
-            {
-                apply(*ss);
-            }
-        }
-    }
-}
-
 void Optimizer::TextureVisitor::apply(osg::StateSet& stateset)
 {
     for(unsigned int i=0;i<stateset.getTextureAttributeList().size();++i)

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -50,8 +50,6 @@
 
 using namespace osgUtil;
 
-// #define GEOMETRYDEPRECATED
-
 void Optimizer::reset()
 {
 }
@@ -288,14 +286,6 @@ void Optimizer::optimize(osg::Node* node, unsigned int options)
         osg::Timer_t endTick = osg::Timer::instance()->tick();
 
         OSG_INFO<<"MERGE_GEODES took "<<osg::Timer::instance()->delta_s(startTick,endTick)<<std::endl;
-    }
-
-    if (options & CHECK_GEOMETRY)
-    {
-        OSG_INFO<<"Optimizer::optimize() doing CHECK_GEOMETRY"<<std::endl;
-
-        CheckGeometryVisitor mgv(this);
-        node->accept(mgv);
     }
 
     if (options & MAKE_FAST_GEOMETRY)
@@ -1732,20 +1722,8 @@ struct LessGeometryPrimitiveType
     }
 };
 
-void Optimizer::CheckGeometryVisitor::apply(osg::Geometry& geom)
-{
-    if (isOperationPermissibleForObject(&geom))
-    {
-#ifdef GEOMETRYDEPRECATED
-        geom
-        .computeCorrectBindingsAndArraySizes();
-#endif
-    }
-}
-
 void Optimizer::MakeFastGeometryVisitor::apply(osg::Geometry& geom)
 {
-    // GeometryDeprecated CAN REMOVED
     if (isOperationPermissibleForObject(&geom))
     {
         if (geom.checkForDeprecatedData())

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -461,38 +461,6 @@ void Optimizer::StateVisitor::apply(osg::Node& node)
     traverse(node);
 }
 
-void Optimizer::StateVisitor::apply(osg::Geode& geode)
-{
-    if (!isOperationPermissibleForObject(&geode)) return;
-
-    osg::StateSet* ss = geode.getStateSet();
-
-
-    if (ss && ss->getDataVariance()==osg::Object::STATIC)
-    {
-        if (isOperationPermissibleForObject(ss))
-        {
-            addStateSet(ss,&geode);
-        }
-    }
-    for(unsigned int i=0;i<geode.getNumDrawables();++i)
-    {
-        osg::Drawable* drawable = geode.getDrawable(i);
-        if (drawable)
-        {
-            ss = drawable->getStateSet();
-            if (ss && ss->getDataVariance()==osg::Object::STATIC)
-            {
-                if (isOperationPermissibleForObject(drawable) &&
-                    isOperationPermissibleForObject(ss))
-                {
-                    addStateSet(ss,drawable);
-                }
-            }
-        }
-    }
-}
-
 void Optimizer::StateVisitor::optimize()
 {
     OSG_INFO << "Num of StateSet="<<_statesets.size()<< std::endl;


### PR DESCRIPTION
Several optimizers were not functioning correctly when used with new-style scene graphs where Drawables are placed directly in the scene graph rather than under a Geode.

The changed version was tested successfully on a few different models.

Still broken are:
FlattenStaticTransformsDuplicatingSharedSubgraphsVisitor
MergeGeometryVisitor
