### PR TITLE
Support specifying GL version, profile and context flags on GLX

### DIFF
--- a/include/osgViewer/api/X11/GraphicsWindowX11
+++ b/include/osgViewer/api/X11/GraphicsWindowX11
@@ -37,6 +37,7 @@ class OSGVIEWER_EXPORT GraphicsWindowX11 : public osgViewer::GraphicsWindow, pub
             _parent(0),
             _window(0),
             _visualInfo(0),
+            _fbConfig(0),
             #ifdef OSG_USE_EGL
             _eglDisplay(0),
             _eglSurface(0),
@@ -176,6 +177,7 @@ class OSGVIEWER_EXPORT GraphicsWindowX11 : public osgViewer::GraphicsWindow, pub
         Window          _parent;
         Window          _window;
         XVisualInfo*    _visualInfo;
+        GLXFBConfig     _fbConfig;
 
         #ifdef OSG_USE_EGL
         EGLDisplay      _eglDisplay;


### PR DESCRIPTION
This PR contains initial work to support requesting a specific GL context, inspired by how Qt does it [1], in the attempt to get OSG running on Linux with intel/mesa drivers which does not provide a compatibility context.

I'm however stuck at the fundamental question how the glContextVersion should be specified in the traits. Should there be a default, handled directly in GraphicsWindowX11::init, perhaps controllable by an environment variable, which takes effect unless the user explicitly specified one in the traits?

Currently running the default osg example programs fails with shader compilation error messages like

    0:1(10): error: GLSL 3.30 is not supported. Supported versions are: 1.10, 1.20, 1.30, 1.00 ES, 3.00 ES, 3.10 ES, and 3.20 ES

because by default it does not create a core profile context with the required GL/GLSL version.

[1] https://github.com/qt/qtbase/blob/5.9/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp#L167