### PR TITLE
Geometry::compileGLObjects function VAO fix

### DIFF
--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -791,6 +791,9 @@ void Geometry::compileGLObjects(RenderInfo& renderInfo) const
             if ((*itr)->getBufferObject()) bufferObjects.insert((*itr)->getBufferObject());
         }
 
+        if (bufferObjects.empty())
+            return; // no buffers, nothing to compile
+
         //osg::ElapsedTime timer;
 
         // now compile any buffer objects that require it.
@@ -808,11 +811,7 @@ void Geometry::compileGLObjects(RenderInfo& renderInfo) const
 
         // OSG_NOTICE<<"Time to compile "<<timer.elapsedTime_m()<<"ms"<<std::endl;
 
-        // unbind the BufferObjects
-        extensions->glBindBuffer(GL_ARRAY_BUFFER_ARB,0);
-        extensions->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER_ARB,0);
-
-        if (state.useVertexArrayObject(_useVertexArrayObject) && !bufferObjects.empty())
+        if (state.useVertexArrayObject(_useVertexArrayObject))
         {
             VertexArrayState* vas = 0;
 
@@ -826,6 +825,10 @@ void Geometry::compileGLObjects(RenderInfo& renderInfo) const
 
             state.unbindVertexArrayObject();
         }
+
+        // unbind the BufferObjects
+        extensions->glBindBuffer(GL_ARRAY_BUFFER_ARB,0);
+        extensions->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER_ARB,0);
     }
     else
     {


### PR DESCRIPTION
Hello, Robert!

This PR will fix compileGLObjects function in osg::Geometry while using VAO.

**extensions->glBindBuffer(GL_ARRAY_BUFFER_ARB,0);
extensions->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER_ARB,0);**
should be called after "VAO compilation part"... I think

KOS
