### PR TITLE
use osg::maximum, not std::max

### DIFF
--- a/src/osgText/Glyph.cpp
+++ b/src/osgText/Glyph.cpp
@@ -88,7 +88,7 @@ int GlyphTexture::getTexelMargin(const Glyph* glyph)
     int height = glyph->t();
     int effect_margin = getEffectMargin(glyph);
 
-    int max_dimension = std::max(width, height) + 2 * effect_margin;
+    int max_dimension = osg::maximum(width, height) + 2 * effect_margin;
     int margin = osg::maximum(max_dimension/4, 2) + effect_margin;
 
     return margin;


### PR DESCRIPTION
Hi Robert,
std::max trips my VC2015 compile:
E:\osg\35\laurens\OpenSceneGraph\src\osgText\Glyph.cpp(91): error C2039: 'max': is not a member of 'std'
Regards, Laurens.