### PR TITLE
pragma(tic) shader composing fixes in the State

### DIFF
--- a/include/osg/State
+++ b/include/osg/State
@@ -2108,7 +2108,7 @@ inline void State::pushDefineList(DefineMap& defineMap,const StateSet::DefineLis
             dv.push_back(StateSet::DefinePair(aitr->second.first,aitr->second.second));
 
             // if the back of the stack has changed since the last then mark it as changed.
-            bool changed = (dv[dv.size()-2].first==dv[dv.size()-1].first);
+            bool changed = (dv[dv.size()-2] != dv.back());
             if (changed)
             {
                 ds.changed = true;
@@ -2177,7 +2177,7 @@ inline void State::popDefineList(DefineMap& defineMap,const StateSet::DefineList
         if (!dv.empty())
         {
             // if the stack has less than 2 entries or new back vs old back are different then mark the DefineStack as changed
-            if ((dv.size()<2) || (dv[dv.size()-2].first!=dv.back().first))
+            if ((dv.size() < 2) || (dv[dv.size()-2] != dv.back()))
             {
                 ds.changed = true;
                 defineMap.changed = true;

--- a/src/osg/State.cpp
+++ b/src/osg/State.cpp
@@ -1828,30 +1828,27 @@ void State::frameCompleted()
 
 bool State::DefineMap::updateCurrentDefines()
 {
-    if (changed)
+    if (!changed)
+		return false;
+
+    currentDefines.clear();
+    for(DefineStackMap::const_iterator itr = map.begin();
+        itr != map.end();
+        ++itr)
     {
-        currentDefines.clear();
-        for(DefineStackMap::const_iterator itr = map.begin();
-            itr != map.end();
-            ++itr)
+        const DefineStack::DefineVec& dv = itr->second.defineVec;
+        if (!dv.empty())
         {
-            const DefineStack::DefineVec& dv = itr->second.defineVec;
-            if (!dv.empty())
+            const StateSet::DefinePair& dp = dv.back();
+            if (dp.second & osg::StateAttribute::ON)
             {
-                const StateSet::DefinePair& dp = dv.back();
-                if (dp.second & osg::StateAttribute::ON)
-                {
-                    currentDefines[itr->first] = dp;
-                }
+                currentDefines[itr->first] = dp;
             }
         }
-        changed = false;
-        return true;
     }
-    else
-    {
-        return false;
-    }
+    changed = false;
+
+	return true;
 }
 
 std::string State::getDefineString(const osg::ShaderDefines& shaderDefines)


### PR DESCRIPTION
Hello, Robert!
This PR is for the OpenSceneGraph-3.4 branch, but maybe can be used for master.

There was a commit ad0a73273c972fe07e5b3f71c1d144e80b0976ed which fixed "the State::DefineMap::changed flag is not resetted to false after currentDefines are updated", but this flag is not correctly changed in push/popDefileList functions.

For example:
Group* parent = new Group;
parent->getOrCreateStateSet->setDefine("LIGHT", StateAttribute::OFF)
Node* node1 = new Node;
node1->getOrCreateStateSet->setDefine("LIGHT", StateAttribute::**ON**)
Node* node2 = new Node;
parent->addChild(node2);

Without this patch, node2 will be with "**LIGHT ON**", but must be without light

std::pairs must be compared, not just their keys.


PS
I have the same problem in 3.5.6 dev release and talked about this while 3.5.6 testing.

KOS