### PR TITLE
Emscripten: EGL instead of SDL2 in GLExtensions.cpp

### DIFF
--- a/src/osg/GLExtensions.cpp
+++ b/src/osg/GLExtensions.cpp
@@ -48,8 +48,8 @@
         #include <dlfcn.h>
     #endif
 #elif defined(__EMSCRIPTEN__)
-    // Emscripten ships SDL, which we use to get OpenGL function addresses.
-    #include <SDL2/SDL.h>
+    // Emscripten ships EGL, which we use to get OpenGL function addresses.
+    #include <EGL/egl.h>
 #else
     #include <dlfcn.h>
 #endif
@@ -411,8 +411,8 @@ OSG_INIT_SINGLETON_PROXY(GLExtensionDisableStringInitializationProxy, osg::getGL
         return dlsym(RTLD_DEFAULT, funcName);
 
     #elif defined(__EMSCRIPTEN__)
-        // Use SDL to get OpenGL function address for Emscripten.
-        return SDL_GL_GetProcAddress(funcName);
+        // Use EGL to get OpenGL function address for Emscripten.
+        return convertPointerType<void*, __eglMustCastToProperFunctionPointerType>(eglGetProcAddress(funcName));
 
     #else // all other unixes
 


### PR DESCRIPTION
A little bit better realization of Emscripten in GLExtensions.cpp, that does not depends on SDL2 module.

PS
SDL_GL_GetProcAddress realized via eglGetProcAddress
