### PR TITLE
Add a flag to manage the inertia on camera from user code.

### DIFF
--- a/include/osgGA/StandardManipulator
+++ b/include/osgGA/StandardManipulator
@@ -84,6 +84,14 @@ class OSGGA_EXPORT StandardManipulator : public CameraManipulator
         virtual bool handle( const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& us );
         virtual void getUsage( osg::ApplicationUsage& usage ) const;
 
+		/** Sets inertia available or not when a mouse button is released.*/
+		inline void setInertia( bool inertia );
+
+		/** Gets the state of the inertia when a mouse button is released.
+			true to keep motion of the camera; false to stop motion when
+			the mouse button is released.*/
+		inline bool hasInertia() const ;
+
     protected:
 
         virtual bool handleFrame( const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& us );
@@ -168,12 +176,25 @@ class OSGGA_EXPORT StandardManipulator : public CameraManipulator
         inline void setRelativeFlag( int index, bool value );
         static int numRelativeFlagsAllocated;
         static int allocateRelativeFlag();
+
+		// inertia when a mouse button is released
+		bool _inertia;
 };
 
 
 //
 //  inline methods
 //
+
+inline void StandardManipulator::setInertia( bool inertia )
+{
+	_inertia = inertia;
+}
+
+inline bool StandardManipulator::hasInertia() const
+{
+	return _inertia;
+}
 
 inline bool StandardManipulator::getRelativeFlag( int index ) const
 {

--- a/src/osgGA/FirstPersonManipulator.cpp
+++ b/src/osgGA/FirstPersonManipulator.cpp
@@ -307,7 +307,7 @@ bool FirstPersonManipulator::performMovementLeftMouseButton( const double /*even
 
    rotateYawPitch( _rotation, dx, dy, localUp );
 
-   return true;
+   return hasInertia();
 }
 
 
@@ -326,7 +326,7 @@ bool FirstPersonManipulator::performMouseDeltaMovement( const float dx, const fl
 
       rotateYawPitch( _rotation, dx, dy );
 
-   return true;
+   return hasInertia();
 }
 
 

--- a/src/osgGA/FlightManipulator.cpp
+++ b/src/osgGA/FlightManipulator.cpp
@@ -227,19 +227,19 @@ bool FlightManipulator::performMovementLeftMouseButton( const double eventTimeDe
 {
     // pan model
     _velocity += eventTimeDelta * (_acceleration + _velocity);
-    return true;
+    return hasInertia();
 }
 
 
 bool FlightManipulator::performMovementMiddleMouseButton( const double /*eventTimeDelta*/, const double /*dx*/, const double /*dy*/ )
 {
     _velocity = 0.0f;
-    return true;
+    return hasInertia();
 }
 
 
 bool FlightManipulator::performMovementRightMouseButton( const double eventTimeDelta, const double /*dx*/, const double /*dy*/ )
 {
     _velocity -= eventTimeDelta * (_acceleration + _velocity);
-    return true;
+    return hasInertia();
 }

--- a/src/osgGA/NodeTrackerManipulator.cpp
+++ b/src/osgGA/NodeTrackerManipulator.cpp
@@ -278,7 +278,7 @@ bool NodeTrackerManipulator::performMovementLeftMouseButton( const double eventT
                          _ga_t1->getXnormalized(), _ga_t1->getYnormalized(),
                          getThrowScale( eventTimeDelta ) );
 
-    return true;
+    return hasInertia();
 }
 
 
@@ -289,7 +289,7 @@ bool NodeTrackerManipulator::performMovementMiddleMouseButton( const double /*ev
     osg::Quat nodeRotation;
     computeNodeCenterAndRotation(nodeCenter, nodeRotation);
 
-    return true;
+    return hasInertia();
 }
 
 

--- a/src/osgGA/OrbitManipulator.cpp
+++ b/src/osgGA/OrbitManipulator.cpp
@@ -284,7 +284,7 @@ bool OrbitManipulator::performMovementLeftMouseButton( const double eventTimeDel
         rotateTrackball( _ga_t0->getXnormalized(), _ga_t0->getYnormalized(),
                          _ga_t1->getXnormalized(), _ga_t1->getYnormalized(),
                          getThrowScale( eventTimeDelta ) );
-    return true;
+    return hasInertia();
 }
 
 
@@ -294,7 +294,7 @@ bool OrbitManipulator::performMovementMiddleMouseButton( const double eventTimeD
     // pan model
     float scale = -0.3f * _distance * getThrowScale( eventTimeDelta );
     panModel( dx*scale, dy*scale );
-    return true;
+    return hasInertia();
 }
 
 
@@ -303,7 +303,7 @@ bool OrbitManipulator::performMovementRightMouseButton( const double eventTimeDe
 {
     // zoom model
     zoomModel( dy * getThrowScale( eventTimeDelta ), true );
-    return true;
+    return hasInertia();
 }
 
 
@@ -315,7 +315,7 @@ bool OrbitManipulator::performMouseDeltaMovement( const float dx, const float dy
     else
         rotateTrackball( 0.f, 0.f, dx, dy, 1.f );
 
-    return true;
+    return hasInertia();
 }
 
 

--- a/src/osgGA/StandardManipulator.cpp
+++ b/src/osgGA/StandardManipulator.cpp
@@ -41,7 +41,8 @@ StandardManipulator::StandardManipulator( int flags )
       _modelSize( 0. ),
       _verticalAxisFixed( true ),
       _flags( flags ),
-      _relativeFlags( 0 )
+      _relativeFlags( 0 ),
+	  _inertia( true )
 {
 }
 
@@ -60,7 +61,8 @@ StandardManipulator::StandardManipulator( const StandardManipulator& uim, const 
       _modelSize( uim._modelSize ),
       _verticalAxisFixed( uim._verticalAxisFixed ),
       _flags( uim._flags ),
-      _relativeFlags( uim._relativeFlags )
+      _relativeFlags( uim._relativeFlags ),
+	  _inertia( true )
 {
 }
 
@@ -462,7 +464,7 @@ bool StandardManipulator::performMovement()
     This method implements movement for left mouse button.*/
 bool StandardManipulator::performMovementLeftMouseButton( const double /*eventTimeDelta*/, const double /*dx*/, const double /*dy*/ )
 {
-    return false;
+    return _inertia;
 }
 
 
@@ -471,7 +473,7 @@ bool StandardManipulator::performMovementLeftMouseButton( const double /*eventTi
     or combination of left and right mouse button pressed together.*/
 bool StandardManipulator::performMovementMiddleMouseButton( const double /*eventTimeDelta*/, const double /*dx*/, const double /*dy*/ )
 {
-    return false;
+    return _inertia;
 }
 
 
@@ -479,7 +481,7 @@ bool StandardManipulator::performMovementMiddleMouseButton( const double /*event
     This method implements movement for right mouse button.*/
 bool StandardManipulator::performMovementRightMouseButton( const double /*eventTimeDelta*/, const double /*dx*/, const double /*dy*/ )
 {
-    return false;
+    return _inertia;
 }
 
 
@@ -502,7 +504,7 @@ bool StandardManipulator::handleMouseDeltaMovement( const GUIEventAdapter& ea, G
 /// The method performs manipulator update based on relative mouse movement (mouse delta).
 bool StandardManipulator::performMouseDeltaMovement( const float /*dx*/, const float /*dy*/ )
 {
-   return false;
+   return _inertia;
 }
 
 

--- a/src/osgGA/TerrainManipulator.cpp
+++ b/src/osgGA/TerrainManipulator.cpp
@@ -297,7 +297,7 @@ bool TerrainManipulator::performMovementMiddleMouseButton( const double eventTim
         }
     }
 
-    return true;
+    return hasInertia();
 }
 
 
@@ -305,7 +305,7 @@ bool TerrainManipulator::performMovementRightMouseButton( const double eventTime
 {
     // zoom model
     zoomModel( dy * getThrowScale( eventTimeDelta ), false );
-    return true;
+    return hasInertia();
 }
 
 


### PR DESCRIPTION
A method is added to enable or disable the inertia applied on the camera when it is moved with the mouse.

Indeed, if the mouse is moved while a mouse button is pressed, the camera translates, rotates or zoom. If the mouse button is released while the mouse is still moved, the camera continues its previous transformation in a linear way (~inertia).

As this behavior may not be wanted in some applications, the inertia can be deactivated from user code thanks to this new method.

The default value of the inertia matches with the previous implementation of concrete camera manipulators for compatibility matter.