### PR TITLE
Fix stat64 build issue with NDK 15 by definining it as stat for Android

### DIFF
--- a/src/osgDB/FileUtils.cpp
+++ b/src/osgDB/FileUtils.cpp
@@ -95,6 +95,10 @@ typedef char TCHAR;
     #endif
 #endif
 
+#if defined(__ANDROID__)
+    #define stat64 stat
+#endif
+
     // set up _S_ISDIR()
 #if !defined(S_ISDIR)
 #  if defined( _S_IFDIR) && !defined( __S_IFDIR)


### PR DESCRIPTION
Such a #define already exists for other platforms.
Android NDK 14 worked fine without the #define, but something was changed in NDK 15. Now OSG only builds for Android using this #define.

More details are available at OSG guide issue: https://github.com/OGStudio/openscenegraph-cross-platform-guide/issues/2