### PR TITLE
fix normalization bug (happen too early )

### DIFF
--- a/include/osgAnimation/RigTransformSoftware
+++ b/include/osgAnimation/RigTransformSoftware
@@ -124,6 +124,7 @@ namespace osgAnimation
                     accummulateMatrix(invBindMatrix, matrix, w);
                 }
             }
+            void normalize();
             inline const osg::Matrix& getMatrix() const { return _result;}
         protected:
             BonePtrWeightList _boneweights;


### PR DESCRIPTION
not sure if this bug  affects master too ...
if a bone is not found in the bone map it's removed but vertexggroup is not normalized after that 