### PR TITLE
fix StatsHandler crush on windows

### DIFF
--- a/src/osgViewer/StatsHandler.cpp
+++ b/src/osgViewer/StatsHandler.cpp
@@ -767,8 +767,11 @@ struct BlockDrawCallback : public virtual osg::Drawable::DrawCallback
 
         vertices->dirty();
 
-        osg::DrawArrays* drawArrays = static_cast<osg::DrawArrays*>(geom->getPrimitiveSet(0));
-        drawArrays->setCount(vi);
+        osg::DrawArrays* drawArrays = dynamic_cast<osg::DrawArrays*>(geom->getPrimitiveSet(0));
+        if(drawArrays)
+        {
+            drawArrays->setCount(vi);
+        }
 
         drawable->drawImplementation(renderInfo);
     }


### PR DESCRIPTION
change static_cast to dynamic_cast to avoid type cast error