### PR TITLE
BufferObject Configuration serialization

### DIFF
--- a/include/osgDB/OutputStream
+++ b/include/osgDB/OutputStream
@@ -209,9 +209,9 @@ protected:
     typedef std::map<std::string, int> VersionMap;
     VersionMap _domainVersionMap;
     WriteImageHint _writeImageHint;
-    bool _writeBufferObjectConfiguration;
     bool _useSchemaData;
     bool _useRobustBinaryFormat;
+    bool _writeBufferObjectConfiguration;
 
     typedef std::map<std::string, std::string> SchemaMap;
     SchemaMap _inbuiltSchemaMap;

--- a/include/osgDB/OutputStream
+++ b/include/osgDB/OutputStream
@@ -89,6 +89,9 @@ public:
     void setWriteImageHint( WriteImageHint hint ) { _writeImageHint = hint; }
     WriteImageHint getWriteImageHint() const { return _writeImageHint; }
 
+    void setWriteBufferObjectConfiguration( bool hint ) { _writeBufferObjectConfiguration = hint; }
+    bool getWriteBufferObjectConfiguration() const { return _writeBufferObjectConfiguration; }
+
     // Serialization related functions
     OutputStream& operator<<( bool b ) { _out->writeBool(b); return *this; }
     OutputStream& operator<<( char c ) { _out->writeChar(c); return *this; }
@@ -206,6 +209,7 @@ protected:
     typedef std::map<std::string, int> VersionMap;
     VersionMap _domainVersionMap;
     WriteImageHint _writeImageHint;
+    bool _writeBufferObjectConfiguration;
     bool _useSchemaData;
     bool _useRobustBinaryFormat;
 

--- a/src/osgDB/OutputStream.cpp
+++ b/src/osgDB/OutputStream.cpp
@@ -25,7 +25,7 @@
 using namespace osgDB;
 
 OutputStream::OutputStream( const osgDB::Options* options )
-:   _writeImageHint(WRITE_USE_IMAGE_HINT), _useSchemaData(false), _useRobustBinaryFormat(true)
+:   _writeImageHint(WRITE_USE_IMAGE_HINT), _useSchemaData(false), _useRobustBinaryFormat(true), _writeBufferObjectConfiguration(false)
 {
     BEGIN_BRACKET.set( "{", +INDENT_VALUE );
     END_BRACKET.set( "}", -INDENT_VALUE );
@@ -37,6 +37,8 @@ OutputStream::OutputStream( const osgDB::Options* options )
         _useRobustBinaryFormat = false;
     if ( options->getPluginStringData("SchemaData")=="true" )
         _useSchemaData = true;
+    if ( options->getPluginStringData("WriteBufferObjectConfiguration")=="true" )
+        _writeBufferObjectConfiguration = true;
     if ( !options->getPluginStringData("SchemaFile").empty() )
         _schemaName = options->getPluginStringData("SchemaFile");
     if ( !options->getPluginStringData("Compressor").empty() )

--- a/src/osgWrappers/serializers/osg/BufferData.cpp
+++ b/src/osgWrappers/serializers/osg/BufferData.cpp
@@ -4,6 +4,59 @@
 #include <osgDB/OutputStream>
 
 
+class BufferData_serializer_BufferData:public osg::BufferData
+{
+
+public:
+    void setBufferObjectWithoutAddingBD2BO( osg::BufferObject*bufferObject)
+    {
+        if (_bufferObject==bufferObject) return;
+
+        _bufferObject = bufferObject;
+    }
+};
+static bool checkBufferObject( const osg::BufferData& node )
+{
+    return true;
+}
+
+///don't add BufferData to BufferObject (let BufferObject Serializer::readBufferData do it)
+static bool readBufferObject( osgDB::InputStream& is, osg::BufferData& bd )
+{
+    BufferData_serializer_BufferData &localbd  =static_cast<BufferData_serializer_BufferData&>(bd);
+    osg::ref_ptr<osg::Object> obj = is.readObject();
+    osg::BufferObject* bo = dynamic_cast<osg::BufferObject*>( obj.get() );
+    if ( bo ) localbd.setBufferObjectWithoutAddingBD2BO(bo);
+    return true;
+}
+
+static bool writeBufferObject( osgDB::OutputStream& os, const osg::BufferData& bd )
+{
+    if (os.getWriteBufferObjectConfiguration())
+        os << bd.getBufferObject();
+    else os << (osg::BufferObject*)NULL;
+    return true;
+}
+static bool checkBufferIndex( const osg::BufferData& bd )
+{
+    return true;
+}
+
+static bool readBufferIndex( osgDB::InputStream& is, osg::BufferData& bd )
+{
+    unsigned int index;
+    is >> index;
+    bd.setBufferIndex(index);
+    return true;
+}
+
+static bool writeBufferIndex( osgDB::OutputStream& os, const osg::BufferData& bd )
+{
+    if (os.getWriteBufferObjectConfiguration())
+        os << bd.getBufferIndex();
+    else os << 0;
+    return true;
+}
 
 REGISTER_OBJECT_WRAPPER( BufferData,
                          0,
@@ -12,6 +65,7 @@ REGISTER_OBJECT_WRAPPER( BufferData,
 {
     {
         UPDATE_TO_VERSION_SCOPED( 147 )
-        ADD_OBJECT_SERIALIZER(BufferObject, osg::BufferObject, NULL);
+        ADD_USER_SERIALIZER(BufferObject);
+        ADD_USER_SERIALIZER(BufferIndex);
     }
 }

--- a/src/osgWrappers/serializers/osg/BufferObject.cpp
+++ b/src/osgWrappers/serializers/osg/BufferObject.cpp
@@ -3,12 +3,47 @@
 #include <osgDB/InputStream>
 #include <osgDB/OutputStream>
 
+static bool checkBufferData( const osg::BufferObject& node )
+{
+    return node.getNumBufferData()>0;
+}
+
+/// add BufferData to BufferObject (let BufferData Serializer::readBufferObject not in charge of it)
+static bool readBufferData( osgDB::InputStream& is, osg::BufferObject& node )
+{
+    unsigned int size = 0;
+    is >> size >> is.BEGIN_BRACKET;
+    for ( unsigned int i=0; i<size; ++i )
+    {
+        osg::ref_ptr<osg::Object> obj = is.readObject();
+        osg::BufferData* child = dynamic_cast<osg::BufferData*>( obj.get() );
+        if ( child ) node.addBufferData( child );
+    }
+    is >> is.END_BRACKET;
+    node.dirty();
+    return true;
+}
+
+static bool writeBufferData( osgDB::OutputStream& os, const osg::BufferObject& node )
+{
+    unsigned int size = node.getNumBufferData();
+    os << size << os.BEGIN_BRACKET << std::endl;
+    for ( unsigned int i=0; i<size; ++i )
+    {
+        os << node.getBufferData(i);
+    }
+    os << os.END_BRACKET << std::endl;
+    return true;
+}
+
 REGISTER_OBJECT_WRAPPER( BufferObject,
                          /*new osg::BufferObject*/NULL,
                          osg::BufferObject,
                          "osg::Object osg::BufferObject" )
 {
-    ADD_GLENUM_SERIALIZER( Target,GLenum, GL_ARRAY_BUFFER_ARB);  // _type
-    ADD_GLENUM_SERIALIZER( Usage,GLenum, GL_STATIC_DRAW_ARB);  // _type   setTarget(GL_ARRAY_BUFFER_ARB);
-    ADD_BOOL_SERIALIZER( CopyDataAndReleaseGLBufferObject, false);
+    ADD_GLENUM_SERIALIZER( Target,GLenum, GL_ARRAY_BUFFER_ARB );  // _type
+    ADD_GLENUM_SERIALIZER( Usage,GLenum, GL_STATIC_DRAW_ARB );  // _usage
+    ADD_BOOL_SERIALIZER( CopyDataAndReleaseGLBufferObject,false );
+    ADD_USER_SERIALIZER( BufferData );  // _BufferData
 }
+

--- a/src/osgWrappers/serializers/osg/PrimitiveSet.cpp
+++ b/src/osgWrappers/serializers/osg/PrimitiveSet.cpp
@@ -85,6 +85,10 @@ REGISTER_OBJECT_WRAPPER( DrawArrays,
                          osg::DrawArrays,
                          "osg::Object osg::BufferData osg::PrimitiveSet osg::DrawArrays" )
 {
+    {
+        UPDATE_TO_VERSION_SCOPED( 147 )
+        ADDED_ASSOCIATE("osg::BufferData")
+    }
     ADD_GLINT_SERIALIZER( First, 0);
     ADD_GLINT_SERIALIZER( Count, 0);
 }
@@ -98,6 +102,10 @@ REGISTER_OBJECT_WRAPPER( DrawArrayLengths,
                          osg::DrawArrayLengths,
                          "osg::Object osg::BufferData osg::PrimitiveSet osg::DrawArrayLengths" )
 {
+    {
+        UPDATE_TO_VERSION_SCOPED( 147 )
+        ADDED_ASSOCIATE("osg::BufferData")
+    }
     ADD_GLINT_SERIALIZER( First, 0);
     ADD_ISAVECTOR_SERIALIZER( vector, osgDB::BaseSerializer::RW_INT, 4 );
 }

--- a/src/osgWrappers/serializers/osg/PrimitiveSet.cpp
+++ b/src/osgWrappers/serializers/osg/PrimitiveSet.cpp
@@ -16,9 +16,12 @@ osg::ref_ptr<MySerializer> serializer = new MySerializer( \
 REGISTER_OBJECT_WRAPPER( PrimitiveSet,
                          0,
                          osg::PrimitiveSet,
-                         "osg::Object osg::PrimitiveSet" )
+                         "osg::Object osg::BufferData osg::PrimitiveSet" )
 {
-
+    {
+        UPDATE_TO_VERSION_SCOPED( 147 )
+        ADDED_ASSOCIATE("osg::BufferData")
+    }
     ADD_INT_SERIALIZER( NumInstances, 0);
 
 #if 1
@@ -80,7 +83,7 @@ namespace DrawArraysWrapper {
 REGISTER_OBJECT_WRAPPER( DrawArrays,
                          new osg::DrawArrays,
                          osg::DrawArrays,
-                         "osg::Object osg::PrimitiveSet osg::DrawArrays" )
+                         "osg::Object osg::BufferData osg::PrimitiveSet osg::DrawArrays" )
 {
     ADD_GLINT_SERIALIZER( First, 0);
     ADD_GLINT_SERIALIZER( Count, 0);
@@ -93,7 +96,7 @@ namespace DrawArrayLengthsWrapper {
 REGISTER_OBJECT_WRAPPER( DrawArrayLengths,
                          new osg::DrawArrayLengths,
                          osg::DrawArrayLengths,
-                         "osg::Object osg::PrimitiveSet osg::DrawArrayLengths" )
+                         "osg::Object osg::BufferData osg::PrimitiveSet osg::DrawArrayLengths" )
 {
     ADD_GLINT_SERIALIZER( First, 0);
     ADD_ISAVECTOR_SERIALIZER( vector, osgDB::BaseSerializer::RW_INT, 4 );
@@ -130,7 +133,7 @@ struct ResizeDrawElements : public osgDB::MethodObject
 REGISTER_OBJECT_WRAPPER( DrawElements,
                          0,
                          osg::DrawElements,
-                         "osg::Object osg::PrimitiveSet osg::DrawElements" )
+                         "osg::Object osg::BufferData osg::PrimitiveSet osg::DrawElements" )
 {
     ADD_METHOD_OBJECT( "resizeElements", ResizeDrawElements );
 }
@@ -140,7 +143,7 @@ REGISTER_OBJECT_WRAPPER( DrawElements,
 
 #define DRAW_ELEMENTS_WRAPPER( DRAWELEMENTS, ELEMENTTYPE ) \
     namespace Wrapper##DRAWELEMENTS { \
-        REGISTER_OBJECT_WRAPPER( DRAWELEMENTS, new osg::DRAWELEMENTS, osg::DRAWELEMENTS, "osg::Object osg::PrimitiveSet osg::"#DRAWELEMENTS) \
+        REGISTER_OBJECT_WRAPPER( DRAWELEMENTS, new osg::DRAWELEMENTS, osg::DRAWELEMENTS, "osg::Object osg::BufferData osg::PrimitiveSet osg::"#DRAWELEMENTS) \
         { \
                 ADD_ISAVECTOR_SERIALIZER( vector, osgDB::BaseSerializer::ELEMENTTYPE, 4 ); \
         } \
@@ -156,7 +159,7 @@ namespace MultiDrawArrayWrapper {
 REGISTER_OBJECT_WRAPPER( MultiDrawArrays,
                          new osg::MultiDrawArrays,
                          osg::MultiDrawArrays,
-                         "osg::Object osg::PrimitiveSet osg::MultiDrawArrays" )
+                         "osg::Object osg::BufferData osg::PrimitiveSet osg::MultiDrawArrays" )
 {
     ADD_VECTOR_SERIALIZER( Firsts, osg::MultiDrawArrays::Firsts, osgDB::BaseSerializer::RW_INT, 8 );
     ADD_VECTOR_SERIALIZER( Counts, osg::MultiDrawArrays::Counts, osgDB::BaseSerializer::RW_INT, 8 );


### PR DESCRIPTION
-add a flag in Outpustream in order to know whether or not BufferObject associated with BufferData should be serialized 
It can be usefull in order to save custom BufferObject configuration.
-Changes involved in BufferData serializers

Details 
in bd serilializer (use a trick not to add BufferData to BufferObject
///don't add BufferData to BufferObject (let BufferObject Serializer::readBufferData do it)
static bool readBufferObject( osgDB::InputStream& is, osg::BufferData& bd );

in bo serializer (do the job of adding BufferData to BufferObject)
/// add BufferData to BufferObject (finish job began in BufferData serilizer::readBufferObject)
static bool readBufferData( osgDB::InputStream& is, osg::BufferObject& node )

I doubt adding a bool flag in Outpustream dedicated to BufferObject serializer is the cleaner way to control bo serilization but you surely the my point. 

With It I'm able to serialize complex patterns such as transformfeedback or indirectdraw so i though it was cool enough to raise your interest for this feature



