### PR TITLE
alleviate pressure on treading problems in std::ostream behind osg::Notify

### DIFF
--- a/src/osgDB/DatabasePager.cpp
+++ b/src/osgDB/DatabasePager.cpp
@@ -728,7 +728,10 @@ void DatabasePager::DatabaseThread::run()
 
         _active = true;
 
-        OSG_INFO<<_name<<": _pager->size()= "<<read_queue->size()<<" to delete = "<<read_queue->_childrenToDeleteList.size()<<std::endl;
+        if (osg::isNotifyEnabled(osg::INFO)) {
+            unsigned int rqSize = read_queue->size();
+            OSG_INFO << _name << ": _pager->size()= " << rqSize << " to delete = " << read_queue->_childrenToDeleteList.size() << std::endl;
+        }
 
 
 


### PR DESCRIPTION
While chasing a memory overrun causing spurious chashes on shutdown of our program, I found that this point in the code tended to trigger a treading issue in Visual Studio's (2013 & 2015) ostream buffer, as the size() function requests a mutex held by an other databasepager tread that's likely to genarate some osg_info as well.