### PR TITLE
Use osg::Quat::value_type instead of double in collada plugin

### DIFF
--- a/src/osgPlugins/dae/daeWTransforms.cpp
+++ b/src/osgPlugins/dae/daeWTransforms.cpp
@@ -39,7 +39,7 @@ void daeWriter::writeUpdateTransformElements(const osg::Vec3 &pos, const osg::Qu
 
     // Make a three rotate place elements for the euler angles
     // TODO decompose quaternion into three euler angles
-    double angle;
+    osg::Quat::value_type angle;
     osg::Vec3 axis;
     q.getRotate( angle, axis );
 
@@ -154,7 +154,7 @@ void daeWriter::apply( osg::PositionAttitudeTransform &node )
             scale->getValue().append3( s.x(), s.y(), s.z() );
         }
 
-        double angle;
+        osg::Quat::value_type angle;
         osg::Vec3 axis;
         q.getRotate( angle, axis );
         if ( angle != 0 )


### PR DESCRIPTION
Note that although the value_type is currently always double, using the proper typedef will open the door to implementing a float Quaternion in the future (as I have actually done so in my own fork).

I can open a PR for the float quaternion too, if we want such a thing? I used it for a performance improvement in my animation code. It is implemented as a build time option similar to the float matrix option.