### PR TITLE
reduce the need to reallocate the std::ostream buffer behind osg::Notify

### DIFF
--- a/src/osg/Notify.cpp
+++ b/src/osg/Notify.cpp
@@ -61,6 +61,9 @@ struct NotifyStreamBuffer : public std::stringbuf
 {
     NotifyStreamBuffer() : _severity(osg::NOTICE)
     {
+        /* reduce the need to reallocate the std::ostream buffer behind osg::Notify (causing multitreading issues) by pre-allocating 4095 bytes */
+        str(std::string(4095, 0));
+        pubseekpos(0, std::ios_base::out);
     }
 
     void setNotifyHandler(osg::NotifyHandler *handler) { _handler = handler; }


### PR DESCRIPTION
… (causing multitreading issues) by pre-allocating 4095 bytes.

While digging into treading problems I found out that Visual Studio's ostream has a problem if thread A starts some output to the stream, thread B writes enough output to cause the buffer to be resized and thread A then continues to write to the old buffer, while only respecting the length of the new buffer - overrunning the now released old buffer and overwriting other (valid) data. pre-allocating a reasonable buffer helps to minimize the problem - in my case it disappeared.
Regards, Laurens. 