### PR TITLE
Submit serializer particle

### DIFF
--- a/src/osgWrappers/serializers/osgParticle/Particle.cpp
+++ b/src/osgWrappers/serializers/osgParticle/Particle.cpp
@@ -36,7 +36,7 @@ bool readParticle( osgDB::InputStream& is, osgParticle::Particle& p )
     if ( hasInterpolator )
     {
         is >> is.BEGIN_BRACKET;
-        p.setAlphaInterpolator( is.readObjectOfType<osgParticle::Interpolator>() );
+        p.setSizeInterpolator( is.readObjectOfType<osgParticle::Interpolator>() );
         is >> is.END_BRACKET;
     }
     is >> is.PROPERTY("AlphaInterpolator") >> hasInterpolator;
@@ -50,7 +50,7 @@ bool readParticle( osgDB::InputStream& is, osgParticle::Particle& p )
     if ( hasInterpolator )
     {
         is >> is.BEGIN_BRACKET;
-        p.setAlphaInterpolator( is.readObjectOfType<osgParticle::Interpolator>() );
+        p.setColorInterpolator( is.readObjectOfType<osgParticle::Interpolator>() );
         is >> is.END_BRACKET;
     }
 

--- a/src/osgWrappers/serializers/osgParticle/Particle.cpp
+++ b/src/osgWrappers/serializers/osgParticle/Particle.cpp
@@ -81,8 +81,8 @@ bool readParticle( osgDB::InputStream& is, osgParticle::Particle& p )
             is >> is.END_BRACKET;
         }
 
-        is >> is.END_BRACKET;
     }
+    is >> is.END_BRACKET;
     return true;
 }
 


### PR DESCRIPTION
read endbracket for fileversion 145:
osgconv spaceship.osgt spaceship2.osgt; osgconv spaceship2.osgt spaceship3.osgt; osgviewer spaceship3.osgt 
shows the partice engines have stopped working, due to the missing read of an endbracket in file version 145 and up.