### PR TITLE
IMAGEIO plugin tweak

### DIFF
--- a/include/osg/GLDefines
+++ b/include/osg/GLDefines
@@ -45,8 +45,10 @@
 typedef char GLchar;
 #endif
 
-#if !defined(GL_VERSION_2_0)
+#ifndef GL_VERTEX_PROGRAM_POINT_SIZE
     #define GL_VERTEX_PROGRAM_POINT_SIZE      0x8642
+#endif
+#ifndef GL_VERTEX_PROGRAM_TWO_SIDE
     #define GL_VERTEX_PROGRAM_TWO_SIDE        0x8643
 #endif
 


### PR DESCRIPTION
Hello, Robert!

In this PR there are changes for imageio plugin for Apple macOS and iOS.
Newer plugin can open 8, 16, 24, 32 bit images with 1, 2, 3 and 4 components + it can be faster (no benchmarking :^/ ) and is better for OpenGL 3.2 (core profile) and GLES2/3

Tested on iOS 7.1 (GLES3/GLES2) and upper, on macOS 10.12 (GL3 in compatibility mode)

Also I have some build problems with GLDefines on macOS (GL3 + GL2 profile) - patch attached
"GL3 + GL2" because OpenSceneGraph 3.4 version works only in compatibility profile mode (no VAO)
OSG 3.5.6 has VAO, so there we can switch to core profile

This patch can also be merged with master.

KOS