### PR TITLE
Fix loading of 16bit PNG images

### DIFF
--- a/src/osgPlugins/png/ReaderWriterPNG.cpp
+++ b/src/osgPlugins/png/ReaderWriterPNG.cpp
@@ -307,6 +307,18 @@ class ReaderWriterPNG : public osgDB::ReaderWriter
                     pixelFormat = GL_RGBA;
 
                 int internalFormat = pixelFormat;
+                if (depth > 8)
+                {
+                    switch(color)
+                    {
+                      case(GL_LUMINANCE): internalFormat = GL_LUMINANCE16; break;
+                      case(GL_ALPHA): internalFormat = GL_ALPHA16; break;
+                      case(GL_LUMINANCE_ALPHA): internalFormat = GL_LUMINANCE16_ALPHA16; break;
+                      case(GL_RGB): internalFormat = GL_RGB16; break;
+                      case(GL_RGBA): internalFormat = GL_RGBA16; break;
+                      default: break;
+                    }
+                }
 
                 png_destroy_read_struct(&png, &info, &endinfo);
 


### PR DESCRIPTION
When a 16bit PNG image is loaded, the internalTextureFormat is set to unsized (i.e pixelFormat) constant. This results in 8 Bit Texture2D, which is not expected.