### PR TITLE
Serializer for osg::TextureBuffer and osg::Texture2DMultisample

### DIFF
--- a/include/osg/Texture2DMultisample
+++ b/include/osg/Texture2DMultisample
@@ -61,6 +61,9 @@ class OSG_EXPORT Texture2DMultisample : public Texture
         inline void setNumSamples( int samples ) { _numSamples = samples; }
         GLsizei getNumSamples() const { return _numSamples; }
 
+        inline void setFixedSampleLocations( GLboolean fixedSampleLocations ) { _fixedsamplelocations = fixedSampleLocations; }
+        inline GLboolean getFixedSampleLocations() const { return _fixedsamplelocations; }
+
         // unnecessary for Texture2DMultisample
         virtual void setImage(unsigned int /*face*/, Image* /*image*/) {}
 

--- a/src/osgWrappers/serializers/osg/Texture2DMultisample.cpp
+++ b/src/osgWrappers/serializers/osg/Texture2DMultisample.cpp
@@ -1,0 +1,15 @@
+#include <osg/Texture2DMultisample>
+#include <osgDB/ObjectWrapper>
+#include <osgDB/InputStream>
+#include <osgDB/OutputStream>
+
+REGISTER_OBJECT_WRAPPER( Texture2DMultisample,
+                         new osg::Texture2DMultisample,
+                         osg::Texture2DMultisample,
+                         "osg::Object osg::StateAttribute osg::Texture osg::Texture2DMultisample" )
+{
+    ADD_INT_SERIALIZER( TextureWidth, 0 );                  // _textureWidth
+    ADD_INT_SERIALIZER( TextureHeight, 0 );                 // _textureHeight
+    ADD_INT_SERIALIZER( NumSamples, 1 );                    // _numSamples
+    ADD_UCHAR_SERIALIZER( FixedSampleLocations, GL_FALSE ); // _fixedsamplelocations
+}

--- a/src/osgWrappers/serializers/osg/TextureBuffer.cpp
+++ b/src/osgWrappers/serializers/osg/TextureBuffer.cpp
@@ -48,7 +48,7 @@ static bool writeImage( osgDB::OutputStream& os, const osg::TextureBuffer& textu
 
 static bool checkBufferData( const osg::TextureBuffer& texture )
 {
-    return texture.getBufferData()->asArray() != NULL;
+    return texture.getBufferData() != NULL && texture.getBufferData()->asArray() != NULL;
 }
 
 static bool readBufferData( osgDB::InputStream& is, osg::TextureBuffer& texture )

--- a/src/osgWrappers/serializers/osg/TextureBuffer.cpp
+++ b/src/osgWrappers/serializers/osg/TextureBuffer.cpp
@@ -1,0 +1,98 @@
+#include <osg/TextureBuffer>
+#include <osg/Array>
+#include <osgDB/ObjectWrapper>
+#include <osgDB/InputStream>
+#include <osgDB/OutputStream>
+
+static bool checkImage( const osg::TextureBuffer& texture )
+{
+    return texture.getImage() != NULL;
+}
+
+static bool readImage( osgDB::InputStream& is, osg::TextureBuffer& texture )
+{
+    if ( is.isBinary() )
+    {
+        osg::ref_ptr<osg::Image> image = is.readImage();
+        texture.setImage(image.get());
+    }
+    else
+    {        
+        is >> is.BEGIN_BRACKET;
+        osg::ref_ptr<osg::Image> image = is.readImage();
+        texture.setImage(image.get());
+        is >> is.END_BRACKET;    
+    }    
+    
+    return true;
+}
+
+static bool writeImage( osgDB::OutputStream& os, const osg::TextureBuffer& texture )
+{
+    const osg::Image* image = texture.getImage();    
+
+    if ( os.isBinary() )
+    {        
+        os.writeImage(image);
+    }
+    else
+    {
+        os << os.BEGIN_BRACKET << std::endl;
+        os.writeImage(image);
+        os << os.END_BRACKET << std::endl;
+    }
+
+    return true;
+}
+
+
+static bool checkBufferData( const osg::TextureBuffer& texture )
+{
+    return texture.getBufferData()->asArray() != NULL;
+}
+
+static bool readBufferData( osgDB::InputStream& is, osg::TextureBuffer& texture )
+{
+    if ( is.isBinary() )
+    {
+        osg::ref_ptr<osg::Array> bufferData = is.readArray();
+        texture.setBufferData(bufferData);
+    }
+    else
+    {
+        is >> is.BEGIN_BRACKET;
+        osg::ref_ptr<osg::Array> bufferData = is.readArray();
+        texture.setBufferData(bufferData);
+        is >> is.END_BRACKET;    
+    }
+    
+    return true;
+}
+
+static bool writeBufferData( osgDB::OutputStream& os, const osg::TextureBuffer& texture )
+{    
+    const osg::Array* array = texture.getBufferData()->asArray();
+
+    if ( os.isBinary() )
+    {
+        os.writeArray(array);
+    }
+    else
+    {        
+        os << os.BEGIN_BRACKET << std::endl;
+        os.writeArray(array);
+        os << os.END_BRACKET << std::endl;
+    }    
+
+    return true;
+}
+
+REGISTER_OBJECT_WRAPPER( TextureBuffer,
+                         new osg::TextureBuffer,
+                         osg::TextureBuffer,
+                         "osg::Object osg::StateAttribute osg::Texture osg::TextureBuffer" )
+{
+    ADD_USER_SERIALIZER(Image);            // _bufferData as osg::Image
+    ADD_USER_SERIALIZER(BufferData);       // _bufferData as osg::Array
+    ADD_INT_SERIALIZER( TextureWidth, 0 ); // _textureWidth    
+}


### PR DESCRIPTION
Hello,

I implemented serializers for the TextureBuffer and Texture2DMultisample classes.
The TextureBuffer serializer supports buffer data that is stored as osg::Image or osg::Array which should be sufficient for most use cases.

Greetings
Marcel