### PR TITLE
change the design of BufferIndexBinding to work with BufferData instead of BufferObject +matrix transpose

### DIFF
--- a/examples/osgSSBO/osgSSBO.cpp
+++ b/examples/osgSSBO/osgSSBO.cpp
@@ -773,7 +773,7 @@ void ComputeNode::initComputingSetup()
     _dataArray->setBufferObject(_ssbo.get());
 
 
-    _ssbb = new osg::ShaderStorageBufferBinding(0, _ssbo.get(), 0, blockSize);
+    _ssbb = new osg::ShaderStorageBufferBinding(0, _dataArray, 0, blockSize);
     statesetComputation->setAttributeAndModes(_ssbb.get(), osg::StateAttribute::ON);
 
 

--- a/examples/osgatomiccounter/osgatomiccounter.cpp
+++ b/examples/osgatomiccounter/osgatomiccounter.cpp
@@ -108,10 +108,10 @@ class ResetAtomicCounter : public osg::StateAttributeCallback
             osg::AtomicCounterBufferBinding * acbb = dynamic_cast<osg::AtomicCounterBufferBinding *>(sa);
             if (acbb)
             {
-                osg::AtomicCounterBufferObject * acbo = dynamic_cast<osg::AtomicCounterBufferObject*>(acbb->getBufferObject());
-                if (acbo && acbo->getBufferData(0))
+                osg::BufferData * acbd = acbb->getBufferData();
+                if (acbd)
                 {
-                    acbo->getBufferData(0)->dirty();
+                    acbd->dirty();
                 }
             }
         }
@@ -207,10 +207,10 @@ int main(int argc, char** argv)
     acboBlue->setUsage(GL_STREAM_COPY);
     atomicCounterArrayBlue->setBufferObject(acboBlue.get());
 
-    osg::ref_ptr<osg::AtomicCounterBufferBinding> acbbRedAndGreen = new osg::AtomicCounterBufferBinding(0, acboRedAndGreen.get(), 0, sizeof(GLuint)*3);
+    osg::ref_ptr<osg::AtomicCounterBufferBinding> acbbRedAndGreen = new osg::AtomicCounterBufferBinding(0, atomicCounterArrayRedAndGreen.get(), 0, sizeof(GLuint)*3);
     ss->setAttributeAndModes(acbbRedAndGreen.get());
 
-    osg::ref_ptr<osg::AtomicCounterBufferBinding> acbbBlue = new osg::AtomicCounterBufferBinding(2, acboBlue.get(), 0, sizeof(GLuint));
+    osg::ref_ptr<osg::AtomicCounterBufferBinding> acbbBlue = new osg::AtomicCounterBufferBinding(2, atomicCounterArrayBlue.get(), 0, sizeof(GLuint));
     ss->setAttributeAndModes(acbbBlue.get());
 
     acbbRedAndGreen->setUpdateCallback(new ResetAtomicCounter);

--- a/examples/osgbindlesstext/osgbindlesstext.cpp
+++ b/examples/osgbindlesstext/osgbindlesstext.cpp
@@ -165,7 +165,7 @@ public:
         val->_handles = new osg::UInt64Array();
         val->_handles->resize(count*2,0);
         val->_handles->setBufferObject(val->_sbbo.get());
-        val->_ssbb    = new osg::UniformBufferBinding(0, val->_sbbo.get(), 0, sizeof(GLuint64)*count);
+        val->_ssbb    = new osg::UniformBufferBinding(0, val->_handles.get(), 0, sizeof(GLuint64)*count);
         return val;
     }
     BindlessBuffer& operator  = (const BindlessBuffer& rhs){

--- a/examples/osguniformbuffer/osguniformbuffer.cpp
+++ b/examples/osguniformbuffer/osguniformbuffer.cpp
@@ -104,9 +104,7 @@ public:
     void operator() (StateAttribute* attr, NodeVisitor* nv)
     {
         UniformBufferBinding* ubb = static_cast<UniformBufferBinding*>(attr);
-        UniformBufferObject* ubo
-            = static_cast<UniformBufferObject*>(ubb->getBufferObject());
-        FloatArray* array = static_cast<FloatArray*>(ubo->getBufferData(0));
+        FloatArray* array = static_cast<FloatArray*>(ubb->getBufferData());
         double time = nv->getFrameStamp()->getSimulationTime();
         double frac = fmod(time, 1.0);
         Vec4f warmColor = (Vec4f(0.0, 0.0, 1.0 ,1) * frac
@@ -165,7 +163,7 @@ int main(int argc, char** argv)
     group1->addChild(loadedModel.get());
     scene->addChild(group1);
     ref_ptr<UniformBufferBinding> ubb1
-        = new UniformBufferBinding(0, ubo.get(), 0, blockSize);
+        = new UniformBufferBinding(0, colorArray.get(), 0, blockSize);
     ss1->setAttributeAndModes(ubb1.get(), StateAttribute::ON);
 
     ref_ptr<FloatArray> colorArray2
@@ -180,7 +178,7 @@ int main(int argc, char** argv)
     group2->addChild(loadedModel.get());
     scene->addChild(group2);
     ref_ptr<UniformBufferBinding> ubb2
-        = new UniformBufferBinding(0, ubo2.get(), 0, blockSize);
+        = new UniformBufferBinding(0, colorArray2.get(), 0, blockSize);
     ss2->setAttributeAndModes(ubb2.get(), StateAttribute::ON);
 
     ref_ptr<FloatArray> colorArray3
@@ -195,7 +193,7 @@ int main(int argc, char** argv)
     group3->addChild(loadedModel.get());
     scene->addChild(group3);
     ref_ptr<UniformBufferBinding> ubb3
-        = new UniformBufferBinding(0, ubo3.get(), 0, blockSize);
+        = new UniformBufferBinding(0, colorArray3.get(), 0, blockSize);
     ubb3->setUpdateCallback(new UniformBufferCallback);
     ubb3->setDataVariance(Object::DYNAMIC);
     ss3->setAttributeAndModes(ubb3.get(), StateAttribute::ON);

--- a/include/osg/BufferIndexBinding
+++ b/include/osg/BufferIndexBinding
@@ -1,6 +1,7 @@
 /* -*-c++-*- OpenSceneGraph - Copyright (C) 1998-2006 Robert Osfield
  * Copyright (C) 2010 Tim Moore
  * Copyright (C) 2012 David Callu
+ * Copyright (C) 2017 Julien Valentin
  *
  * This library is open source and may be redistributed and/or modified under
  * the terms of the OpenSceneGraph Public License (OSGPL) version 0.0 or
@@ -40,53 +41,67 @@ class OSG_EXPORT BufferIndexBinding : public StateAttribute
 {
  protected:
     BufferIndexBinding(GLenum target, GLuint index);
-    BufferIndexBinding(GLenum target, GLuint index, BufferObject* bo, GLintptr offset,
-                       GLsizeiptr size);
+    BufferIndexBinding(GLenum target, GLuint index, BufferData* bd, GLintptr offset=0, GLsizeiptr size=0);
     BufferIndexBinding(const BufferIndexBinding& rhs, const CopyOp& copyop=CopyOp::SHALLOW_COPY);
  public:
     // The member value is part of the key to this state attribute in
     // the State class. Using the index target, we can separately
     // track the bindings for many different index targets.
     virtual unsigned getMember() const { return static_cast<unsigned int>(_index); }
-
     GLenum getTarget() const { return _target; }
+    ///enable arbitrary BufferBinding (user is responsible for _target mismatch with bufferdata
+    /// what can be done is setting wrong _target and use the one of bd if not subclassed
+    void setTarget(GLenum t){_target=t;}
 
-    /** Set the renderbuffer index of the BlendEquationi. */
-    void setIndex(unsigned int index);
+    inline void setBufferData(BufferData *bufferdata) {
+        if (_bufferData.valid())
+        {
+            _bufferData->removeClient(this);
+        }
+
+        _bufferData=bufferdata;
+
+        if (_bufferData.valid())
+        {
+            if(!_bufferData->getBufferObject())
+                _bufferData->setBufferObject(new VertexBufferObject());
+            if(_size==0)
+                _size=_bufferData->getTotalDataSize();
+        }
+    }
+    /** Get the buffer data to be bound.
+     */
+    inline const BufferData* getBufferData() const { return _bufferData.get(); }
+    inline BufferData* getBufferData(){ return _bufferData.get(); }
 
     /** Get the index target.
      */
-    unsigned int getIndex() const { return _index; }
-
-    /** Set the buffer object that will be bound to the index target.
+    inline GLuint getIndex() const { return _index; }
+    /** Set the index target. (and update parents StateSets)
      */
-    void setBufferObject(BufferObject *bo) { _bufferObject = bo; }
+    void setIndex(GLuint index);
 
-    /** Get the buffer object to be bound.
-     */
-    const BufferObject* getBufferObject() const { return _bufferObject.get(); }
-    BufferObject* getBufferObject(){ return _bufferObject.get(); }
 
-    /** Set the starting offset into the buffer object for data for
+    /** Set the starting offset into the buffer data for
     the indexed target. Note: the required  alignment on the offset
     may be quite large (e.g., 256 bytes on NVidia 8600M). This
     should be checked with glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT...).
     */
-    void setOffset(GLintptr offset) { _offset = offset; }
-    GLintptr getOffset() const { return _offset; }
+    inline void setOffset(GLintptr offset) { _offset = offset; }
+    inline GLintptr getOffset() const { return _offset; }
 
-    /** Set the size of data for the indexed target.
+    /** Set the size override of bufferdata binded for the indexed target.
      */
-    void setSize(GLsizeiptr size) { _size = size; }
-    GLsizeiptr getSize() const { return _size; }
+    inline void setSize(GLsizeiptr size) { _size = size; }
+    inline GLsizeiptr getSize() const { return _size; }
 
     virtual void apply(State& state) const;
 
  protected:
     virtual ~BufferIndexBinding();
-    const GLenum _target;
+    /*const*/ GLenum _target;
+    ref_ptr<BufferData> _bufferData;
     GLuint _index;
-    ref_ptr<BufferObject> _bufferObject;
     GLintptr _offset;
     GLsizeiptr _size;
 };
@@ -100,21 +115,20 @@ class OSG_EXPORT UniformBufferBinding : public BufferIndexBinding
     UniformBufferBinding(GLuint index);
     /** Create a binding for a uniform buffer index target.
      *  @param index the index target
-     *  @param bo associated buffer object
-     *  @param offset offset into buffer object
-     *  @param size size of data in buffer object
+     *  @param bd associated buffer data
+     *  @param offset offset into buffer data
+     *  @param size size of data in buffer data
      */
-    UniformBufferBinding(GLuint index, BufferObject* bo, GLintptr offset, GLsizeiptr size);
+    UniformBufferBinding(GLuint index, BufferData* bd, GLintptr offset=0, GLsizeiptr size=0);
     UniformBufferBinding(const UniformBufferBinding& rhs, const CopyOp& copyop=CopyOp::SHALLOW_COPY);
     META_StateAttribute(osg, UniformBufferBinding, UNIFORMBUFFERBINDING);
 
     virtual int compare(const StateAttribute& bb) const
     {
         COMPARE_StateAttribute_Types(UniformBufferBinding, bb)
-
         COMPARE_StateAttribute_Parameter(_target)
         COMPARE_StateAttribute_Parameter(_index)
-        COMPARE_StateAttribute_Parameter(_bufferObject)
+        COMPARE_StateAttribute_Parameter(_bufferData)
         COMPARE_StateAttribute_Parameter(_offset)
         COMPARE_StateAttribute_Parameter(_size)
         return 0;
@@ -127,17 +141,16 @@ class OSG_EXPORT TransformFeedbackBufferBinding : public BufferIndexBinding
 {
  public:
     TransformFeedbackBufferBinding(GLuint index = 0);
-    TransformFeedbackBufferBinding(GLuint index, BufferObject* bo, GLintptr offset, GLsizeiptr size);
+    TransformFeedbackBufferBinding(GLuint index, BufferData* bd, GLintptr offset=0, GLsizeiptr size=0);
     TransformFeedbackBufferBinding(const TransformFeedbackBufferBinding& rhs, const CopyOp& copyop=CopyOp::SHALLOW_COPY);
     META_StateAttribute(osg, TransformFeedbackBufferBinding, TRANSFORMFEEDBACKBUFFERBINDING);
 
     virtual int compare(const StateAttribute& bb) const
     {
         COMPARE_StateAttribute_Types(TransformFeedbackBufferBinding, bb)
-
         COMPARE_StateAttribute_Parameter(_target)
         COMPARE_StateAttribute_Parameter(_index)
-        COMPARE_StateAttribute_Parameter(_bufferObject)
+        COMPARE_StateAttribute_Parameter(_bufferData)
         COMPARE_StateAttribute_Parameter(_offset)
         COMPARE_StateAttribute_Parameter(_size)
         return 0;
@@ -152,11 +165,11 @@ class OSG_EXPORT AtomicCounterBufferBinding : public BufferIndexBinding
     AtomicCounterBufferBinding(GLuint index=0);
     /** Create a binding for a atomic counter buffer index target.
      *  @param index the index target
-     *  @param bo associated buffer object
-     *  @param offset offset into buffer object
-     *  @param size size of data in buffer object
+     *  @param bd associated buffer data
+     *  @param offset offset into buffer data
+     *  @param size size of data in buffer data
      */
-    AtomicCounterBufferBinding(GLuint index, BufferObject* bo, GLintptr offset, GLsizeiptr size);
+    AtomicCounterBufferBinding(GLuint index, BufferData* bd, GLintptr offset=0, GLsizeiptr size=0);
     AtomicCounterBufferBinding(const AtomicCounterBufferBinding& rhs, const CopyOp& copyop=CopyOp::SHALLOW_COPY);
     META_StateAttribute(osg, AtomicCounterBufferBinding, ATOMICCOUNTERBUFFERBINDING);
 
@@ -165,10 +178,9 @@ class OSG_EXPORT AtomicCounterBufferBinding : public BufferIndexBinding
     virtual int compare(const StateAttribute& bb) const
     {
         COMPARE_StateAttribute_Types(AtomicCounterBufferBinding, bb)
-
         COMPARE_StateAttribute_Parameter(_target)
         COMPARE_StateAttribute_Parameter(_index)
-        COMPARE_StateAttribute_Parameter(_bufferObject)
+        COMPARE_StateAttribute_Parameter(_bufferData)
         COMPARE_StateAttribute_Parameter(_offset)
         COMPARE_StateAttribute_Parameter(_size)
         return 0;
@@ -181,11 +193,11 @@ class OSG_EXPORT ShaderStorageBufferBinding : public BufferIndexBinding
     ShaderStorageBufferBinding(GLuint index=0);
     /** Create a binding for a shader storage buffer index target.
      *  @param index the index target
-     *  @param bo associated buffer object
-     *  @param offset offset into buffer object
-     *  @param size size of data in buffer object
+     *  @param bd associated buffer data
+     *  @param offset offset into buffer data
+     *  @param size size of data in buffer data
      */
-    ShaderStorageBufferBinding(GLuint index, BufferObject* bo, GLintptr offset, GLsizeiptr size);
+    ShaderStorageBufferBinding(GLuint index, BufferData* bd, GLintptr offset=0, GLsizeiptr size=0);
     ShaderStorageBufferBinding(const ShaderStorageBufferBinding& rhs, const CopyOp& copyop=CopyOp::SHALLOW_COPY);
     META_StateAttribute(osg, ShaderStorageBufferBinding, SHADERSTORAGEBUFFERBINDING);
 
@@ -194,31 +206,32 @@ class OSG_EXPORT ShaderStorageBufferBinding : public BufferIndexBinding
         COMPARE_StateAttribute_Types(ShaderStorageBufferBinding, bb)
         COMPARE_StateAttribute_Parameter(_target)
         COMPARE_StateAttribute_Parameter(_index)
-        COMPARE_StateAttribute_Parameter(_bufferObject)
+        COMPARE_StateAttribute_Parameter(_bufferData)
         COMPARE_StateAttribute_Parameter(_offset)
         COMPARE_StateAttribute_Parameter(_size)
         return 0;
     }
 };
 
+
 class OSG_EXPORT DrawIndirectBufferBinding : public BufferIndexBinding
 {
  public:
     DrawIndirectBufferBinding();
-    /** Create a binding for a uniform buffer index target.
-     *  @param bo associated buffer object
+    /** Create a binding for a draw indirect buffer target.
+     *  @param bd associated buffer data
      */
-    DrawIndirectBufferBinding( BufferObject* bo);
-    void apply(State& state) const;
+    DrawIndirectBufferBinding( BufferData* bd);
     DrawIndirectBufferBinding(const DrawIndirectBufferBinding& rhs, const CopyOp& copyop=CopyOp::SHALLOW_COPY);
-
     META_StateAttribute(osg, DrawIndirectBufferBinding, INDIRECTDRAWBUFFERBINDING);
+
+    virtual void apply(State& state) const;
 
     virtual int compare(const StateAttribute& bb) const
     {
         COMPARE_StateAttribute_Types(DrawIndirectBufferBinding, bb)
         COMPARE_StateAttribute_Parameter(_target)
-        COMPARE_StateAttribute_Parameter(_bufferObject)
+        COMPARE_StateAttribute_Parameter(_bufferData)
         return 0;
     }
 };

--- a/include/osg/Matrixd
+++ b/include/osg/Matrixd
@@ -242,6 +242,12 @@ class OSG_EXPORT Matrixd
         /** full 4x4 matrix invert. */
         bool invert_4x4( const Matrixd& rhs);
 
+        /** transpose a matrix */
+        bool transpose(const Matrixd&rhs);
+
+        /** transpose orthogonal part of the matrix **/
+        bool transpose3x3(const Matrixd&rhs);
+
         /** ortho-normalize the 3x3 rotation & scale matrix */
         void orthoNormalize(const Matrixd& rhs);
 

--- a/include/osg/Matrixf
+++ b/include/osg/Matrixf
@@ -242,6 +242,12 @@ class OSG_EXPORT Matrixf
         /** full 4x4 matrix invert. */
         bool invert_4x4( const Matrixf& rhs);
 
+        /** transpose matrix **/
+        bool transpose(const Matrixf&rhs);
+
+        /** transpose orthogonal part of the matrix **/
+        bool transpose3x3(const Matrixf&rhs);
+
         /** ortho-normalize the 3x3 rotation & scale matrix */
         void orthoNormalize(const Matrixf& rhs);
 

--- a/src/osg/BufferIndexBinding.cpp
+++ b/src/osg/BufferIndexBinding.cpp
@@ -1,6 +1,7 @@
 /* -*-c++-*- OpenSceneGraph - Copyright (C) 1998-2006 Robert Osfield
  * Copyright (C) 2010 Tim Moore
  * Copyright (C) 2012 David Callu
+ * Copyright (C) 2017 Julien Valentin
  *
  * This library is open source and may be redistributed and/or modified under
  * the terms of the OpenSceneGraph Public License (OSGPL) version 0.0 or
@@ -24,23 +25,25 @@
 
 namespace osg {
 
+
 BufferIndexBinding::BufferIndexBinding(GLenum target, GLuint index)
-    : _target(target), _index(index), _offset(0), _size(0)
+    :_target(target), _bufferData(0), _index(index), _offset(0), _size(0)
 {
 }
 
-BufferIndexBinding::BufferIndexBinding(GLenum target, GLuint index, BufferObject* bo,
+BufferIndexBinding::BufferIndexBinding(GLenum target, GLuint index, BufferData* bo,
                                        GLintptr offset, GLsizeiptr size)
-    : _target(target), _index(index), _bufferObject(bo), _offset(offset), _size(size)
+    : _target(target), _index(index), _offset(offset), _size(size)
 {
+    setBufferData(bo);
 }
 
-BufferIndexBinding::BufferIndexBinding(const BufferIndexBinding& rhs, const CopyOp& copyop)
-    : StateAttribute(rhs, copyop),
-      _target(rhs._target), _index(rhs._index),
-      _bufferObject(static_cast<BufferObject*>(copyop(rhs._bufferObject.get()))),
-      _offset(rhs._offset),
-      _size(rhs._size)
+BufferIndexBinding::BufferIndexBinding(const BufferIndexBinding& rhs, const CopyOp& copyop):StateAttribute(rhs,copyop),
+    _target(rhs._target),
+    _bufferData(static_cast<BufferData*>(copyop(rhs._bufferData.get()))),
+    _index(rhs._index),
+    _offset(rhs._offset),
+    _size(rhs._size)
 {
 }
 
@@ -59,15 +62,13 @@ void BufferIndexBinding::setIndex(unsigned int index)
 
 void BufferIndexBinding::apply(State& state) const
 {
-    if (_bufferObject.valid())
+    if (_bufferData.valid())
     {
         GLBufferObject* glObject
-            = _bufferObject->getOrCreateGLBufferObject(state.getContextID());
-        if (!glObject->_extensions->isUniformBufferObjectSupported)
-            return;
+            = _bufferData->getBufferObject()->getOrCreateGLBufferObject(state.getContextID());
         if (glObject->isDirty()) glObject->compileBuffer();
         glObject->_extensions->glBindBufferRange(_target, _index,
-                                                 glObject->getGLObjectID(), _offset, _size);
+                glObject->getGLObjectID(), glObject->getOffset(_bufferData->getBufferIndex())+_offset, _size-_offset);
     }
 }
 
@@ -77,30 +78,30 @@ UniformBufferBinding::UniformBufferBinding()
 }
 
 UniformBufferBinding::UniformBufferBinding(GLuint index)
-  : BufferIndexBinding(GL_UNIFORM_BUFFER, index)
+    : BufferIndexBinding(GL_UNIFORM_BUFFER, index)
 {
 }
 
-UniformBufferBinding::UniformBufferBinding(GLuint index, BufferObject* bo, GLintptr offset,
-                                           GLsizeiptr size)
+UniformBufferBinding::UniformBufferBinding(GLuint index, BufferData* bo, GLintptr offset,
+        GLsizeiptr size)
     : BufferIndexBinding(GL_UNIFORM_BUFFER, index, bo, offset, size)
 {
 
 }
 
 UniformBufferBinding::UniformBufferBinding(const UniformBufferBinding& rhs,
-                                           const CopyOp& copyop)
+        const CopyOp& copyop)
     : BufferIndexBinding(rhs, copyop)
 {
 }
 
 
 TransformFeedbackBufferBinding::TransformFeedbackBufferBinding(GLuint index)
-  : BufferIndexBinding(GL_TRANSFORM_FEEDBACK_BUFFER, index)
+    : BufferIndexBinding(GL_TRANSFORM_FEEDBACK_BUFFER, index)
 {
 }
 
-TransformFeedbackBufferBinding::TransformFeedbackBufferBinding(GLuint index, BufferObject* bo, GLintptr offset, GLsizeiptr size)
+TransformFeedbackBufferBinding::TransformFeedbackBufferBinding(GLuint index, BufferData* bo, GLintptr offset, GLsizeiptr size)
     : BufferIndexBinding(GL_TRANSFORM_FEEDBACK_BUFFER, index, bo, offset, size)
 {
 
@@ -113,11 +114,11 @@ TransformFeedbackBufferBinding::TransformFeedbackBufferBinding(const TransformFe
 
 
 AtomicCounterBufferBinding::AtomicCounterBufferBinding(GLuint index)
-  : BufferIndexBinding(GL_ATOMIC_COUNTER_BUFFER, index)
+    : BufferIndexBinding(GL_ATOMIC_COUNTER_BUFFER, index)
 {
 }
 
-AtomicCounterBufferBinding::AtomicCounterBufferBinding(GLuint index, BufferObject* bo, GLintptr offset, GLsizeiptr size)
+AtomicCounterBufferBinding::AtomicCounterBufferBinding(GLuint index, BufferData* bo, GLintptr offset, GLsizeiptr size)
     : BufferIndexBinding(GL_ATOMIC_COUNTER_BUFFER, index, bo, offset, size)
 {
 
@@ -130,9 +131,9 @@ AtomicCounterBufferBinding::AtomicCounterBufferBinding(const AtomicCounterBuffer
 
 void AtomicCounterBufferBinding::readData(osg::State & state, osg::UIntArray & uintArray) const
 {
-    if (!_bufferObject) return;
+    if (!_bufferData) return;
 
-    GLBufferObject* bo = _bufferObject->getOrCreateGLBufferObject( state.getContextID() );
+    GLBufferObject* bo = _bufferData->getBufferObject()->getOrCreateGLBufferObject( state.getContextID() );
     if (!bo) return;
 
 
@@ -143,7 +144,7 @@ void AtomicCounterBufferBinding::readData(osg::State & state, osg::UIntArray & u
         bo->_extensions->glBindBuffer(GL_ATOMIC_COUNTER_BUFFER, bo->getGLObjectID());
 
     GLubyte* src = (GLubyte*)bo->_extensions->glMapBuffer(GL_ATOMIC_COUNTER_BUFFER,
-                                                          GL_READ_ONLY_ARB);
+                   GL_READ_ONLY_ARB);
     if(src)
     {
         size_t size = osg::minimum<int>(_size, uintArray.getTotalDataSize());
@@ -161,7 +162,7 @@ ShaderStorageBufferBinding::ShaderStorageBufferBinding(GLuint index)
 {
 }
 
-ShaderStorageBufferBinding::ShaderStorageBufferBinding(GLuint index, BufferObject* bo, GLintptr offset, GLsizeiptr size)
+ShaderStorageBufferBinding::ShaderStorageBufferBinding(GLuint index, BufferData* bo, GLintptr offset, GLsizeiptr size)
     : BufferIndexBinding(GL_SHADER_STORAGE_BUFFER, index, bo, offset, size)
 {
 
@@ -173,26 +174,24 @@ ShaderStorageBufferBinding::ShaderStorageBufferBinding(const ShaderStorageBuffer
 }
 
 
-
-
-
 DrawIndirectBufferBinding::DrawIndirectBufferBinding( )
   : BufferIndexBinding(GL_DRAW_INDIRECT_BUFFER, 0)
 {
 }
 void DrawIndirectBufferBinding::apply(State& state) const
 {
-    if (_bufferObject.valid())
+    if (_bufferData.valid())
     {
+        BufferObject * bo = _bufferData->getBufferObject();
         GLBufferObject* glObject
-            = _bufferObject->getOrCreateGLBufferObject(state.getContextID());
+            = bo->getOrCreateGLBufferObject(state.getContextID());
         if (!glObject->_extensions->isUniformBufferObjectSupported)
             return;
-      //  if (glObject->isDirty()) glObject->compileBuffer();
+        if (glObject->isDirty()) glObject->compileBuffer();
         glObject->_extensions->glBindBuffer (_target, glObject->getGLObjectID());
     }
 }
-DrawIndirectBufferBinding::DrawIndirectBufferBinding(  BufferObject* bo)
+DrawIndirectBufferBinding::DrawIndirectBufferBinding(  BufferData* bo)
     : BufferIndexBinding(GL_DRAW_INDIRECT_BUFFER, 0, bo, 0, 0)
 {
 

--- a/src/osg/Matrix_implementation.cpp
+++ b/src/osg/Matrix_implementation.cpp
@@ -742,6 +742,41 @@ inline T SGL_ABS(T a)
 #define SGL_SWAP(a,b,temp) ((temp)=(a),(a)=(b),(b)=(temp))
 #endif
 
+bool Matrix_implementation::transpose(const Matrix_implementation&mat){
+    if (&mat==this) {
+       Matrix_implementation tm(mat);
+       return transpose(tm);
+    }
+    _mat[0][1]=mat._mat[1][0];
+    _mat[0][2]=mat._mat[2][0];
+    _mat[0][3]=mat._mat[3][0];
+    _mat[1][0]=mat._mat[0][1];
+    _mat[1][2]=mat._mat[2][1];
+    _mat[1][3]=mat._mat[3][1];
+    _mat[2][0]=mat._mat[0][2];
+    _mat[2][1]=mat._mat[1][2];
+    _mat[2][3]=mat._mat[3][2];
+    _mat[3][0]=mat._mat[0][3];
+    _mat[3][1]=mat._mat[1][3];
+    _mat[3][2]=mat._mat[2][3];
+    return true;
+}
+
+bool Matrix_implementation::transpose3x3(const Matrix_implementation&mat){
+    if (&mat==this) {
+       Matrix_implementation tm(mat);
+       return transpose3x3(tm);
+    }
+    _mat[0][1]=mat._mat[1][0];
+    _mat[0][2]=mat._mat[2][0];
+    _mat[1][0]=mat._mat[0][1];
+    _mat[1][2]=mat._mat[2][1];
+    _mat[2][0]=mat._mat[0][2];
+    _mat[2][1]=mat._mat[1][2];
+
+    return true;
+}
+
 bool Matrix_implementation::invert_4x4( const Matrix_implementation& mat )
 {
     if (&mat==this) {
@@ -763,7 +798,7 @@ bool Matrix_implementation::invert_4x4( const Matrix_implementation& mat )
     for(i=0;i<4;i++)
     {
        big=0.0;
-       for (j=0; j<4; j++)
+       for (j=0; j<4; ++j)
           if (ipiv[j] != 1)
              for (k=0; k<4; k++)
              {
@@ -781,7 +816,7 @@ bool Matrix_implementation::invert_4x4( const Matrix_implementation& mat )
              }
        ++(ipiv[icol]);
        if (irow != icol)
-          for (l=0; l<4; l++) SGL_SWAP(operator()(irow,l),
+          for (l=0; l<4; ++l) SGL_SWAP(operator()(irow,l),
                                        operator()(icol,l),
                                        temp);
 
@@ -792,13 +827,13 @@ bool Matrix_implementation::invert_4x4( const Matrix_implementation& mat )
 
        pivinv = 1.0/operator()(icol,icol);
        operator()(icol,icol) = 1;
-       for (l=0; l<4; l++) operator()(icol,l) *= pivinv;
-       for (ll=0; ll<4; ll++)
+       for (l=0; l<4; ++l) operator()(icol,l) *= pivinv;
+       for (ll=0; ll<4; ++ll)
           if (ll != icol)
           {
              dum=operator()(ll,icol);
              operator()(ll,icol) = 0;
-             for (l=0; l<4; l++) operator()(ll,l) -= operator()(icol,l)*dum;
+             for (l=0; l<4; ++l) operator()(ll,l) -= operator()(icol,l)*dum;
           }
     }
     for (int lx=4; lx>0; --lx)

--- a/src/osgWrappers/serializers/osg/BufferIndexBinding.cpp
+++ b/src/osgWrappers/serializers/osg/BufferIndexBinding.cpp
@@ -1,0 +1,86 @@
+#include <osg/BufferIndexBinding>
+#include <osg/BufferObject>
+#include <osgDB/ObjectWrapper>
+#include <osgDB/InputStream>
+#include <osgDB/OutputStream>
+
+#define ADD_GLUINT_SERIALIZER(PROP, DEF) \
+    wrapper->addSerializer( new osgDB::PropByValSerializer< MyClass, GLuint >( \
+        #PROP, ((unsigned int)(DEF)), &MyClass::get##PROP, &MyClass::set##PROP), osgDB::BaseSerializer::RW_UINT )
+
+#define GLsizei_ptrSERIALIZER(TYPE,XXX) \
+static bool check##XXX( const TYPE& node )\
+{    return node.get##XXX()>0;}\
+static bool read##XXX( osgDB::InputStream& is, TYPE& node )\
+{\
+    unsigned int size = 0; is >> size ;    node.set##XXX(size);    return true;\
+}\
+static bool write##XXX( osgDB::OutputStream& os, const TYPE& node )\
+{\
+    unsigned int size = node.get##XXX();    os << size << std::endl;    return true;\
+}
+
+GLsizei_ptrSERIALIZER(osg::BufferIndexBinding,Size)
+GLsizei_ptrSERIALIZER(osg::BufferIndexBinding,Offset)
+
+
+namespace wrap_osgBufferIndexBinding
+{
+
+REGISTER_OBJECT_WRAPPER( BufferIndexBinding,
+                         /*new osg::BufferIndexBinding*/NULL,
+                         osg::BufferIndexBinding,
+                         "osg::Object osg::StateAttribute osg::BufferIndexBinding" )
+{
+
+    ADD_GLENUM_SERIALIZER( Target,GLenum, GL_BUFFER);  // _target
+    ADD_OBJECT_SERIALIZER( BufferData, osg::BufferData, NULL );  // _bufferObject
+    ADD_GLUINT_SERIALIZER( Index, 0);  // _index
+
+    ADD_USER_SERIALIZER(Size);
+    ADD_USER_SERIALIZER(Offset);
+}
+}
+namespace wrap_osgUniformBufferBinding
+{
+
+REGISTER_OBJECT_WRAPPER( UniformBufferBinding,
+                         new osg::UniformBufferBinding,
+                         osg::UniformBufferBinding,
+                         "osg::Object osg::StateAttribute osg::BufferIndexBinding osg::UniformBufferBinding" )
+{
+}
+}
+namespace wrap_osgTransformFeedbackBufferBinding
+{
+
+REGISTER_OBJECT_WRAPPER( TransformFeedbackBufferBinding,
+                         new osg::TransformFeedbackBufferBinding,
+                         osg::TransformFeedbackBufferBinding,
+                         "osg::Object osg::StateAttribute osg::BufferIndexBinding osg::TransformFeedbackBufferBinding" )
+{
+}
+}
+
+namespace wrap_osgAtomicCounterBufferBinding
+{
+
+REGISTER_OBJECT_WRAPPER( AtomicCounterBufferBinding,
+                         new osg::AtomicCounterBufferBinding,
+                         osg::AtomicCounterBufferBinding,
+                         "osg::Object osg::StateAttribute osg::BufferIndexBinding osg::AtomicCounterBufferBinding" )
+{
+}
+}
+namespace wrap_osgShaderStorageBufferBinding
+{
+
+REGISTER_OBJECT_WRAPPER( ShaderStorageBufferBinding,
+                         new osg::ShaderStorageBufferBinding,
+                         osg::ShaderStorageBufferBinding,
+                         "osg::Object osg::StateAttribute osg::BufferIndexBinding osg::ShaderStorageBufferBinding" )
+{
+}
+}
+
+


### PR DESCRIPTION
1) change the design of BufferIndexBinding to work with BufferData instead of BufferObject: it's more consistent with the rest of osg, allow user to bind bufferdata relative stuff, and further it allow serialization

2) add 2 methods: transpose (4x4 transpose) and transpose3x3 (orthogonal part of a mat4x4)
