### PR TITLE
fix gcc/VC compile warnings, reject color mapped tga files with missing colormap.

### DIFF
--- a/src/osgPlugins/tga/ReaderWriterTGA.cpp
+++ b/src/osgPlugins/tga/ReaderWriterTGA.cpp
@@ -273,8 +273,8 @@ int *numComponents_ret)
     int flags;
     int format;
     unsigned char *colormap;
-    int colormapLen;
-    int indexsize;
+    int colormapLen = 0;
+    int indexsize = 0;
     int rleIsCompressed;
     int rleRemaining;
     int rleEntrySize;
@@ -360,6 +360,10 @@ int *numComponents_ret)
     {
         case 1:                  /* colormap, uncompressed */
         {
+            if (colormapLen == 0 || indexsize == 0) {
+                tgaerror = ERR_UNSUPPORTED; /* colormap missing or empty */
+                return NULL;
+            }
             unsigned char * formattedMap = new unsigned char[colormapLen * format];
             for (int i = 0; i < colormapLen; i++)
             {
@@ -395,7 +399,7 @@ int *numComponents_ret)
                         break;
                     default:
                         tgaerror = ERR_UNSUPPORTED;
-                        break;
+                        return NULL; /* unreachable code - (depth < 1 || depth > 4) rejected by "check for reasonable values in case this is not a tga file" near the start of this function*/
                     }
 
                     int adjustedX = bLeftToRight ? x : (width - 1) - x;


### PR DESCRIPTION
Hi Robert,
The pr:
Add support for type-1 (colour-mapped, uncompressed) targa images to … #306 by "AnyOldName3"
cause a few compiler warnings both by gcc and Visual Studio:
/home/travis/build/openscenegraph/OpenSceneGraph/src/osgPlugins/tga/ReaderWriterTGA.cpp: In function ‘unsigned char* simage_tga_load(std::istream&, int*, int*, int*)’:
/home/travis/build/openscenegraph/OpenSceneGraph/src/osgPlugins/tga/ReaderWriterTGA.cpp:366:75: warning: ‘indexsize’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                 convert_data(colormap, formattedMap, i, indexsize, format);
                                                                           ^
/home/travis/build/openscenegraph/OpenSceneGraph/src/osgPlugins/tga/ReaderWriterTGA.cpp:364:13: warning: ‘colormapLen’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             for (int i = 0; i < colormapLen; i++)

116>e:\osg\35\laurens\openscenegraph\src\osgplugins\tga\readerwritertga.cpp(363): warning C4701: potentially uninitialized local variable 'colormapLen' used
116>e:\osg\35\laurens\openscenegraph\src\osgplugins\tga\readerwritertga.cpp(366): warning C4701: potentially uninitialized local variable 'indexsize' used
116>e:\osg\35\laurens\openscenegraph\src\osgplugins\tga\readerwritertga.cpp(403): warning C4701: potentially uninitialized local variable 'index' used

After looking up the tga file format I found that this could actually be triggered by an invalid tga file with no colormap OR a valid tga with an unknown colormap type (not type 1). 
I adjusted the code to remove the compile warnings and return ERR_UNSUPPORTED in the unhandled cases.
Regards, Laurens.