### PR TITLE
Corrected Image::getColor method when using texture coordinates

### DIFF
--- a/src/osg/Image.cpp
+++ b/src/osg/Image.cpp
@@ -1937,9 +1937,9 @@ Vec4 Image::getColor(unsigned int s,unsigned t,unsigned r) const
 
 Vec4 Image::getColor(const Vec3& texcoord) const
 {
-    unsigned int s = osg::clampTo(int(texcoord.x()*float(_s-1)), 0, _s-1);
-    unsigned int t = osg::clampTo(int(texcoord.y()*float(_t-1)), 0, _t-1);
-    unsigned int r = osg::clampTo(int(texcoord.z()*float(_r-1)), 0, _r-1);
+    unsigned int s = osg::clampTo(int(texcoord.x()*float(_s)), 0, _s-1);
+    unsigned int t = osg::clampTo(int(texcoord.y()*float(_t)), 0, _t-1);
+    unsigned int r = osg::clampTo(int(texcoord.z()*float(_r)), 0, _r-1);
     //OSG_NOTICE<<"getColor("<<texcoord<<")="<<getColor(s,t,r)<<std::endl;
     return getColor(s,t,r);
 }


### PR DESCRIPTION
Please correct me if I'm wrong, but I think there is a tiny error in the Image::getColor method when using texture coordinates for reading pixel values.

Let’s assume we would only have 2x2 pixel sized image, we get the following structure if the lower left corner is the origin:

p2 p3
p0 p1

According to the current implementation the computed pixel coordinate is always 0 for any texture coordinate in the range 0.0 to < 1.0.
`unsigned int s = osg::clampTo(int(texcoord.x()*float(_s-1)), 0, _s-1);`
For example: s = 0.9  * (2 -1=1) = 0.9 -->0 after float to int conversion. 
This means Image::getColor() will always return p0 in this case, however, I would expect to obtain pixel p3 when choosing a texture coordinate with U and V < 0.5.

If do the same with a 3x3 image...

p6 p7 p8
p3 p4 p5
p0 p1 p2

my assumption would be again, choosing a texture coordinate UV(> 0.66, >0.66) should return p8
s = 0.7 (3-1=2) = 1.4 --> 1 after float to int conversion, so we would get p4 instead.