### PR TITLE
judge the ''GLBufferObject' if really is a VBO'

### DIFF
--- a/src/osg/VertexArrayState.cpp
+++ b/src/osg/VertexArrayState.cpp
@@ -663,8 +663,18 @@ void VertexArrayState::setArray(ArrayDispatch* vad, osg::State& state, const osg
             GLBufferObject* vbo = isVertexBufferObjectSupported() ? new_array->getOrCreateGLBufferObject(state.getContextID()) : 0;
             if (vbo)
             {
-                bindVertexBufferObject(vbo);
-                vad->enable_and_dispatch(state, new_array, vbo);
+				//add by myself to judge if this buffer object is really a VBO 2017 04 22
+				VertexBufferObject* prototype_vbo = dynamic_cast<VertexBufferObject*>(vbo->getBufferObject());
+				if (prototype_vbo)
+				{
+					bindVertexBufferObject(vbo);
+					vad->enable_and_dispatch(state, new_array, vbo);
+				}
+				else
+				{
+					unbindVertexBufferObject();
+					vad->enable_and_dispatch(state, new_array);
+				}
             }
             else
             {
@@ -677,8 +687,18 @@ void VertexArrayState::setArray(ArrayDispatch* vad, osg::State& state, const osg
             GLBufferObject* vbo = isVertexBufferObjectSupported() ? new_array->getOrCreateGLBufferObject(state.getContextID()) : 0;
             if (vbo)
             {
-                bindVertexBufferObject(vbo);
-                vad->dispatch(state, new_array, vbo);
+				//add by myself to judge if this buffer object is really a VBO 2017 04 22
+				VertexBufferObject* prototype_vbo = dynamic_cast<VertexBufferObject*>(vbo->getBufferObject());
+				if (prototype_vbo)
+				{
+					bindVertexBufferObject(vbo);
+					vad->dispatch(state, new_array, vbo);
+				}
+				else
+				{
+					unbindVertexBufferObject();
+					vad->dispatch(state, new_array);
+				}
             }
             else
             {
@@ -744,4 +764,6 @@ void VertexArrayState::dirty()
 {
     setRequiresSetArrays(true);
 }
+
+
 


### PR DESCRIPTION
when we attach an other type GLbufferobject such as SSAO UBO etc to an array of a geometry, the orginal src of "setArray" will bind this non-vbo glbufferobject as vbo,then APP crashing occurs no matter  whether the geometry open the _useVertexBufferObjects flag.So I fixed this bug to manage it ignoring if the _useVertexBufferObjects flag is true or false.