### PR TITLE
Under macOS the glValidateProgram reports too many errors 

### DIFF
--- a/src/osg/Program.cpp
+++ b/src/osg/Program.cpp
@@ -517,9 +517,10 @@ void Program::apply( osg::State& state ) const
         // for shader debugging: to minimize performance impact,
         // optionally validate based on notify level.
         // TODO: enable this using notify level, or perhaps its own getenv()?
+#ifndef __APPLE__
         if( osg::isNotifyEnabled(osg::INFO) )
             pcp->validateProgram();
-
+#endif
         pcp->useProgram();
         state.setLastAppliedProgramObject(pcp);
     }


### PR DESCRIPTION
Under macOS the glValidateProgram reports too many false negatives (errors) about missing buffers, etc..

From the internet https://stackoverflow.com/questions/15335510/opengl-glvalidateprogram-error-on-mac-os-x :
« […] The purpose of glValidateProgram is not to use it as an added "check" step after linking the program, because the GL and application state is hardly ready for actually using that program at this point, probably it's even before we get around to initializing the default framebuffer (its bitdepth, its multisample buffers, etc), and that's what the error hints at.

An appropriate place to call glValidateProgram would be right before you make a real render call. »