### PR TITLE
add IndirectDraw feature and MultiDrawIndirect PrimitiveSets

### DIFF
--- a/include/osg/BufferObject
+++ b/include/osg/BufferObject
@@ -635,6 +635,28 @@ class OSG_EXPORT ElementBufferObject : public BufferObject
         virtual ~ElementBufferObject();
 };
 
+class OSG_EXPORT DrawIndirectBufferObject : public BufferObject
+{
+    public:
+
+        DrawIndirectBufferObject();
+
+        /** Copy constructor using CopyOp to manage deep vs shallow copy.*/
+        DrawIndirectBufferObject(const DrawIndirectBufferObject& vbo,const CopyOp& copyop=CopyOp::SHALLOW_COPY);
+
+        META_Object(osg,DrawIndirectBufferObject);
+
+        unsigned int addArray(osg::Array* array);
+        void removeArray(osg::Array* array);
+
+        void setArray(unsigned int i, Array* array);
+        Array* getArray(unsigned int i);
+        const Array* getArray(unsigned int i) const;
+
+    protected:
+        virtual ~DrawIndirectBufferObject();
+};
+
 class Image;
 class OSG_EXPORT PixelBufferObject : public BufferObject
 {

--- a/include/osg/GLDefines
+++ b/include/osg/GLDefines
@@ -435,6 +435,8 @@ typedef char GLchar;
 #define GL_SAMPLER_CUBE_MAP_ARRAY_SHADOW  0x900D
 #define GL_INT_SAMPLER_CUBE_MAP_ARRAY     0x900E
 #define GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY 0x900F
+#define GL_DRAW_INDIRECT_BUFFER           0x8F3F
+#define GL_DRAW_INDIRECT_BUFFER_BINDING   0x8F43
 #endif
 
 // ARB_shader_atomic_counters
@@ -556,14 +558,14 @@ typedef char GLchar;
 #define GL_MAP_UNSYNCHRONIZED_BIT 0x0020
 #endif
 
-#define GL_INT64_ARB               0x140E 
-#define GL_UNSIGNED_INT64_ARB      0x140F 
-#define GL_INT64_VEC2_ARB          0x8FE9 
-#define GL_INT64_VEC3_ARB          0x8FEA 
-#define GL_INT64_VEC4_ARB          0x8FEB 
-#define GL_UNSIGNED_INT64_VEC2_ARB 0x8FF5 
-#define GL_UNSIGNED_INT64_VEC3_ARB 0x8FF6 
-#define GL_UNSIGNED_INT64_VEC4_ARB 0x8FF7 
+#define GL_INT64_ARB               0x140E
+#define GL_UNSIGNED_INT64_ARB      0x140F
+#define GL_INT64_VEC2_ARB          0x8FE9
+#define GL_INT64_VEC3_ARB          0x8FEA
+#define GL_INT64_VEC4_ARB          0x8FEB
+#define GL_UNSIGNED_INT64_VEC2_ARB 0x8FF5
+#define GL_UNSIGNED_INT64_VEC3_ARB 0x8FF6
+#define GL_UNSIGNED_INT64_VEC4_ARB 0x8FF7
 /* ------------------------------ GL_KHR_debug ----------------------------- */
 #ifndef GL_KHR_debug
 #define GL_KHR_debug 1

--- a/include/osg/PrimitiveSet
+++ b/include/osg/PrimitiveSet
@@ -133,7 +133,11 @@ class OSG_EXPORT PrimitiveSet : public BufferData
             DrawElementsUBytePrimitiveType,
             DrawElementsUShortPrimitiveType,
             DrawElementsUIntPrimitiveType,
-            MultiDrawArraysPrimitiveType
+            MultiDrawArraysPrimitiveType,
+            MultiDrawArraysIndirectPrimitiveType,
+            MultiDrawElementsUByteIndirectPrimitiveType,
+            MultiDrawElementsUShortIndirectPrimitiveType,
+            MultiDrawElementsUIntIndirectPrimitiveType
         };
 
         enum Mode

--- a/include/osg/PrimitiveSetIndirect
+++ b/include/osg/PrimitiveSetIndirect
@@ -1,0 +1,480 @@
+/* -*-c++-*- OpenSceneGraph - Copyright (C) 1998-2006 Robert Osfield
+ *
+ * This library is open source and may be redistributed and/or modified under
+ * the terms of the OpenSceneGraph Public License (OSGPL) version 0.0 or
+ * (at your option) any later version.  The full license is in LICENSE file
+ * included with this distribution, and on the openscenegraph.org website.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * OpenSceneGraph Public License for more details.
+ *
+ * osg/PrimitiveSetIndirect
+ * Author: Julien Valentin 2016-2017
+*/
+
+#ifndef OSG_INDIRECTPRIMITIVESET
+#define OSG_INDIRECTPRIMITIVESET 1
+
+#include <osg/PrimitiveSet>
+
+
+namespace osg {
+/// GL DrawArraysCommand
+typedef  struct GLDrawArraysIndirectCmd {
+    GLDrawArraysIndirectCmd(uint pcount = 0, uint pinstanceCount = 0, uint pfirst = 0, uint pbaseInstance = 0)
+        :count(pcount), instanceCount(pinstanceCount), first(pfirst), baseInstance(pbaseInstance){};
+    uint  count;
+    uint  instanceCount;
+    uint  first;
+    uint  baseInstance;
+} DrawArraysIndirectCmd;
+
+/// vector of DrawArraysCommand to be hosted on GPU
+class DrawArraysIndirectCommand: public BufferData, public  MixinVector<DrawArraysIndirectCmd>
+{
+public:
+    META_Object(osg,DrawArraysIndirectCommand)
+    DrawArraysIndirectCommand();
+    DrawArraysIndirectCommand(const DrawArraysIndirectCommand& copy,const CopyOp& copyop=CopyOp::SHALLOW_COPY);
+    virtual const GLvoid*   getDataPointer() const {
+        return empty()?0:&front();
+    }
+    virtual unsigned int    getTotalDataSize() const {
+        return 16u*static_cast<unsigned int>(size());
+    }
+};
+
+
+/// GL DrawElementsCommand
+typedef  struct GLDrawElementsIndirectCmd {
+    GLDrawElementsIndirectCmd(uint pcount = 0, uint pinstanceCount = 0, uint pfirstIndex = 0, uint pbaseVertex = 0, uint pbaseInstance = 0)
+        :count(pcount), instanceCount(pinstanceCount), firstIndex(pfirstIndex), baseVertex(pbaseVertex), baseInstance(pbaseInstance){};
+    unsigned int  count;
+    unsigned int  instanceCount;
+    unsigned int  firstIndex;
+    unsigned int  baseVertex;
+    unsigned int  baseInstance;
+} DrawElementsIndirectCmd;
+
+/// vector of DrawElementsCommand to be hosted on GPU
+class DrawElementsIndirectCommand: public BufferData, public MixinVector<DrawElementsIndirectCmd>
+{
+public:
+    META_Object(osg,DrawElementsIndirectCommand)
+    DrawElementsIndirectCommand();
+    DrawElementsIndirectCommand(const DrawElementsIndirectCommand& copy,const CopyOp& copyop=CopyOp::SHALLOW_COPY);
+    virtual const GLvoid*   getDataPointer() const {
+        return empty()?0:&front();
+    }
+    virtual unsigned int    getTotalDataSize() const {
+        return 20u*static_cast<unsigned int>(size());
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////
+/// \brief The MultiDrawElementsIndirect base PrimitiveSet
+///
+class MultiDrawElementsIndirect : public DrawElements
+{
+public:
+
+    MultiDrawElementsIndirect(Type primType=PrimitiveType, GLenum mode=0, GLsizei stride=0):
+        DrawElements(primType,mode, 0),_stride(stride) {setIndirectCommand(new DrawElementsIndirectCommand());}
+
+    MultiDrawElementsIndirect(const MultiDrawElementsIndirect& rhs,const CopyOp& copyop=CopyOp::SHALLOW_COPY):
+        DrawElements(rhs,copyop),_stride(rhs._stride) {
+        _indirectCommand=(DrawElementsIndirectCommand*)copyop(rhs._indirectCommand.get());
+    }
+    inline void setStride( GLsizei  i) {
+        _stride=i;
+    }
+    inline GLsizei getStride()const {
+        return _stride;
+    }
+
+    inline void setIndirectCommand(DrawElementsIndirectCommand*idc) {
+        _indirectCommand = idc;
+        if(!_indirectCommand->getBufferObject())
+            _indirectCommand->setBufferObject(new osg::DrawIndirectBufferObject());
+    }
+    inline DrawElementsIndirectCommand* getIndirectCommand()const {
+        return _indirectCommand;
+    }
+protected:
+    virtual ~MultiDrawElementsIndirect() {}
+
+    GLsizei _stride;
+    ref_ptr<DrawElementsIndirectCommand> _indirectCommand;
+
+};
+///////////////////////////////////////////////////////////////////////////////////////
+/// \brief The MultiDrawElementsIndirectUByte PrimitiveSet
+///
+class OSG_EXPORT MultiDrawElementsIndirectUByte : public MultiDrawElementsIndirect, public VectorGLubyte
+{
+public:
+
+    typedef VectorGLubyte vector_type;
+
+    MultiDrawElementsIndirectUByte(GLenum mode=0):
+        MultiDrawElementsIndirect(MultiDrawElementsUByteIndirectPrimitiveType,mode) {}
+
+    MultiDrawElementsIndirectUByte(const MultiDrawElementsIndirectUByte& array, const CopyOp& copyop=CopyOp::SHALLOW_COPY):
+        MultiDrawElementsIndirect(array,copyop),
+        vector_type(array) {}
+
+    /**
+     * \param mode One of osg::PrimitiveSet::Mode. Determines the type of primitives used.
+     * \param no Number of intended elements. This will be the size of the underlying vector.
+     * \param ptr Pointer to a GLubyte to copy index data from.
+     */
+    MultiDrawElementsIndirectUByte(GLenum mode, unsigned int no, const GLubyte* ptr) :
+        MultiDrawElementsIndirect(MultiDrawElementsUByteIndirectPrimitiveType,mode),
+        vector_type(ptr,ptr+no) {}
+
+    /**
+     * \param mode One of osg::PrimitiveSet::Mode. Determines the type of primitives used.
+     * \param no Number of intended elements. This will be the size of the underlying vector.
+     */
+    MultiDrawElementsIndirectUByte(GLenum mode, unsigned int no) :
+        MultiDrawElementsIndirect(MultiDrawElementsUByteIndirectPrimitiveType,mode),
+        vector_type(no) {}
+
+    virtual Object* cloneType() const {
+        return new MultiDrawElementsIndirectUByte();
+    }
+    virtual Object* clone(const CopyOp& copyop) const {
+        return new MultiDrawElementsIndirectUByte(*this,copyop);
+    }
+    virtual bool isSameKindAs(const Object* obj) const {
+        return dynamic_cast<const MultiDrawElementsIndirectUByte*>(obj)!=NULL;
+    }
+    virtual const char* libraryName() const {
+        return "osg";
+    }
+    virtual const char* className() const {
+        return "MultiDrawElementsIndirectUByte";
+    }
+
+    virtual const GLvoid*   getDataPointer() const {
+        return empty()?0:&front();
+    }
+    virtual unsigned int    getTotalDataSize() const {
+        return static_cast<unsigned int>(size());
+    }
+    virtual bool            supportsBufferObject() const {
+        return false;
+    }
+
+    virtual void draw(State& state, bool useVertexBufferObjects) const;
+
+    virtual void accept(PrimitiveFunctor& functor) const;
+    virtual void accept(PrimitiveIndexFunctor& functor) const;
+
+    virtual unsigned int getNumIndices() const {
+        return static_cast<unsigned int>(size());
+    }
+    virtual unsigned int index(unsigned int pos) const {
+        return (*this)[pos];
+    }
+    virtual void offsetIndices(int offset);
+
+    virtual GLenum getDataType() {
+        return GL_UNSIGNED_BYTE;
+    }
+    virtual void resizeElements(unsigned int numIndices) {
+        resize(numIndices);
+    }
+    virtual void reserveElements(unsigned int numIndices) {
+        reserve(numIndices);
+    }
+    virtual void setElement(unsigned int i, unsigned int v)  {
+        (*this)[i] = v;
+    }
+    virtual unsigned int getElement(unsigned int i) {
+        return (*this)[i];
+    }
+    virtual void addElement(unsigned int v) {
+        push_back(GLubyte(v));
+    }
+
+protected:
+
+    virtual ~MultiDrawElementsIndirectUByte();
+};
+
+
+///////////////////////////////////////////////////////////////////////////////////////
+/// \brief The MultiDrawElementsIndirectUShort PrimitiveSet
+///
+class OSG_EXPORT MultiDrawElementsIndirectUShort : public MultiDrawElementsIndirect, public VectorGLushort
+{
+public:
+
+    typedef VectorGLushort vector_type;
+
+    MultiDrawElementsIndirectUShort(GLenum mode=0):
+        MultiDrawElementsIndirect(MultiDrawElementsUShortIndirectPrimitiveType,mode) {}
+
+    MultiDrawElementsIndirectUShort(const MultiDrawElementsIndirectUShort& array,const CopyOp& copyop=CopyOp::SHALLOW_COPY):
+        MultiDrawElementsIndirect(array,copyop),
+        vector_type(array) {}
+
+    /**
+     * \param mode One of osg::PrimitiveSet::Mode. Determines the type of primitives used.
+     * \param no Number of intended elements. This will be the size of the underlying vector.
+     * \param ptr Pointer to a GLushort to copy index data from.
+     */
+    MultiDrawElementsIndirectUShort(GLenum mode, unsigned int no, const GLushort* ptr) :
+        MultiDrawElementsIndirect(MultiDrawElementsUShortIndirectPrimitiveType,mode),
+        vector_type(ptr,ptr+no) {}
+
+    /**
+     * \param mode One of osg::PrimitiveSet::Mode. Determines the type of primitives used.
+     * \param no Number of intended elements. This will be the size of the underlying vector.
+     */
+    MultiDrawElementsIndirectUShort(GLenum mode, unsigned int no) :
+        MultiDrawElementsIndirect(MultiDrawElementsUShortIndirectPrimitiveType,mode),
+        vector_type(no) {}
+
+    template <class InputIterator>
+    MultiDrawElementsIndirectUShort(GLenum mode, InputIterator first,InputIterator last) :
+        MultiDrawElementsIndirect(MultiDrawElementsUShortIndirectPrimitiveType,mode),
+        vector_type(first,last) {}
+
+    virtual Object* cloneType() const {
+        return new MultiDrawElementsIndirectUShort();
+    }
+    virtual Object* clone(const CopyOp& copyop) const {
+        return new MultiDrawElementsIndirectUShort(*this,copyop);
+    }
+    virtual bool isSameKindAs(const Object* obj) const {
+        return dynamic_cast<const MultiDrawElementsIndirectUShort*>(obj)!=NULL;
+    }
+    virtual const char* libraryName() const {
+        return "osg";
+    }
+    virtual const char* className() const {
+        return "MultiDrawElementsIndirectUShort";
+    }
+
+    virtual const GLvoid*   getDataPointer() const {
+        return empty()?0:&front();
+    }
+    virtual unsigned int    getTotalDataSize() const {
+        return 2u*static_cast<unsigned int>(size());
+    }
+    virtual bool            supportsBufferObject() const {
+        return false;
+    }
+
+    virtual void draw(State& state, bool useVertexBufferObjects) const;
+
+    virtual void accept(PrimitiveFunctor& functor) const;
+    virtual void accept(PrimitiveIndexFunctor& functor) const;
+
+    virtual unsigned int getNumIndices() const {
+        return static_cast<unsigned int>(size());
+    }
+    virtual unsigned int index(unsigned int pos) const {
+        return (*this)[pos];
+    }
+    virtual void offsetIndices(int offset);
+
+    virtual GLenum getDataType() {
+        return GL_UNSIGNED_SHORT;
+    }
+    virtual void resizeElements(unsigned int numIndices) {
+        resize(numIndices);
+    }
+    virtual void reserveElements(unsigned int numIndices) {
+        reserve(numIndices);
+    }
+    virtual void setElement(unsigned int i, unsigned int v) {
+        (*this)[i] = v;
+    }
+    virtual unsigned int getElement(unsigned int i) {
+        return (*this)[i];
+    }
+    virtual void addElement(unsigned int v) {
+        push_back(GLushort(v));
+    }
+
+protected:
+
+    virtual ~MultiDrawElementsIndirectUShort();
+};
+
+///////////////////////////////////////////////////////////////////////////////////////
+/// \brief The MultiDrawElementsIndirectUInt PrimitiveSet
+///
+class OSG_EXPORT MultiDrawElementsIndirectUInt : public MultiDrawElementsIndirect, public VectorGLuint
+{
+public:
+
+    typedef VectorGLuint vector_type;
+
+    MultiDrawElementsIndirectUInt(GLenum mode=0):
+        MultiDrawElementsIndirect(MultiDrawElementsUIntIndirectPrimitiveType,mode) {}
+
+    MultiDrawElementsIndirectUInt(const MultiDrawElementsIndirectUInt& array,const CopyOp& copyop=CopyOp::SHALLOW_COPY):
+        MultiDrawElementsIndirect(array,copyop),
+        vector_type(array) {}
+
+    /**
+     * \param mode One of osg::PrimitiveSet::Mode. Determines the type of primitives used.
+     * \param no Number of intended elements. This will be the size of the underlying vector.
+     * \param ptr Pointer to a GLuint to copy index data from.
+     */
+    MultiDrawElementsIndirectUInt(GLenum mode, unsigned int no, const GLuint* ptr) :
+        MultiDrawElementsIndirect(MultiDrawElementsUIntIndirectPrimitiveType,mode),
+        vector_type(ptr,ptr+no) {}
+
+    /**
+     * \param mode One of osg::PrimitiveSet::Mode. Determines the type of primitives used.
+     * \param no Number of intended elements. This will be the size of the underlying vector.
+     */
+    MultiDrawElementsIndirectUInt(GLenum mode, unsigned int no) :
+        MultiDrawElementsIndirect(MultiDrawElementsUIntIndirectPrimitiveType,mode),
+        vector_type(no) {}
+
+    template <class InputIterator>
+    MultiDrawElementsIndirectUInt(GLenum mode, InputIterator first,InputIterator last) :
+        MultiDrawElementsIndirect(MultiDrawElementsUIntIndirectPrimitiveType,mode),
+        vector_type(first,last) {}
+
+    virtual Object* cloneType() const {
+        return new MultiDrawElementsIndirectUInt();
+    }
+    virtual Object* clone(const CopyOp& copyop) const {
+        return new MultiDrawElementsIndirectUInt(*this,copyop);
+    }
+    virtual bool isSameKindAs(const Object* obj) const {
+        return dynamic_cast<const MultiDrawElementsIndirectUInt*>(obj)!=NULL;
+    }
+    virtual const char* libraryName() const {
+        return "osg";
+    }
+    virtual const char* className() const {
+        return "MultiDrawElementsIndirectUInt";
+    }
+
+    virtual const GLvoid*   getDataPointer() const {
+        return empty()?0:&front();
+    }
+    virtual unsigned int    getTotalDataSize() const {
+        return 4u*static_cast<unsigned int>(size());
+    }
+    virtual bool            supportsBufferObject() const {
+        return false;
+    }
+
+    virtual void draw(State& state, bool useVertexBufferObjects) const;
+
+    virtual void accept(PrimitiveFunctor& functor) const;
+    virtual void accept(PrimitiveIndexFunctor& functor) const;
+
+    virtual unsigned int getNumIndices() const {
+        return static_cast<unsigned int>(size());
+    }
+    virtual unsigned int index(unsigned int pos) const {
+        return (*this)[pos];
+    }
+    virtual void offsetIndices(int offset);
+
+    virtual GLenum getDataType() {
+        return GL_UNSIGNED_INT;
+    }
+    virtual void resizeElements(unsigned int numIndices) {
+        resize(numIndices);
+    }
+    virtual void reserveElements(unsigned int numIndices) {
+        reserve(numIndices);
+    }
+    virtual void setElement(unsigned int i, unsigned int v) {
+        (*this)[i] = v;
+    }
+    virtual unsigned int getElement(unsigned int i) {
+        return (*this)[i];
+    }
+    virtual void addElement(unsigned int v) {
+        push_back(GLuint(v));
+    }
+
+protected:
+
+    virtual ~MultiDrawElementsIndirectUInt();
+};
+
+///////////////////////////////////////////////////////////////////////////////////////
+/// \brief The MultiDrawArraysIndirect PrimitiveSet
+///
+class OSG_EXPORT MultiDrawArraysIndirect : public osg::PrimitiveSet
+{
+public:
+
+    MultiDrawArraysIndirect(GLenum mode=0, GLsizei stride=0):
+        osg::PrimitiveSet(Type(MultiDrawArraysIndirectPrimitiveType), mode),
+        _stride(stride) {setIndirectCommand(new DrawArraysIndirectCommand);}
+
+    MultiDrawArraysIndirect(const MultiDrawArraysIndirect& dal,const CopyOp& copyop=CopyOp::SHALLOW_COPY):
+        osg::PrimitiveSet(dal,copyop),
+         _indirectCommand((DrawArraysIndirectCommand*)copyop( dal._indirectCommand.get())),
+        _stride(dal._stride)
+    {}
+
+    virtual osg::Object* cloneType() const {
+        return new MultiDrawArraysIndirect();
+    }
+    virtual osg::Object* clone(const osg::CopyOp& copyop) const {
+        return new MultiDrawArraysIndirect(*this,copyop);
+    }
+    virtual bool isSameKindAs(const osg::Object* obj) const {
+        return dynamic_cast<const MultiDrawArraysIndirect*>(obj)!=NULL;
+    }
+    virtual const char* libraryName() const {
+        return "osg";
+    }
+    virtual const char* className() const {
+        return "MultiDrawArraysIndirect";
+    }
+
+    virtual void draw(State& state, bool useVertexBufferObjects) const;
+
+    virtual void accept(PrimitiveFunctor& functor) const;
+    virtual void accept(PrimitiveIndexFunctor& functor) const;
+
+    virtual unsigned int getNumIndices() const;
+    virtual unsigned int index(unsigned int pos) const;
+    virtual void offsetIndices(int offset);
+
+    virtual unsigned int getNumPrimitives() const;
+
+    void setStride( GLsizei  i) {
+        _stride=i;
+    }
+    GLsizei getStride()const {
+        return _stride;
+    }
+
+    inline void setIndirectCommand(DrawArraysIndirectCommand*idc) {
+        _indirectCommand = idc;
+        if(!_indirectCommand->getBufferObject())
+            _indirectCommand->setBufferObject(new osg::DrawIndirectBufferObject());
+    }
+    inline DrawArraysIndirectCommand* getIndirectCommand()const {
+        return _indirectCommand;
+    }
+
+protected:
+
+    ref_ptr<DrawArraysIndirectCommand> _indirectCommand;
+    GLsizei _stride;
+
+};
+
+}
+
+#endif

--- a/include/osg/PrimitiveSetIndirect
+++ b/include/osg/PrimitiveSetIndirect
@@ -93,7 +93,6 @@ public:
     inline GLsizei getStride()const {
         return _stride;
     }
-
     inline void setIndirectCommand(DrawElementsIndirectCommand*idc) {
         _indirectCommand = idc;
         if(!_indirectCommand->getBufferObject())
@@ -102,6 +101,7 @@ public:
     inline DrawElementsIndirectCommand* getIndirectCommand()const {
         return _indirectCommand;
     }
+    virtual unsigned int getNumPrimitives() const;
 protected:
     virtual ~MultiDrawElementsIndirect() {}
 

--- a/include/osg/State
+++ b/include/osg/State
@@ -591,6 +591,27 @@ class OSG_EXPORT State : public Referenced
         }
 
 
+        inline void bindDrawIndirectBufferObject(osg::GLBufferObject* ibo)
+        {
+            if (ibo->isDirty())
+            {
+                ibo->compileBuffer();
+                _currentDIBO = ibo;
+            }
+            else if (ibo != _currentDIBO)
+            {
+                ibo->bindBuffer();
+                _currentDIBO = ibo;
+            }
+        }
+
+        inline void unbindDrawIndirectBufferObject()
+        {
+            if (!_currentDIBO) return;
+            _glBindBuffer(GL_DRAW_INDIRECT_BUFFER,0);
+            _currentDIBO = 0;
+        }
+
         void setCurrentVertexArrayObject(GLuint vao) { _currentVAO = vao; }
         GLuint getCurrentVertexArrayObject() const { return _currentVAO; }
 
@@ -1259,6 +1280,7 @@ class OSG_EXPORT State : public Referenced
         unsigned int                    _currentActiveTextureUnit;
         unsigned int                    _currentClientActiveTextureUnit;
         GLBufferObject*                 _currentPBO;
+        GLBufferObject*                 _currentDIBO;
         GLuint                          _currentVAO;
 
 

--- a/src/osg/BufferObject.cpp
+++ b/src/osg/BufferObject.cpp
@@ -1358,6 +1358,50 @@ const DrawElements* ElementBufferObject::getDrawElements(unsigned int i) const
     return dynamic_cast<const DrawElements*>(getBufferData(i));
 }
 
+//////////////////////////////////////////////////////////////////////////////////
+//
+//  DrawIndirectBufferObject
+//
+DrawIndirectBufferObject::DrawIndirectBufferObject()
+{
+    setTarget(GL_DRAW_INDIRECT_BUFFER);
+    setUsage(GL_STATIC_DRAW_ARB);
+//    setUsage(GL_STREAM_DRAW_ARB);
+}
+
+DrawIndirectBufferObject::DrawIndirectBufferObject(const DrawIndirectBufferObject& vbo,const CopyOp& copyop):
+    BufferObject(vbo,copyop)
+{
+}
+
+DrawIndirectBufferObject::~DrawIndirectBufferObject()
+{
+}
+
+unsigned int DrawIndirectBufferObject::addArray(osg::Array* array)
+{
+    return addBufferData(array);
+}
+
+void DrawIndirectBufferObject::removeArray(osg::Array* array)
+{
+    removeBufferData(array);
+}
+
+void DrawIndirectBufferObject::setArray(unsigned int i, Array* array)
+{
+    setBufferData(i,array);
+}
+
+Array* DrawIndirectBufferObject::getArray(unsigned int i)
+{
+    return dynamic_cast<osg::Array*>(getBufferData(i));
+}
+
+const Array* DrawIndirectBufferObject::getArray(unsigned int i) const
+{
+    return dynamic_cast<const osg::Array*>(getBufferData(i));
+}
 
 //////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/osg/CMakeLists.txt
+++ b/src/osg/CMakeLists.txt
@@ -136,6 +136,7 @@ SET(TARGET_H
     ${HEADER_PATH}/Polytope
     ${HEADER_PATH}/PositionAttitudeTransform
     ${HEADER_PATH}/PrimitiveSet
+    ${HEADER_PATH}/PrimitiveSetIndirect
     ${HEADER_PATH}/PrimitiveRestartIndex
     ${HEADER_PATH}/Program
     ${HEADER_PATH}/Projection
@@ -342,6 +343,7 @@ SET(TARGET_SRC
     Polytope.cpp
     PositionAttitudeTransform.cpp
     PrimitiveSet.cpp
+    PrimitiveSetIndirect.cpp
     PrimitiveRestartIndex.cpp
     Program.cpp
     Projection.cpp

--- a/src/osg/PrimitiveSetIndirect.cpp
+++ b/src/osg/PrimitiveSetIndirect.cpp
@@ -26,7 +26,7 @@ using namespace osg;
 // DrawArrayIndirectCommand
 //
 
-DrawArraysIndirectCommand::DrawArraysIndirectCommand():BufferData(),MixinVector<DrawArraysIndirectCmd>() {}
+DrawArraysIndirectCommand::DrawArraysIndirectCommand():BufferData(), MixinVector<DrawArraysIndirectCmd>() {}
 DrawArraysIndirectCommand::DrawArraysIndirectCommand(const DrawArraysIndirectCommand& copy,const CopyOp& copyop/*=CopyOp::SHALLOW_COPY*/)
     :BufferData(copy, copyop),MixinVector<DrawArraysIndirectCmd>() {
 }
@@ -34,7 +34,7 @@ DrawArraysIndirectCommand::DrawArraysIndirectCommand(const DrawArraysIndirectCom
 //
 // DrawElementIndirectCommand
 //
-DrawElementsIndirectCommand::DrawElementsIndirectCommand():BufferData(),MixinVector<DrawElementsIndirectCmd>() {}
+DrawElementsIndirectCommand::DrawElementsIndirectCommand():BufferData(), MixinVector<DrawElementsIndirectCmd>() {}
 DrawElementsIndirectCommand::DrawElementsIndirectCommand(const DrawElementsIndirectCommand& copy,const CopyOp& copyop/*=CopyOp::SHALLOW_COPY*/)
     :BufferData(copy, copyop), MixinVector<DrawElementsIndirectCmd>(){
 }
@@ -42,47 +42,7 @@ MultiDrawElementsIndirectUByte::~MultiDrawElementsIndirectUByte()
 {
     releaseGLObjects();
 }
-/*
-void DrawArraysIndirect::draw(State& state, bool) const
-{
-    GLBufferObject* dibo=_indirectCommand->getBufferObject()->getOrCreateGLBufferObject(state.getContextID());
-    state.bindDrawIndirectBufferObject(dibo);
 
-#if defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE)
-    GLenum mode = _mode;
-    if (_mode==GL_QUADS)
-    {
-        state.drawQuads(_first, _count, _numInstances);
-        return;
-    }
-    else if (mode==GL_POLYGON)
-    {
-        mode = GL_TRIANGLE_FAN;
-    }
-    else if (mode==GL_QUAD_STRIP)
-    {
-        mode = GL_TRIANGLE_STRIP;
-    }
-
-    if (_numInstances>=1) state.glDrawArraysInstanced(mode,_first,_count, _numInstances);
-    else glDrawArrays(mode,_first,_count);
-#else
-    // if (_numInstances>=1) state.glDrawArraysItInstanced(_mode,_first,_count, _numInstances);
-    //else
-    state.get<GLExtensions>()->glDrawArraysIndirect(_mode,_indirect);
-#endif
-}
-
-void DrawArraysIndirect::accept(PrimitiveFunctor& functor) const
-{
-    //cant mimic GPU stored drawcall functor.drawArrays(_mode,_first,_count);
-}
-
-void DrawArraysIndirect::accept(PrimitiveIndexFunctor& functor) const
-{
-    //cant mimic GPU stored drawcall functor.drawArrays(_mode,_first,_count);
-}
-*/
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // MultiDrawElementsIndirectUByte
@@ -90,8 +50,8 @@ void DrawArraysIndirect::accept(PrimitiveIndexFunctor& functor) const
 
 void MultiDrawElementsIndirectUByte::draw(State& state, bool useVertexBufferObjects) const
 {
-    GLBufferObject* dibo=_indirectCommand->getBufferObject()->getOrCreateGLBufferObject(state.getContextID());
-    state.bindDrawIndirectBufferObject(dibo);
+    GLBufferObject* dibo = _indirectCommand->getBufferObject()->getOrCreateGLBufferObject( state.getContextID() );
+    state.bindDrawIndirectBufferObject( dibo );
     GLenum mode = _mode;
 #if defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE)
     if (mode==GL_POLYGON) mode = GL_TRIANGLE_FAN;
@@ -144,8 +104,8 @@ MultiDrawElementsIndirectUShort::~MultiDrawElementsIndirectUShort()
 }
 
 void MultiDrawElementsIndirectUShort::draw(State& state, bool useVertexBufferObjects) const
-{   GLBufferObject* dibo=_indirectCommand->getBufferObject()->getOrCreateGLBufferObject(state.getContextID());
-    state.bindDrawIndirectBufferObject(dibo);
+{   GLBufferObject* dibo = _indirectCommand->getBufferObject()->getOrCreateGLBufferObject( state.getContextID() );
+    state.bindDrawIndirectBufferObject( dibo );
 
     GLenum mode = _mode;
 #if defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE)
@@ -198,8 +158,8 @@ MultiDrawElementsIndirectUInt::~MultiDrawElementsIndirectUInt()
 
 void MultiDrawElementsIndirectUInt::draw(State& state, bool useVertexBufferObjects) const
 {
-    GLBufferObject* dibo=_indirectCommand->getBufferObject()->getOrCreateGLBufferObject(state.getContextID());
-    state.bindDrawIndirectBufferObject(dibo);
+    GLBufferObject* dibo = _indirectCommand->getBufferObject()->getOrCreateGLBufferObject( state.getContextID() );
+    state.bindDrawIndirectBufferObject( dibo );
     GLenum mode = _mode;
 #if defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE)
     if (mode==GL_POLYGON) mode = GL_TRIANGLE_FAN;
@@ -213,7 +173,7 @@ void MultiDrawElementsIndirectUInt::draw(State& state, bool useVertexBufferObjec
 
     state.bindElementBufferObject(ebo);
 
-    state.get<GLExtensions>()-> glMultiDrawElementsIndirect(mode, GL_UNSIGNED_INT, (const GLvoid *)(dibo->getOffset(_indirectCommand->getBufferIndex())),_indirectCommand->size(),_stride);
+    state.get<GLExtensions>()-> glMultiDrawElementsIndirect(mode, GL_UNSIGNED_INT, (const GLvoid *)(dibo->getOffset(_indirectCommand->getBufferIndex())),_indirectCommand->size(), _stride);
 
 }
 
@@ -249,12 +209,12 @@ void MultiDrawElementsIndirectUInt::offsetIndices(int offset)
 //
 void MultiDrawArraysIndirect::draw(osg::State& state, bool) const
 {
-    GLBufferObject* dibo=_indirectCommand->getBufferObject()->getOrCreateGLBufferObject(state.getContextID());
-    state.bindDrawIndirectBufferObject(dibo);
+    GLBufferObject* dibo = _indirectCommand->getBufferObject()->getOrCreateGLBufferObject( state.getContextID() );
+    state.bindDrawIndirectBufferObject( dibo );
 
     GLExtensions* ext = state.get<GLExtensions>();
 
-    ext->glMultiDrawArraysIndirect(_mode,  (const GLvoid *)(dibo->getOffset(_indirectCommand->getBufferIndex())),_indirectCommand->size(),_stride);
+    ext->glMultiDrawArraysIndirect(_mode,  (const GLvoid *)(dibo->getOffset(_indirectCommand->getBufferIndex())),_indirectCommand->size(), _stride);
 
 }
 
@@ -298,7 +258,6 @@ unsigned int MultiDrawArraysIndirect::index(unsigned int pos) const
 
 void MultiDrawArraysIndirect::offsetIndices(int offset)
 {
-
     for(DrawArraysIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
         itcmd->first += offset;
 }

--- a/src/osg/PrimitiveSetIndirect.cpp
+++ b/src/osg/PrimitiveSetIndirect.cpp
@@ -42,7 +42,41 @@ MultiDrawElementsIndirectUByte::~MultiDrawElementsIndirectUByte()
 {
     releaseGLObjects();
 }
-
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// MultiDrawElementsIndirect
+//
+unsigned int MultiDrawElementsIndirect::getNumPrimitives() const
+{
+    unsigned int total=0;
+    switch(_mode)
+    {
+    case(POINTS):
+         for(DrawElementsIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+            total+=itcmd->count;
+    case(LINES):
+        for(DrawElementsIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+           total+=itcmd->count/2;
+    case(TRIANGLES):
+        for(DrawElementsIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+           total+=itcmd->count/3;
+    case(QUADS):
+        for(DrawElementsIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+           total+=itcmd->count/4;
+    case(LINE_STRIP):
+    case(LINE_LOOP):
+    case(TRIANGLE_STRIP):
+    case(TRIANGLE_FAN):
+    case(QUAD_STRIP):
+    case(PATCHES):
+    case(POLYGON):
+    {
+        unsigned int primcount = _indirectCommand->size();
+        return primcount;
+    }
+    }
+    return total;
+}
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // MultiDrawElementsIndirectUByte

--- a/src/osg/PrimitiveSetIndirect.cpp
+++ b/src/osg/PrimitiveSetIndirect.cpp
@@ -1,0 +1,336 @@
+/* -*-c++-*- OpenSceneGraph - Copyright (C) 1998-2006 Robert Osfield
+ *
+ * This library is open source and may be redistributed and/or modified under
+ * the terms of the OpenSceneGraph Public License (OSGPL) version 0.0 or
+ * (at your option) any later version.  The full license is in LICENSE file
+ * included with this distribution, and on the openscenegraph.org website.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * OpenSceneGraph Public License for more details.
+ *
+ * osg/PrimitiveSetIndirect.cpp
+ * Author: Julien Valentin 2016-2017
+*/
+
+#include <osg/PrimitiveSetIndirect>
+#include <osg/BufferObject>
+#include <osg/State>
+#include <osg/Notify>
+#include <assert.h>
+
+using namespace osg;
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// DrawArrayIndirectCommand
+//
+
+DrawArraysIndirectCommand::DrawArraysIndirectCommand():BufferData(),MixinVector<DrawArraysIndirectCmd>() {}
+DrawArraysIndirectCommand::DrawArraysIndirectCommand(const DrawArraysIndirectCommand& copy,const CopyOp& copyop/*=CopyOp::SHALLOW_COPY*/)
+    :BufferData(copy, copyop),MixinVector<DrawArraysIndirectCmd>() {
+}
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// DrawElementIndirectCommand
+//
+DrawElementsIndirectCommand::DrawElementsIndirectCommand():BufferData(),MixinVector<DrawElementsIndirectCmd>() {}
+DrawElementsIndirectCommand::DrawElementsIndirectCommand(const DrawElementsIndirectCommand& copy,const CopyOp& copyop/*=CopyOp::SHALLOW_COPY*/)
+    :BufferData(copy, copyop), MixinVector<DrawElementsIndirectCmd>(){
+}
+MultiDrawElementsIndirectUByte::~MultiDrawElementsIndirectUByte()
+{
+    releaseGLObjects();
+}
+/*
+void DrawArraysIndirect::draw(State& state, bool) const
+{
+    GLBufferObject* dibo=_indirectCommand->getBufferObject()->getOrCreateGLBufferObject(state.getContextID());
+    state.bindDrawIndirectBufferObject(dibo);
+
+#if defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE)
+    GLenum mode = _mode;
+    if (_mode==GL_QUADS)
+    {
+        state.drawQuads(_first, _count, _numInstances);
+        return;
+    }
+    else if (mode==GL_POLYGON)
+    {
+        mode = GL_TRIANGLE_FAN;
+    }
+    else if (mode==GL_QUAD_STRIP)
+    {
+        mode = GL_TRIANGLE_STRIP;
+    }
+
+    if (_numInstances>=1) state.glDrawArraysInstanced(mode,_first,_count, _numInstances);
+    else glDrawArrays(mode,_first,_count);
+#else
+    // if (_numInstances>=1) state.glDrawArraysItInstanced(_mode,_first,_count, _numInstances);
+    //else
+    state.get<GLExtensions>()->glDrawArraysIndirect(_mode,_indirect);
+#endif
+}
+
+void DrawArraysIndirect::accept(PrimitiveFunctor& functor) const
+{
+    //cant mimic GPU stored drawcall functor.drawArrays(_mode,_first,_count);
+}
+
+void DrawArraysIndirect::accept(PrimitiveIndexFunctor& functor) const
+{
+    //cant mimic GPU stored drawcall functor.drawArrays(_mode,_first,_count);
+}
+*/
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// MultiDrawElementsIndirectUByte
+//
+
+void MultiDrawElementsIndirectUByte::draw(State& state, bool useVertexBufferObjects) const
+{
+    GLBufferObject* dibo=_indirectCommand->getBufferObject()->getOrCreateGLBufferObject(state.getContextID());
+    state.bindDrawIndirectBufferObject(dibo);
+    GLenum mode = _mode;
+#if defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE)
+    if (mode==GL_POLYGON) mode = GL_TRIANGLE_FAN;
+    if (mode==GL_QUAD_STRIP) mode = GL_TRIANGLE_STRIP;
+#endif
+
+
+    GLBufferObject* ebo = getOrCreateGLBufferObject(state.getContextID());
+
+    assert (useVertexBufferObjects && ebo);
+
+    state.bindElementBufferObject(ebo);
+
+    state.get<GLExtensions>()-> glMultiDrawElementsIndirect(mode, GL_UNSIGNED_BYTE, (const GLvoid *)(dibo->getOffset(_indirectCommand->getBufferIndex())),_indirectCommand->size(), _stride);
+
+}
+
+void MultiDrawElementsIndirectUByte::accept(PrimitiveFunctor& functor) const
+{
+   /* if (!empty())
+        for(DrawElementsIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+            functor.drawElements(_mode,itcmd->count,&(*this)[itcmd->firstIndex],itcmd->baseVertex);*/
+}
+
+void MultiDrawElementsIndirectUByte::accept(PrimitiveIndexFunctor& functor) const
+{
+    /* if (!empty())
+        for(DrawElementsIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+            functor.drawElements(_mode,itcmd->count,&(*this)[itcmd->firstIndex],itcmd->baseVertex); */
+}
+
+void MultiDrawElementsIndirectUByte::offsetIndices(int offset)
+{
+    for(iterator itr=begin();
+            itr!=end();
+            ++itr)
+    {
+        *itr += offset;
+    }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// MultiDrawElementsIndirectUShort
+//
+MultiDrawElementsIndirectUShort::~MultiDrawElementsIndirectUShort()
+{
+    releaseGLObjects();
+}
+
+void MultiDrawElementsIndirectUShort::draw(State& state, bool useVertexBufferObjects) const
+{   GLBufferObject* dibo=_indirectCommand->getBufferObject()->getOrCreateGLBufferObject(state.getContextID());
+    state.bindDrawIndirectBufferObject(dibo);
+
+    GLenum mode = _mode;
+#if defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE)
+    if (mode==GL_POLYGON) mode = GL_TRIANGLE_FAN;
+    if (mode==GL_QUAD_STRIP) mode = GL_TRIANGLE_STRIP;
+#endif
+
+    GLBufferObject* ebo = getOrCreateGLBufferObject(state.getContextID());
+
+    assert (useVertexBufferObjects && ebo);
+
+    state.bindElementBufferObject(ebo);
+
+    state.get<GLExtensions>()-> glMultiDrawElementsIndirect(mode, GL_UNSIGNED_SHORT, (const GLvoid *)(dibo->getOffset(_indirectCommand->getBufferIndex())),_indirectCommand->size(),_stride);
+
+}
+
+void MultiDrawElementsIndirectUShort::accept(PrimitiveFunctor& functor) const
+{
+    /* if (!empty())
+        for(DrawElementsIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+            functor.drawElements(_mode,itcmd->count,&(*this)[itcmd->firstIndex],itcmd->baseVertex); */
+}
+
+void MultiDrawElementsIndirectUShort::accept(PrimitiveIndexFunctor& functor) const
+{
+     /* if (!empty())
+        for(DrawElementsIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+            functor.drawElements(_mode,itcmd->count,&(*this)[itcmd->firstIndex],itcmd->baseVertex); */
+}
+
+void MultiDrawElementsIndirectUShort::offsetIndices(int offset)
+{
+    for(iterator itr=begin();
+            itr!=end();
+            ++itr)
+    {
+        *itr += offset;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// MultiDrawElementsIndirectUInt
+//
+MultiDrawElementsIndirectUInt::~MultiDrawElementsIndirectUInt()
+{
+    releaseGLObjects();
+}
+
+void MultiDrawElementsIndirectUInt::draw(State& state, bool useVertexBufferObjects) const
+{
+    GLBufferObject* dibo=_indirectCommand->getBufferObject()->getOrCreateGLBufferObject(state.getContextID());
+    state.bindDrawIndirectBufferObject(dibo);
+    GLenum mode = _mode;
+#if defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE)
+    if (mode==GL_POLYGON) mode = GL_TRIANGLE_FAN;
+    if (mode==GL_QUAD_STRIP) mode = GL_TRIANGLE_STRIP;
+#endif
+
+
+    GLBufferObject* ebo = getOrCreateGLBufferObject(state.getContextID());
+
+    assert (useVertexBufferObjects && ebo);
+
+    state.bindElementBufferObject(ebo);
+
+    state.get<GLExtensions>()-> glMultiDrawElementsIndirect(mode, GL_UNSIGNED_INT, (const GLvoid *)(dibo->getOffset(_indirectCommand->getBufferIndex())),_indirectCommand->size(),_stride);
+
+}
+
+void MultiDrawElementsIndirectUInt::accept(PrimitiveFunctor& functor) const
+{
+
+    /* if (!empty())
+        for(DrawElementsIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+            functor.drawElements(_mode,itcmd->count,&(*this)[itcmd->firstIndex],itcmd->baseVertex); */
+}
+
+void MultiDrawElementsIndirectUInt::accept(PrimitiveIndexFunctor& functor) const
+{
+    /* if (!empty())
+        for(DrawElementsIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+            functor.drawElements(_mode,itcmd->count,&(*this)[itcmd->firstIndex],itcmd->baseVertex); */
+
+}
+
+void MultiDrawElementsIndirectUInt::offsetIndices(int offset)
+{
+    for(iterator itr=begin();
+            itr!=end();
+            ++itr)
+    {
+        *itr += offset;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// MultiDrawArrays
+//
+void MultiDrawArraysIndirect::draw(osg::State& state, bool) const
+{
+    GLBufferObject* dibo=_indirectCommand->getBufferObject()->getOrCreateGLBufferObject(state.getContextID());
+    state.bindDrawIndirectBufferObject(dibo);
+
+    GLExtensions* ext = state.get<GLExtensions>();
+
+    ext->glMultiDrawArraysIndirect(_mode,  (const GLvoid *)(dibo->getOffset(_indirectCommand->getBufferIndex())),_indirectCommand->size(),_stride);
+
+}
+
+void MultiDrawArraysIndirect::accept(PrimitiveFunctor& functor) const
+{
+    for(DrawArraysIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+    {
+        functor.drawArrays(_mode, itcmd->first, itcmd->count);
+    }
+}
+
+void MultiDrawArraysIndirect::accept(PrimitiveIndexFunctor& functor) const
+{
+    for(DrawArraysIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+    {
+        functor.drawArrays(_mode, itcmd->first, itcmd->count);
+    }
+}
+
+unsigned int MultiDrawArraysIndirect::getNumIndices() const
+{
+    unsigned int total=0;
+
+    for(DrawArraysIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+        total+= itcmd->count;
+    return total;
+}
+
+unsigned int MultiDrawArraysIndirect::index(unsigned int pos) const
+{
+    DrawArraysIndirectCommand::iterator itcmd=_indirectCommand->begin();
+    for(; itcmd!=_indirectCommand->end(); itcmd++)
+    {
+        unsigned int count = itcmd->count;
+        if (pos<count) break;
+        pos -= count;
+    }
+    return itcmd->first + pos;
+
+}
+
+void MultiDrawArraysIndirect::offsetIndices(int offset)
+{
+
+    for(DrawArraysIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+        itcmd->first += offset;
+}
+
+unsigned int MultiDrawArraysIndirect::getNumPrimitives() const
+{
+    unsigned int total=0;
+    switch(_mode)
+    {
+    case(POINTS):
+         for(DrawArraysIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+            total+=itcmd->count;
+    case(LINES):
+        for(DrawArraysIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+           total+=itcmd->count/2;
+    case(TRIANGLES):
+        for(DrawArraysIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+           total+=itcmd->count/3;
+    case(QUADS):
+        for(DrawArraysIndirectCommand::iterator itcmd=_indirectCommand->begin(); itcmd!=_indirectCommand->end(); itcmd++)
+           total+=itcmd->count/4;
+    case(LINE_STRIP):
+    case(LINE_LOOP):
+    case(TRIANGLE_STRIP):
+    case(TRIANGLE_FAN):
+    case(QUAD_STRIP):
+    case(PATCHES):
+    case(POLYGON):
+    {
+        unsigned int primcount = _indirectCommand->size();
+        return primcount;
+    }
+    }
+    return total;
+}

--- a/src/osg/State.cpp
+++ b/src/osg/State.cpp
@@ -89,6 +89,7 @@ State::State():
     _currentClientActiveTextureUnit=0;
 
     _currentPBO = 0;
+    _currentDIBO = 0;
     _currentVAO = 0;
 
     _isSecondaryColorSupported = false;


### PR DESCRIPTION
IndexedPrimitiveFunctors lacks a basevertex feature, it make accept() methods unimplementable for IndirectedDrawPrimitives.
I added a basevertex parameter to IndexedPrimitiveFunctors::drawelements methods 
virtual void drawElements(GLenum mode,GLsizei count,const GLubyte* indices, const GLuint basevertex = 0)
but it induces a cascade of file changes so I would be glad to have your opinion on this before PR