### PR TITLE
Move bindVertexArrayObject to osg::State to avoid null vao from being bound redundantly on every draw call

### DIFF
--- a/include/osg/Drawable
+++ b/include/osg/Drawable
@@ -518,7 +518,7 @@ inline void Drawable::draw(RenderInfo& renderInfo) const
 
         State::SetCurrentVertexArrayStateProxy setVASProxy(state, vas);
 
-        vas->bindVertexArrayObject();
+        state.bindVertexArrayObject();
 
         drawInner(renderInfo);
 
@@ -528,7 +528,7 @@ inline void Drawable::draw(RenderInfo& renderInfo) const
     }
 
     // TODO, add check against whether VAO is active and supported
-    if (state.getCurrentVertexArrayState()) state.getCurrentVertexArrayState()->bindVertexArrayObject();
+    if (state.getCurrentVertexArrayState()) state.bindVertexArrayObject();
 
 
 #ifdef OSG_GL_DISPLAYLISTS_AVAILABLE

--- a/include/osg/State
+++ b/include/osg/State
@@ -565,6 +565,16 @@ class OSG_EXPORT State : public Referenced
         void setCurrentPixelBufferObject(osg::GLBufferObject* pbo) { _currentPBO = pbo; }
         const GLBufferObject* getCurrentPixelBufferObject() { return _currentPBO; }
 
+        inline void bindVertexArrayObject()
+        {
+            GLuint vao = _vas->getVertexArrayObject();
+            if (vao != _currentVAO)
+            {
+                _glExtensions->glBindVertexArray(vao);
+                _currentVAO = vao;
+            }
+        }
+
         inline void bindPixelBufferObject(osg::GLBufferObject* pbo)
         {
             if (pbo)
@@ -1248,6 +1258,7 @@ class OSG_EXPORT State : public Referenced
         unsigned int                    _currentActiveTextureUnit;
         unsigned int                    _currentClientActiveTextureUnit;
         GLBufferObject*                 _currentPBO;
+        GLuint                          _currentVAO;
 
 
         inline ModeMap& getOrCreateTextureModeMap(unsigned int unit)

--- a/include/osg/VertexArrayState
+++ b/include/osg/VertexArrayState
@@ -164,10 +164,6 @@ public:
 
         void deleteVertexArrayObject();
 
-        inline void bindVertexArrayObject() const { _ext->glBindVertexArray (_vertexArrayObject); }
-
-        inline void unbindVertexArrayObject() const { _ext->glBindVertexArray (0); }
-
         GLuint getVertexArrayObject() const { return _vertexArrayObject; }
 
 

--- a/src/osg/Drawable.cpp
+++ b/src/osg/Drawable.cpp
@@ -646,7 +646,7 @@ void Drawable::draw(RenderInfo& renderInfo) const
 
         State::SetCurrentVertexArrayStateProxy setVASProxy(state, vas);
 
-        vas->bindVertexArrayObject();
+        state.bindVertexArrayObject();
 
         drawInner(renderInfo);
 
@@ -656,7 +656,7 @@ void Drawable::draw(RenderInfo& renderInfo) const
     }
 
     // TODO, add check against whether VAO is active and supported
-    if (state.getCurrentVertexArrayState()) state.getCurrentVertexArrayState()->bindVertexArrayObject();
+    if (state.getCurrentVertexArrayState()) state.bindVertexArrayObject();
 
 
 #ifdef OSG_GL_DISPLAYLISTS_AVAILABLE

--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -820,7 +820,7 @@ void Geometry::compileGLObjects(RenderInfo& renderInfo) const
 
             State::SetCurrentVertexArrayStateProxy setVASProxy(state, vas);
 
-            vas->bindVertexArrayObject();
+            state.bindVertexArrayObject();
 
             drawVertexArraysImplementation(renderInfo);
         }

--- a/src/osg/State.cpp
+++ b/src/osg/State.cpp
@@ -89,6 +89,7 @@ State::State():
     _currentClientActiveTextureUnit=0;
 
     _currentPBO = 0;
+    _currentVAO = 0;
 
     _isSecondaryColorSupported = false;
     _isFogCoordSupported = false;

--- a/src/osgTerrain/GeometryPool.cpp
+++ b/src/osgTerrain/GeometryPool.cpp
@@ -861,7 +861,7 @@ void SharedGeometry::compileGLObjects(osg::RenderInfo& renderInfo) const
 
             osg::State::SetCurrentVertexArrayStateProxy setVASProxy(state, vas);
 
-            vas->bindVertexArrayObject();
+            state.bindVertexArrayObject();
 
             if (vbo_glBufferObject) vas->bindVertexBufferObject(vbo_glBufferObject);
             if (ebo_glBufferObject) vas->bindElementBufferObject(ebo_glBufferObject);


### PR DESCRIPTION
When not using VAOs, OSG would redundantly bind a null VAO before every draw call:

![redundant_vao](https://cloud.githubusercontent.com/assets/720642/22720096/23c672e2-eda9-11e6-93ee-aef539c07c49.png)

To solve this, I moved the bind method into osg::State so we can check against the last bound VAO.

With this change applied my program is seeing a performance improvement in the draw thread of about 4%.