### PR TITLE
Bug/osg fixes

### DIFF
--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -133,7 +133,7 @@ void Geometry::configureBufferObjects()
         itr != arrays.end();
         ++itr)
     {
-        osg::Array* array = *itr;
+        osg::Array* array = itr->get();
         if (array->getBinding()==osg::Array::BIND_PER_VERTEX)
         {
             if (array->getNumElements()==numVertices)

--- a/src/osgPlugins/3ds/ReaderWriter3DS.cpp
+++ b/src/osgPlugins/3ds/ReaderWriter3DS.cpp
@@ -619,7 +619,7 @@ osg::Node* ReaderWriter3DS::ReaderObject::processNode(StateSetMap& drawStateMap,
         {
             // add our geometry to group (where our children already are)
             // creates geometry under modifier node
-            processMesh(drawStateMap,group,mesh,meshAppliedMatPtr);
+            processMesh(drawStateMap,meshTransform,mesh,meshAppliedMatPtr);
             return group;
         }
         else

--- a/src/osgPlugins/Inventor/ConvertToInventor.cpp
+++ b/src/osgPlugins/Inventor/ConvertToInventor.cpp
@@ -282,7 +282,7 @@ void osgArray2ivMField_composite_template(const osg::Array *array, fieldClass &f
     assert(startIndex >= 0 && stopIndex >= 0);
     assert(stopIndex <= int(array->getNumElements()));
   }
-  assert(numItemsUntilMinusOne <= 0 && "Composite template must have numItemsUntilMinusOne set to 0.");
+  // assert(numItemsUntilMinusOne <= 0 && "Composite template must have numItemsUntilMinusOne set to 0.");
   field.setNum(num);
   ivType *a = field.startEditing();
 
@@ -305,7 +305,7 @@ void osgArray2ivMField_pack_template(const osg::Array *array, fieldClass &field,
     assert(startIndex >= 0 && stopIndex >= 0);
     assert(stopIndex <= int(array->getNumElements()));
   }
-  assert(numItemsUntilMinusOne <= 0 && "Pack template must have numItemsUntilMinusOne set to 0.");
+  // assert(numItemsUntilMinusOne <= 0 && "Pack template must have numItemsUntilMinusOne set to 0.");
   field.setNum(num);
   ivType *a = field.startEditing();
 

--- a/src/osgPlugins/OpenCASCADE/ReaderWriterOpenCASCADE.cpp
+++ b/src/osgPlugins/OpenCASCADE/ReaderWriterOpenCASCADE.cpp
@@ -262,7 +262,7 @@ osg::ref_ptr<osg::Geometry> ReaderWritterOpenCASCADE::OCCTKReader::_createGeomet
             std::cout << "Adding Primitive set" << std::endl;
         #endif
 
-        geom->addPrimitiveSet(triangleStrip);
+        geom->addPrimitiveSet(triangleStrip.get());
     }
 
     return geom;

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -2320,6 +2320,13 @@ class MergeArrayVisitor : public osg::ArrayVisitor
         virtual void apply(osg::UIntArray& rhs) { if (_offset) _mergeAndOffset(rhs); else  _merge(rhs); }
 
         virtual void apply(osg::Vec4ubArray& rhs) { _merge(rhs); }
+        virtual void apply(osg::Vec3ubArray& rhs) { _merge(rhs); }
+        virtual void apply(osg::Vec2ubArray& rhs) { _merge(rhs); }
+
+        virtual void apply(osg::Vec4usArray& rhs) { _merge(rhs); }
+        virtual void apply(osg::Vec3usArray& rhs) { _merge(rhs); }
+        virtual void apply(osg::Vec2usArray& rhs) { _merge(rhs); }
+
         virtual void apply(osg::FloatArray& rhs) { _merge(rhs); }
         virtual void apply(osg::Vec2Array& rhs) { _merge(rhs); }
         virtual void apply(osg::Vec3Array& rhs) { _merge(rhs); }
@@ -2333,6 +2340,7 @@ class MergeArrayVisitor : public osg::ArrayVisitor
         virtual void apply(osg::Vec2bArray&  rhs) { _merge(rhs); }
         virtual void apply(osg::Vec3bArray&  rhs) { _merge(rhs); }
         virtual void apply(osg::Vec4bArray&  rhs) { _merge(rhs); }
+
         virtual void apply(osg::Vec2sArray& rhs) { _merge(rhs); }
         virtual void apply(osg::Vec3sArray& rhs) { _merge(rhs); }
         virtual void apply(osg::Vec4sArray& rhs) { _merge(rhs); }

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -2269,21 +2269,18 @@ class MergeArrayVisitor : public osg::ArrayVisitor
 {
     protected:
         osg::Array* _lhs;
-        int         _offset;
     public:
         MergeArrayVisitor() :
-            _lhs(0),
-            _offset(0) {}
+            _lhs(0) {}
 
 
         /// try to merge the content of two arrays.
-        bool merge(osg::Array* lhs,osg::Array* rhs, int offset=0)
+        bool merge(osg::Array* lhs,osg::Array* rhs)
         {
             if (lhs==0 || rhs==0) return true;
             if (lhs->getType()!=rhs->getType()) return false;
 
             _lhs = lhs;
-            _offset = offset;
 
             rhs->accept(*this);
             return true;
@@ -2296,28 +2293,14 @@ class MergeArrayVisitor : public osg::ArrayVisitor
             lhs->insert(lhs->end(),rhs.begin(),rhs.end());
         }
 
-        template<typename T>
-        void _mergeAndOffset(T& rhs)
-        {
-            T* lhs = static_cast<T*>(_lhs);
-
-            typename T::iterator itr;
-            for(itr = rhs.begin();
-                itr != rhs.end();
-                ++itr)
-            {
-                lhs->push_back(*itr + _offset);
-            }
-        }
-
         virtual void apply(osg::Array&) { OSG_WARN << "Warning: Optimizer's MergeArrayVisitor cannot merge Array type." << std::endl; }
 
-        virtual void apply(osg::ByteArray& rhs) { if (_offset) _mergeAndOffset(rhs); else  _merge(rhs); }
-        virtual void apply(osg::ShortArray& rhs) { if (_offset) _mergeAndOffset(rhs); else  _merge(rhs); }
-        virtual void apply(osg::IntArray& rhs) { if (_offset) _mergeAndOffset(rhs); else  _merge(rhs); }
-        virtual void apply(osg::UByteArray& rhs) { if (_offset) _mergeAndOffset(rhs); else  _merge(rhs); }
-        virtual void apply(osg::UShortArray& rhs) { if (_offset) _mergeAndOffset(rhs); else  _merge(rhs); }
-        virtual void apply(osg::UIntArray& rhs) { if (_offset) _mergeAndOffset(rhs); else  _merge(rhs); }
+        virtual void apply(osg::ByteArray& rhs) { _merge(rhs); }
+        virtual void apply(osg::ShortArray& rhs) { _merge(rhs); }
+        virtual void apply(osg::IntArray& rhs) { _merge(rhs); }
+        virtual void apply(osg::UByteArray& rhs) { _merge(rhs); }
+        virtual void apply(osg::UShortArray& rhs) { _merge(rhs); }
+        virtual void apply(osg::UIntArray& rhs) { _merge(rhs); }
 
         virtual void apply(osg::Vec4ubArray& rhs) { _merge(rhs); }
         virtual void apply(osg::Vec3ubArray& rhs) { _merge(rhs); }


### PR DESCRIPTION
Hi Robert, please find

* Compilation fixes:
    * inventor plugin where a commented variable is asserted
    * implicit conversion from `ref_ptr` ro raw pointer (when using cmake flag `REF_PTR_IMPLICIT_OUTPUT_CONVERSION`)
* Bug fixes:
    * 3ds plugin read (see http://forum.openscenegraph.org/viewtopic.php?t=16482 for discussion)
    * missing array types in array merge (typically an issue when running the optimizer on scenes that have geometries with vertex color)
* Clean up:
    * remove usage of `offset` attribute in `MergeArrayVisitor`; this might be needed in non-public code so I may remove this commit if you prefer) 