### PR TITLE
Fix pragma shader composition when shader source contains windows lin…

### DIFF
--- a/src/osg/Shader.cpp
+++ b/src/osg/Shader.cpp
@@ -19,6 +19,7 @@
  *         Holger Helmich 2010-10-21
 */
 
+#include <algorithm>
 #include <fstream>
 #include <list>
 #include <sstream>
@@ -688,6 +689,8 @@ void Shader::PerContextShader::compileShader(osg::State& state)
     }
     else
     {
+        // Remove \r from windows line endings
+        source.erase(std::remove_if(source.begin(), source.end(), EqualTo('\r')), source.end());
 
         std::string versionLine;
         unsigned int lineNum = 0;
@@ -695,7 +698,7 @@ void Shader::PerContextShader::compileShader(osg::State& state)
         do
         {
             std::string::size_type start_of_line = find_first(source, NoneOf(" \t"), previous_pos);
-            std::string::size_type end_of_line = (start_of_line != std::string::npos) ? find_first(source, OneOf("\n\r"), start_of_line) : std::string::npos;
+            std::string::size_type end_of_line = (start_of_line != std::string::npos) ? find_first(source, EqualTo('\n'), start_of_line) : std::string::npos;
             if (end_of_line != std::string::npos)
             {
                 // OSG_NOTICE<<"A Checking line "<<lineNum<<" ["<<source.substr(start_of_line, end_of_line-start_of_line)<<"]"<<std::endl;

--- a/src/osg/Shader.cpp
+++ b/src/osg/Shader.cpp
@@ -89,6 +89,20 @@ struct NoneOf
     const char* _str;
 };
 
+// Replaces all occurrences of "from" with the contents of "to"
+// It does only one pass, i.e. new matches created in a position before the current match are not replaced
+std::string replaceAll(const std::string& str, const std::string& from, const std::string& to)
+{
+    std::string result = str;
+    std::string::size_type pos = 0;
+    while ((pos = result.find(from, pos)) != std::string::npos)
+    {
+        result.replace(pos, from.length(), to);
+        pos += to.length();
+    }
+    return result;
+}
+
 }
 
 using namespace osg;
@@ -689,8 +703,8 @@ void Shader::PerContextShader::compileShader(osg::State& state)
     }
     else
     {
-        // Remove \r from windows line endings
-        source.erase(std::remove_if(source.begin(), source.end(), EqualTo('\r')), source.end());
+        // Convert all windows line endings to \n
+        source = replaceAll(source, "\r\n", "\n");
 
         std::string versionLine;
         unsigned int lineNum = 0;
@@ -698,7 +712,7 @@ void Shader::PerContextShader::compileShader(osg::State& state)
         do
         {
             std::string::size_type start_of_line = find_first(source, NoneOf(" \t"), previous_pos);
-            std::string::size_type end_of_line = (start_of_line != std::string::npos) ? find_first(source, EqualTo('\n'), start_of_line) : std::string::npos;
+            std::string::size_type end_of_line = (start_of_line != std::string::npos) ? find_first(source, OneOf("\n\r"), start_of_line) : std::string::npos;
             if (end_of_line != std::string::npos)
             {
                 // OSG_NOTICE<<"A Checking line "<<lineNum<<" ["<<source.substr(start_of_line, end_of_line-start_of_line)<<"]"<<std::endl;


### PR DESCRIPTION
…e endings

There was a bug separating the "#version X" line when the shader source code
contained windows line endings. The produced shader code contained single '\r'
characters which failed to compile in the OpenGL driver (at least on nvidia).
The fix unifies line endings to single '\n' character at the beginning of the
parsing.

The target branch is 3.4, a similar fix can be applied to master.

Addresses issue #360. 