### PR TITLE
Still build even if CPACK_GENERATOR is undefined

### DIFF
--- a/CMakeModules/OsgMacroUtils.cmake
+++ b/CMakeModules/OsgMacroUtils.cmake
@@ -122,9 +122,9 @@ MACRO(SETUP_LINK_LIBRARIES)
     FOREACH(LINKLIB ${TARGET_ADDED_LIBRARIES})
       SET(TO_INSERT TRUE)
       FOREACH (value ${TARGET_COMMON_LIBRARIES})
-            IF (${value} STREQUAL ${LINKLIB})
+            IF ("${value}" STREQUAL "${LINKLIB}")
                   SET(TO_INSERT FALSE)
-            ENDIF (${value} STREQUAL ${LINKLIB})
+            ENDIF ("${value}" STREQUAL "${LINKLIB}")
         ENDFOREACH (value ${TARGET_COMMON_LIBRARIES})
       IF(TO_INSERT)
           LIST(APPEND TARGET_LIBRARIES ${LINKLIB})
@@ -269,7 +269,7 @@ MACRO(SETUP_PLUGIN PLUGIN_NAME)
 
       # add cpack config variables for plugin with own package
       IF(BUILD_OSG_PACKAGES)
-        IF(${CPACK_GENERATOR} STREQUAL "DEB")
+        IF("${CPACK_GENERATOR}" STREQUAL "DEB")
             STRING(TOUPPER ${PACKAGE_COMPONENT} UPPER_PACKAGE_COMPONENT)
             SET(CPACK_${UPPER_PACKAGE_COMPONENT}_DEPENDENCIES
                 "libopenscenegraph"


### PR DESCRIPTION
A small fix, but one that was blocking for my particular Win7 x64 VS2013 build.  CMake failed with an error on the `STREQUAL` comparison in line 272.  It was because `CPACK_GENERATOR` was undefined, so `STREQUAL` was only getting one argument.  I added quotes around `${CPACK_GENERATOR}` and now it runs fine.

I am definitely not a CMake expert, and am not claiming to be!  I only looked at `STREQUAL` tests, since that was the specific problem.  Lines 125 and 127 also had those tests.  I added quotes there on the theory that might prevent the same problem from popping up on those lines in the future.