### PR TITLE
LineSegmentIntersector: respect the 'cullingActive' flag for bounding box check

### DIFF
--- a/src/osgUtil/LineSegmentIntersector.cpp
+++ b/src/osgUtil/LineSegmentIntersector.cpp
@@ -500,7 +500,7 @@ void LineSegmentIntersector::intersect(osgUtil::IntersectionVisitor& iv, osg::Dr
     if (reachedLimit()) return;
 
     osg::Vec3d s(_start), e(_end);
-    if ( !intersectAndClip( s, e, drawable->getBoundingBox() ) ) return;
+    if ( drawable->isCullingActive() && !intersectAndClip( s, e, drawable->getBoundingBox() ) ) return;
 
     if (iv.getDoDummyTraversal()) return;
 


### PR DESCRIPTION
For some reason the LineSegmentIntersector was checking this flag when testing bounding spheres, but not for bounding boxes. This inconsistency has been fixed to check the flag in both cases, just like the cull visitor does.