### PR TITLE
osgAnimation: classes UpdateVec2fUniform and UpdateVec4fUniform added

### DIFF
--- a/include/osgAnimation/UpdateUniform
+++ b/include/osgAnimation/UpdateUniform
@@ -69,6 +69,18 @@ namespace osgAnimation
         META_Object(osgAnimation, UpdateFloatUniform);
     };
 
+    // Vec2f
+    struct UpdateVec2fUniform : public UpdateUniform<osg::Vec2f>
+    {
+        UpdateVec2fUniform(const std::string& aName = "") : UpdateUniform<osg::Vec2f>(aName) { }
+        UpdateVec2fUniform(const UpdateVec2fUniform& uv2fu,
+                           const osg::CopyOp& copyop) :
+            osg::Object(uv2fu, copyop),        // copy name
+            UpdateUniform<osg::Vec2f>(uv2fu, copyop) { }
+
+        META_Object(osgAnimation, UpdateVec2fUniform);
+    };
+
     // Vec3f
     struct UpdateVec3fUniform : public UpdateUniform<osg::Vec3f>
     {
@@ -79,6 +91,18 @@ namespace osgAnimation
             UpdateUniform<osg::Vec3f>(uv3fu, copyop) { }
 
         META_Object(osgAnimation, UpdateVec3fUniform);
+    };
+
+    // Vec4f
+    struct UpdateVec4fUniform : public UpdateUniform<osg::Vec4f>
+    {
+        UpdateVec4fUniform(const std::string& aName = "") : UpdateUniform<osg::Vec4f>(aName) { }
+        UpdateVec4fUniform(const UpdateVec4fUniform& uv4fu,
+                           const osg::CopyOp& copyop) :
+            osg::Object(uv4fu, copyop),        // copy name
+            UpdateUniform<osg::Vec4f>(uv4fu, copyop) { }
+
+        META_Object(osgAnimation, UpdateVec4fUniform);
     };
 
     // Matrixf

--- a/src/osgDB/OutputStream.cpp
+++ b/src/osgDB/OutputStream.cpp
@@ -18,7 +18,7 @@
 #include <osgDB/FileUtils>
 #include <osgDB/WriteFile>
 #include <osgDB/ObjectWrapper>
-#include <fstream>
+#include <osgDB/fstream>
 #include <sstream>
 #include <stdlib.h>
 
@@ -559,7 +559,7 @@ void OutputStream::writeImage( const osg::Image* img )
             if ( isBinary() )
             {
                 std::string fullPath = osgDB::findDataFile( img->getFileName() );
-                std::ifstream infile( fullPath.c_str(), std::ios::in|std::ios::binary );
+                osgDB::ifstream infile( fullPath.c_str(), std::ios::in|std::ios::binary );
                 if ( infile )
                 {
                     infile.seekg( 0, std::ios::end );

--- a/src/osgWrappers/serializers/osgAnimation/LibraryWrapper.cpp
+++ b/src/osgWrappers/serializers/osgAnimation/LibraryWrapper.cpp
@@ -30,7 +30,9 @@ USE_SERIALIZER_WRAPPER(osgAnimation_UpdateMorphGeometry)
 USE_SERIALIZER_WRAPPER(osgAnimation_UpdateRigGeometry)
 USE_SERIALIZER_WRAPPER(osgAnimation_UpdateFloatUniform)
 USE_SERIALIZER_WRAPPER(osgAnimation_UpdateMatrixfUniform)
+USE_SERIALIZER_WRAPPER(osgAnimation_UpdateVec2fUniform)
 USE_SERIALIZER_WRAPPER(osgAnimation_UpdateVec3fUniform)
+USE_SERIALIZER_WRAPPER(osgAnimation_UpdateVec4fUniform)
 
 
 extern "C" void wrapper_serializer_library_osgAnimation(void) {}

--- a/src/osgWrappers/serializers/osgAnimation/UpdateVec2fUniform.cpp
+++ b/src/osgWrappers/serializers/osgAnimation/UpdateVec2fUniform.cpp
@@ -1,0 +1,17 @@
+#undef OBJECT_CAST
+#define OBJECT_CAST dynamic_cast
+
+#include <osgAnimation/UpdateUniform>
+#include <osgDB/ObjectWrapper>
+#include <osgDB/InputStream>
+#include <osgDB/OutputStream>
+
+REGISTER_OBJECT_WRAPPER( osgAnimation_UpdateVec2fUniform,
+                         new osgAnimation::UpdateVec2fUniform,
+                         osgAnimation::UpdateVec2fUniform,
+                         "osg::Object osg::Callback osg::UniformCallback osgAnimation::UpdateVec2fUniform" )
+{
+}
+
+#undef OBJECT_CAST
+#define OBJECT_CAST static_cast

--- a/src/osgWrappers/serializers/osgAnimation/UpdateVec4fUniform.cpp
+++ b/src/osgWrappers/serializers/osgAnimation/UpdateVec4fUniform.cpp
@@ -1,0 +1,17 @@
+#undef OBJECT_CAST
+#define OBJECT_CAST dynamic_cast
+
+#include <osgAnimation/UpdateUniform>
+#include <osgDB/ObjectWrapper>
+#include <osgDB/InputStream>
+#include <osgDB/OutputStream>
+
+REGISTER_OBJECT_WRAPPER( osgAnimation_UpdateVec4fUniform,
+                         new osgAnimation::UpdateVec4fUniform,
+                         osgAnimation::UpdateVec4fUniform,
+                         "osg::Object osg::Callback osg::UniformCallback osgAnimation::UpdateVec4fUniform" )
+{
+}
+
+#undef OBJECT_CAST
+#define OBJECT_CAST static_cast


### PR DESCRIPTION
Hello, Robert!

This patches are **already in the master**.
Should not break any compatibility with 3.4.0.

KOS
