### PR TITLE
obj write support for drawables

### DIFF
--- a/src/osgPlugins/obj/OBJWriterNodeVisitor.cpp
+++ b/src/osgPlugins/obj/OBJWriterNodeVisitor.cpp
@@ -571,5 +571,17 @@ void OBJWriterNodeVisitor::apply( osg::Geode &node )
     _nameStack.pop_back();
 }
 
+void OBJWriterNodeVisitor::apply(osg::Drawable& drawable)
+{
+   osg::Geometry* g = drawable.asGeometry();
+   if (g)
+   {
+      pushStateSet(g->getStateSet());
 
+      osg::Matrix m = osg::computeLocalToWorld(getNodePath());
+      processGeometry(g, m);
+
+      popStateSet(g->getStateSet());
+   }
+}
 

--- a/src/osgPlugins/obj/OBJWriterNodeVisitor.h
+++ b/src/osgPlugins/obj/OBJWriterNodeVisitor.h
@@ -66,6 +66,7 @@ class OBJWriterNodeVisitor: public osg::NodeVisitor {
         }
 
         virtual void apply(osg::Geode &node);
+        virtual void apply(osg::Drawable &drawable);
 
         virtual void apply(osg::Group &node)
         {


### PR DESCRIPTION
obj plugin: added write support for Drawables directly attached to the graph.
The current implementation only support Drawables atteched to Geodes.