### PR TITLE
Removal of compiler warning for Cocoa builds

### DIFF
--- a/include/osgDB/DataTypes
+++ b/include/osgDB/DataTypes
@@ -134,7 +134,7 @@ public:
     : _name(copy._name), _indentDelta(copy._indentDelta) {}
 
     void set( const char* name, int delta=0 )
-    { _name = name, _indentDelta = delta; }
+    { _name = name; _indentDelta = delta; }
 
     std::string _name;
     int _indentDelta;

--- a/include/osgUtil/RenderLeaf
+++ b/include/osgUtil/RenderLeaf
@@ -52,8 +52,8 @@ class OSGUTIL_EXPORT RenderLeaf : public osg::Referenced
         {
             _parent = 0;
             _drawable = drawable;
-            _projection = projection,
-            _modelview = modelview,
+            _projection = projection;
+            _modelview = modelview;
             _depth = depth;
             _dynamic = (drawable->getDataVariance()==osg::Object::DYNAMIC);
             _traversalNumber = traversalNumber;

--- a/src/osgViewer/GraphicsWindowCarbon.cpp
+++ b/src/osgViewer/GraphicsWindowCarbon.cpp
@@ -1100,3 +1100,6 @@ public:
 REGISTER_WINDOWINGSYSTEMINTERFACE(Carbon, CarbonWindowingSystemInterface)
 
 }
+
+#endif
+

--- a/src/osgViewer/GraphicsWindowCocoa.mm
+++ b/src/osgViewer/GraphicsWindowCocoa.mm
@@ -199,7 +199,7 @@ static NSRect convertToQuartzCoordinates(const NSRect& rect)
 // the app-delegate, handling quit-requests
 // ----------------------------------------------------------------------------------------------------------
 
-@interface CocoaAppDelegate : NSObject
+@interface CocoaAppDelegate : NSObject <NSApplicationDelegate>
 {
 }
 


### PR DESCRIPTION
if protocol is not defined a compiler warning is raised with respect to line 1726:

`        [NSApp setDelegate: [[CocoaAppDelegate alloc] init] ];
`