### PR TITLE
Added osgUI to Doxygen-generated documentation

### DIFF
--- a/doc/Doxyfiles/doxyfile.cmake
+++ b/doc/Doxyfiles/doxyfile.cmake
@@ -84,21 +84,22 @@ WARN_LOGFILE           =
 # configuration options related to the input files
 #---------------------------------------------------------------------------
 INPUT                  = "${OpenSceneGraph_SOURCE_DIR}/include/osg" \
+                         "${OpenSceneGraph_SOURCE_DIR}/include/osgAnimation" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgDB" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgFX" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgGA" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgManipulator" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgParticle" \
+                         "${OpenSceneGraph_SOURCE_DIR}/include/osgQt" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgShadow" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgSim" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgTerrain" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgText" \
+                         "${OpenSceneGraph_SOURCE_DIR}/include/osgUI" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgUtil" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgViewer" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgVolume" \
-                         "${OpenSceneGraph_SOURCE_DIR}/include/osgWidget" \
-                         "${OpenSceneGraph_SOURCE_DIR}/include/osgQt" \
-                         "${OpenSceneGraph_SOURCE_DIR}/include/osgAnimation"
+                         "${OpenSceneGraph_SOURCE_DIR}/include/osgWidget"
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *include* \
                          *.cpp


### PR DESCRIPTION
I saw from the forum ([example](http://forum.openscenegraph.org/viewtopic.php?t=15435)) that osgUI has some advantages over osgWidget.  However, when I went looking in the Doxygen output, I didn't see osgUI.  This PR just causes Doxygen to make osgUI docs :) .  I also put the doxyfile input directories in alphabetical order so I could more easily make sure I had them all.

I see there are already some doc comments in osgUI, so I think this is in keeping with your intention.  I checked the issues and pull requests (open and closed), Google search results, and the list of branches, and I don't see anything suggesting osgUI is being left out on purpose.  If it is, my apologies for missing that fact!