### PR TITLE
Fix Emscripten build errors

### DIFF
--- a/examples/osgemscripten/CMakeLists.txt
+++ b/examples/osgemscripten/CMakeLists.txt
@@ -9,8 +9,11 @@ SET(EGL_LIBRARY "GL" CACHE STRING "Suppress linkage error")
 SET(OSG_GL1_AVAILABLE OFF CACHE BOOL "Unavailable under Emscripten")
 SET(OSG_GL2_AVAILABLE OFF CACHE BOOL "Unavailable under Emscripten")
 SET(OSG_GLES2_AVAILABLE ON CACHE BOOL "GLES2 is what Emscripten uses")
+SET(OSG_WINDOWING_SYSTEM "None" CACHE STRING "Unavailable under Emscripten")
 SET(DYNAMIC_OPENTHREADS OFF CACHE BOOL "Link OpenThreads statically")
 SET(DYNAMIC_OPENSCENEGRAPH OFF CACHE BOOL "Link OpenSceneGraph statically")
+# Prevent CMake configuration error.
+SET(_OPENTHREADS_ATOMIC_USE_GCC_BUILTINS_EXITCODE "0" CACHE STRING "Prevent cfg error")
 # Reference SDL2 during build process.
 # We use SDL2 to do the following:
 # * OpenGL functions' address retrieval


### PR DESCRIPTION
Without the fix there are the following errors with `osgemscripten` example:

* OSG_WINDOWING_SYSTEM is incorrectly detected as X11, which doesn't compile under Emscripten
* CMake configuration error prevents the first configuration round, so one has to reconfigure to suppress the error

This fix removes both problems.