### PR TITLE
Avoid call of SetupThreads in DatabasePager Constructor 

### DIFF
--- a/src/osgDB/DatabasePager.cpp
+++ b/src/osgDB/DatabasePager.cpp
@@ -1110,10 +1110,6 @@ DatabasePager::DatabasePager()
     // test of setting the database threads affinity.
     // _affinity = OpenThreads::Affinity(4,4);
 
-    setUpThreads(
-        osg::DisplaySettings::instance()->getNumOfDatabaseThreadsHint(),
-        osg::DisplaySettings::instance()->getNumOfHttpDatabaseThreadsHint());
-
     str = getenv("OSG_DATABASE_PAGER_PRIORITY");
     if (str)
     {


### PR DESCRIPTION
This solves a bug with some shared library configurations. Sometimes the DatabasePager Singleton is initialised before one can call other configuration options like "setNumOfDatabaseThreadsHint". But OSG initialise it here:

https://github.com/openscenegraph/OpenSceneGraph/blob/master/src/osgDB/DatabasePager.cpp#L1555 

So this call in the constructor is not needed.