### PR TITLE
BufferObject/BufferData Serializers and involved updated arrays serializers too

### DIFF
--- a/src/osgWrappers/serializers/osg/Array.cpp
+++ b/src/osgWrappers/serializers/osg/Array.cpp
@@ -34,8 +34,14 @@ struct ResizeArray : public osgDB::MethodObject
 REGISTER_OBJECT_WRAPPER( Array,
                          0,
                          osg::Array,
-                         "osg::Object osg::Array" )
+                         "osg::Object osg::BufferData osg::Array" )
 {
+
+
+    {
+        UPDATE_TO_VERSION_SCOPED( 145 )
+        ADDED_ASSOCIATE("osg::BufferData")
+    }
 #if 0
     BEGIN_ENUM_SERIALIZER_NO_SET( Type, ArrayType );
         ADD_ENUM_VALUE( ArrayType );
@@ -114,8 +120,12 @@ REGISTER_OBJECT_WRAPPER( Array,
 
 #define ARRAY_WRAPPERS( ARRAY, ELEMENTTYPE, NUMELEMENTSONROW ) \
     namespace Wrappers##ARRAY { \
-        REGISTER_OBJECT_WRAPPER( ARRAY, new osg::ARRAY, osg::ARRAY, "osg::Object osg::Array osg::"#ARRAY) \
+        REGISTER_OBJECT_WRAPPER( ARRAY, new osg::ARRAY, osg::ARRAY, "osg::Object osg::BufferData osg::Array osg::"#ARRAY) \
         { \
+            {\
+                UPDATE_TO_VERSION_SCOPED( 145 )\
+                ADDED_ASSOCIATE("osg::BufferData")\
+            }\
                 ADD_ISAVECTOR_SERIALIZER( vector, osgDB::BaseSerializer::ELEMENTTYPE, NUMELEMENTSONROW ); \
         } \
     }

--- a/src/osgWrappers/serializers/osg/BufferObject.cpp
+++ b/src/osgWrappers/serializers/osg/BufferObject.cpp
@@ -1,0 +1,120 @@
+#include <osg/BufferObject>
+#include <osgDB/ObjectWrapper>
+#include <osgDB/InputStream>
+#include <osgDB/OutputStream>
+
+
+
+////////////////////////////////////////
+///         BufferData
+////////////////////////////////////////
+namespace BufferDataWrapper
+{
+class HackedBufferData:public osg::BufferData
+{
+
+public:
+    void setBufferObjectWithoutAddingBD2BO( osg::BufferObject*bufferObject)
+    {
+        if (_bufferObject==bufferObject) return;
+
+        _bufferObject = bufferObject;
+    }
+};
+static bool checkBufferObject( const osg::BufferData& node )
+{
+    return true;
+}
+
+static bool readBufferObject( osgDB::InputStream& is, osg::BufferData& node1 )
+{
+    unsigned int size = 0;
+    HackedBufferData&node  =static_cast<HackedBufferData&>(node1);
+
+    osg::ref_ptr<osg::Object> obj = is.readObject();
+    osg::BufferObject* bo = dynamic_cast<osg::BufferObject*>( obj.get() );
+    if ( bo ) node.setBufferObjectWithoutAddingBD2BO(bo);///don't add BufferData to BufferObject (let Serializer do it)
+    return true;
+}
+
+static bool writeBufferObject( osgDB::OutputStream& os, const osg::BufferData& node )
+{
+    os << node.getBufferObject();
+    return true;
+}
+
+REGISTER_OBJECT_WRAPPER( BufferData,
+                         0,
+                         osg::BufferData,
+                         "osg::Object osg::BufferData" )
+{
+    ADD_USER_SERIALIZER(BufferObject);
+    ADD_UINT_SERIALIZER(BufferIndex,0);
+}
+}
+
+////////////////////////////////////////
+///         BufferObject
+////////////////////////////////////////
+
+namespace BufferObjectWrapper
+{
+static bool checkBufferData( const osg::BufferObject& node )
+{
+    return node.getNumBufferData()>0;
+}
+
+static bool readBufferData( osgDB::InputStream& is, osg::BufferObject& node )
+{
+    unsigned int size = 0;
+    is >> size >> is.BEGIN_BRACKET;
+    for ( unsigned int i=0; i<size; ++i )
+    {
+        osg::ref_ptr<osg::Object> obj = is.readObject();
+        osg::BufferData* child = dynamic_cast<osg::BufferData*>( obj.get() );
+        if ( child ) node.addBufferData( child );
+    }
+    is >> is.END_BRACKET;
+    node.dirty();
+    return true;
+}
+
+static bool writeBufferData( osgDB::OutputStream& os, const osg::BufferObject& node )
+{
+    unsigned int size = node.getNumBufferData();
+    os << size << os.BEGIN_BRACKET << std::endl;
+    for ( unsigned int i=0; i<size; ++i )
+    {
+        os << node.getBufferData(i);
+    }
+    os << os.END_BRACKET << std::endl;
+    return true;
+}
+
+
+REGISTER_OBJECT_WRAPPER( BufferObject,
+                         /*new osg::BufferObject*/NULL,
+                         osg::BufferObject,
+                         "osg::Object osg::BufferObject" )
+{
+    ADD_GLENUM_SERIALIZER( Target,GLenum, GL_ARRAY_BUFFER_ARB);  // _type
+    ADD_GLENUM_SERIALIZER( Usage,GLenum, GL_STATIC_DRAW_ARB);  // _type   setTarget(GL_ARRAY_BUFFER_ARB);
+    ADD_BOOL_SERIALIZER(CopyDataAndReleaseGLBufferObject,false);
+    ADD_USER_SERIALIZER( BufferData );  // _BufferData
+}
+}
+
+namespace VertexBufferObjectWrapper
+{
+REGISTER_OBJECT_WRAPPER( VertexBufferObject,
+                         new osg::VertexBufferObject,
+                         osg::VertexBufferObject,
+                         "osg::Object osg::BufferObject osg::VertexBufferObject" ) {    }
+}
+namespace ElementBufferObjectWrapper
+{
+REGISTER_OBJECT_WRAPPER( ElementBufferObject,
+                         new osg::ElementBufferObject,
+                         osg::ElementBufferObject,
+                         "osg::Object osg::BufferObject osg::ElementBufferObject" ) {    }
+}


### PR DESCRIPTION
here are serializers for BuffererData/BufferObject as well as involved Arrays
to integrate consider adding osg::BufferData as osg::Array serializer
i don't know if dso is good due to this commit i've done to integrate associate version management (i keep these changes for a future pr)
https://github.com/mp3butcher/OpenSceneGraph/commit/f0ae9d71608b07c7b5a88954f8f5a3807d7e21cc
Further for the bo serializer to be usefull, you should consider removing the osg::Geometry FinishLoadingCallback that forbid BufferObject serialization (it reset all arrays's bos to null)