### PR TITLE
fix a crash when reading an osgt file with multiple references to a missing texture.

### DIFF
--- a/src/osgDB/InputStream.cpp
+++ b/src/osgDB/InputStream.cpp
@@ -858,12 +858,13 @@ osg::ref_ptr<osg::Image> InputStream::readImage(bool readFromExternal)
     }
     else
     {
-        image = readObjectFieldsOfType<osg::Image>("osg::Object", id, image.get());
+        image = readObjectFieldsOfType<osg::Image>("osg::Object", id, image.get());// leaves _identifierMap[id] pointing at DummyObject if image invalid
         if ( image.valid() )
         {
             image->setFileName( name );
             image->setWriteHint( (osg::Image::WriteHint)writeHint );
         }
+        _identifierMap[id] = image;//valid or invalid, don't leave this pointing at an osg::Dummyobject as it's used with a static_cast when recycled
     }
     return image;
 }


### PR DESCRIPTION
Hi Robert,
I found a bug crashing the osg when reading an osgt file with a missing texture being reference a secont time by UniqueID. A minimal example of an osgt file is attached (as .zip).
Regards, Laurens.

[MISSING_TEXTURE.zip](https://github.com/openscenegraph/OpenSceneGraph/files/905693/MISSING_TEXTURE.zip)

