### PR TITLE
osg::Program::isFixedFunction() should'nt return true if fixed function unavailable

### DIFF
--- a/src/osg/Program.cpp
+++ b/src/osg/Program.cpp
@@ -633,10 +633,14 @@ Program::PerContextProgram* Program::getPCP(State& state) const
 
 bool Program::isFixedFunction() const
 {
+#ifdef OSG_GL_FIXED_FUNCTION_AVAILABLE
     // A Program object having no attached Shaders is a special case:
     // it indicates that programmable shading is to be disabled,
     // and thus use GL 1.x "fixed functionality" rendering.
     return _shaderList.empty();
+#else
+    return false;
+#endif
 }
 
 


### PR DESCRIPTION
I ran into an issue where osg::Program::isFixedFunction() was called with openGL CoreProfile used and without fixed function available. I believe that this method shouldn't return true if fixed function is unavailable, even if _shaderList.empty() is true.