### PR TITLE
tellg call removed from StreamOperator's checkStream function, becaus…

### DIFF
--- a/src/osgDB/StreamOperator.cpp
+++ b/src/osgDB/StreamOperator.cpp
@@ -16,20 +16,13 @@
 
 using namespace osgDB;
 
-static long long prev_tellg = 0;
-
 void InputIterator::checkStream() const
 {
     if (_in->rdstate()&_in->failbit)
     {
         OSG_NOTICE<<"InputIterator::checkStream() : _in->rdstate() "<<_in->rdstate()<<", "<<_in->failbit<<std::endl;
         OSG_NOTICE<<"                               _in->tellg() = "<<_in->tellg()<<std::endl;
-        OSG_NOTICE<<"                               prev_tellg = "<<prev_tellg<<std::endl;
         _failed = true;
-    }
-    else
-    {
-        prev_tellg = _in->tellg();
     }
 }
 


### PR DESCRIPTION
…e reading of files (readNodeFile etc.) with tellg on 'every iter' is approximately 100 times slower on Emscripten platform