### PR TITLE
Backport State fix to 3.4 branch

### DIFF
--- a/src/osg/State.cpp
+++ b/src/osg/State.cpp
@@ -1842,6 +1842,7 @@ bool State::DefineMap::updateCurrentDefines()
                 }
             }
         }
+        changed = false;
         return true;
     }
     else


### PR DESCRIPTION
I decided to backport the fix for this issue which caused OSG to redundantly glUseProgram() before every single draw call.

For me the difference in FPS is rather significant:
Before:
Draw 7.7ms
After:
Draw 5.0ms