### PR TITLE
VAS "propertization": a possible road to VAS-less drawable

### DIFF
--- a/examples/osgcomputeshaders/osgcomputeshaders.cpp
+++ b/examples/osgcomputeshaders/osgcomputeshaders.cpp
@@ -63,7 +63,7 @@ int main( int argc, char** argv )
     // Create a node for outputting to the texture.
     // It is OK to have just an empty node here, but seems inbuilt uniforms like osg_FrameTime won't work then.
     // TODO: maybe we can have a custom drawable which also will implement glMemoryBarrier?
-    osg::ref_ptr<osg::Node> sourceNode = osgDB::readRefNodeFile("axes.osgt");
+    osg::ref_ptr<osg::Node> sourceNode = 0;//osgDB::readRefNodeFile("axes.osgt");
     if ( !sourceNode ) sourceNode = new osg::ComputeDispatch( 512/16, 512/16, 1 );
     sourceNode->setDataVariance( osg::Object::DYNAMIC );
     sourceNode->getOrCreateStateSet()->setAttributeAndModes( computeProg.get() );

--- a/examples/osgcomputeshaders/osgcomputeshaders.cpp
+++ b/examples/osgcomputeshaders/osgcomputeshaders.cpp
@@ -20,7 +20,7 @@
 // This example can work only if GL version is 4.3 or greater
 
 #include <osg/Texture2D>
-#include <osg/Geometry>
+#include <osg/ComputeDispatch>
 #include <osg/Geode>
 #include <osgDB/ReadFile>
 #include <osgGA/StateSetManipulator>
@@ -64,7 +64,7 @@ int main( int argc, char** argv )
     // It is OK to have just an empty node here, but seems inbuilt uniforms like osg_FrameTime won't work then.
     // TODO: maybe we can have a custom drawable which also will implement glMemoryBarrier?
     osg::ref_ptr<osg::Node> sourceNode = osgDB::readRefNodeFile("axes.osgt");
-    if ( !sourceNode ) sourceNode = new osg::Node;
+    if ( !sourceNode ) sourceNode = new osg::ComputeDispatch( 512/16, 512/16, 1 );
     sourceNode->setDataVariance( osg::Object::DYNAMIC );
     sourceNode->getOrCreateStateSet()->setAttributeAndModes( computeProg.get() );
     sourceNode->getOrCreateStateSet()->addUniform( new osg::Uniform("targetTex", (int)0) );

--- a/include/osg/ComputeDispatch
+++ b/include/osg/ComputeDispatch
@@ -1,0 +1,47 @@
+/* -*-c++-*- OpenSceneGraph - Copyright (C) 1998-2014 Robert Osfield
+ * Copyright (C) 2017 Julien Valentin
+ *
+ * This library is open source and may be redistributed and/or modified under
+ * the terms of the OpenSceneGraph Public License (OSGPL) version 0.0 or
+ * (at your option) any later version.  The full license is in LICENSE file
+ * included with this distribution, and on the openscenegraph.org website.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * OpenSceneGraph Public License for more details.
+*/
+
+#ifndef OSG_COMPUTEDISPATCH
+#define OSG_COMPUTEDISPATCH 1
+
+#include <osg/Export>
+
+#include <osg/Geometry>
+
+namespace osg{
+    class OSG_EXPORT ComputeDispatch : public osg::Drawable
+    {
+        public:
+            ComputeDispatch(GLint numGroupsX=0, GLint numGroupsY=0, GLint numGroupsZ=0  ):
+                Drawable(),
+                _numGroupsX(numGroupsX),
+                _numGroupsY(numGroupsY),
+                _numGroupsZ(numGroupsZ)
+            {}
+
+            ComputeDispatch(const ComputeDispatch&,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY);
+
+            META_Node(osg, ComputeDispatch);
+
+
+            virtual void drawImplementation(RenderInfo& renderInfo) const;
+             /** Set/get compute shader work groups */
+            void setComputeGroups( GLint numGroupsX, GLint numGroupsY, GLint numGroupsZ ) { _numGroupsX=numGroupsX,_numGroupsY=numGroupsY, _numGroupsZ=numGroupsZ; }
+            void getComputeGroups( GLint& numGroupsX, GLint& numGroupsY, GLint& numGroupsZ ) const{ numGroupsX=_numGroupsX; numGroupsY=_numGroupsY; numGroupsZ=_numGroupsZ; }
+        protected:
+            GLint _numGroupsX, _numGroupsY, _numGroupsZ;
+
+    };
+}
+#endif

--- a/include/osg/Drawable
+++ b/include/osg/Drawable
@@ -280,6 +280,11 @@ class OSG_EXPORT Drawable : public Node
 
         virtual PerContextVertexArrayState* createVertexArrayState(RenderInfo& renderInfo) const;
 
+        /** set the vertex array state of this Drawable **/
+        void setVertexArrayState(VertexArrayState*vas) { _vas = vas; }
+
+        /** get the vertex array state of this Drawable **/
+        VertexArrayState* getVertexArrayState()const { return _vas; }
 
         /** Set whether to use a mutex to ensure ref() and unref() are thread safe.*/
         virtual void setThreadSafeRefUnref(bool threadSafe);
@@ -491,8 +496,7 @@ class OSG_EXPORT Drawable : public Node
         typedef osg::buffered_value<GLuint> GLObjectList;
         mutable GLObjectList    _globjList;
 
-        typedef buffered_object< osg::ref_ptr<PerContextVertexArrayState> > VertexArrayStateList;
-        mutable VertexArrayStateList    _vertexArrayStateList;
+        ref_ptr<VertexArrayState> _vas;
 
         ref_ptr<DrawCallback>   _drawCallback;
 };

--- a/include/osg/Drawable
+++ b/include/osg/Drawable
@@ -506,7 +506,7 @@ inline void Drawable::draw(RenderInfo& renderInfo) const
 {
     State& state = *renderInfo.getState();
     bool useVertexArrayObject = state.useVertexArrayObject(_useVertexArrayObject);
-    if (useVertexArrayObject)
+    if (useVertexArrayObject && _vas.valid() )
     {
         unsigned int contextID = renderInfo.getContextID();
 

--- a/include/osg/Drawable
+++ b/include/osg/Drawable
@@ -278,7 +278,7 @@ class OSG_EXPORT Drawable : public Node
         */
         virtual void compileGLObjects(RenderInfo& renderInfo) const;
 
-        virtual VertexArrayState* createVertexArrayState(RenderInfo& renderInfo) const;
+        virtual PerContextVertexArrayState* createVertexArrayState(RenderInfo& renderInfo) const;
 
 
         /** Set whether to use a mutex to ensure ref() and unref() are thread safe.*/
@@ -491,7 +491,7 @@ class OSG_EXPORT Drawable : public Node
         typedef osg::buffered_value<GLuint> GLObjectList;
         mutable GLObjectList    _globjList;
 
-        typedef buffered_object< osg::ref_ptr<VertexArrayState> > VertexArrayStateList;
+        typedef buffered_object< osg::ref_ptr<PerContextVertexArrayState> > VertexArrayStateList;
         mutable VertexArrayStateList    _vertexArrayStateList;
 
         ref_ptr<DrawCallback>   _drawCallback;

--- a/include/osg/Geometry
+++ b/include/osg/Geometry
@@ -233,7 +233,7 @@ class OSG_EXPORT Geometry : public Drawable
 
         bool                            _containsDeprecatedData;
 
-        virtual VertexArrayState* createVertexArrayState(RenderInfo& renderInfo) const;
+        virtual PerContextVertexArrayState* createVertexArrayState(RenderInfo& renderInfo) const;
 
     public:
 

--- a/include/osg/State
+++ b/include/osg/State
@@ -527,19 +527,19 @@ class OSG_EXPORT State : public Referenced
         /** Proxy helper class for applyig a VertexArrayState in a local scope, with the preivous value being resotred automatically on leaving the scope that proxy was created.*/
         struct SetCurrentVertexArrayStateProxy
         {
-            SetCurrentVertexArrayStateProxy(osg::State& state, VertexArrayState* vas):_state(state) { _state.setCurrentVertexArrayState(vas); }
-            ~SetCurrentVertexArrayStateProxy() { _state.setCurrentToGloabalVertexArrayState(); }
+            SetCurrentVertexArrayStateProxy(osg::State& state, PerContextVertexArrayState* vas):_state(state) { _state.setCurrentVertexArrayState(vas); }
+            ~SetCurrentVertexArrayStateProxy() { _state.setCurrentToGlobalVertexArrayState(); }
             osg::State& _state;
         };
 
         /** Set the CurrentVetexArrayState object that take which vertex arrays are bound.*/
-        void setCurrentVertexArrayState(VertexArrayState* vas) { _vas = vas; }
+        void setCurrentVertexArrayState(PerContextVertexArrayState* vas) { _vas = vas; }
 
         /** Get the CurrentVetexArrayState object that take which vertex arrays are bound.*/
-        VertexArrayState* getCurrentVertexArrayState() const { return _vas; }
+        PerContextVertexArrayState* getCurrentVertexArrayState() const { return _vas; }
 
         /** Set the getCurrentVertexArrayState to the GloabalVertexArrayState.*/
-        void setCurrentToGloabalVertexArrayState() { _vas = _globalVertexArrayState.get(); }
+        void setCurrentToGlobalVertexArrayState() { _vas = _globalVertexArrayState.get(); }
 
 
         /** disable the vertex, normal, color, tex coords, secondary color, fog coord and index arrays.*/
@@ -615,7 +615,7 @@ class OSG_EXPORT State : public Referenced
         void setCurrentVertexArrayObject(GLuint vao) { _currentVAO = vao; }
         GLuint getCurrentVertexArrayObject() const { return _currentVAO; }
 
-        inline void bindVertexArrayObject(const VertexArrayState* vas) { bindVertexArrayObject(vas->getVertexArrayObject()); }
+        inline void bindVertexArrayObject(const PerContextVertexArrayState* vas) { bindVertexArrayObject(vas->getVertexArrayObject()); }
 
         inline void bindVertexArrayObject(GLuint vao) { if (_currentVAO!=vao) { _glExtensions->glBindVertexArray(vao); _currentVAO = vao; } }
 
@@ -1068,8 +1068,8 @@ class OSG_EXPORT State : public Referenced
         GraphicsContext*            _graphicsContext;
         unsigned int                _contextID;
 
-        osg::ref_ptr<VertexArrayState>  _globalVertexArrayState;
-        VertexArrayState*               _vas;
+        osg::ref_ptr<PerContextVertexArrayState>  _globalVertexArrayState;
+        PerContextVertexArrayState*               _vas;
 
         bool                            _shaderCompositionEnabled;
         bool                            _shaderCompositionDirty;

--- a/include/osg/VertexArrayState
+++ b/include/osg/VertexArrayState
@@ -11,8 +11,8 @@
  * OpenSceneGraph Public License for more details.
 */
 
-#ifndef OSG_VertexArrayState
-#define OSG_VertexArrayState 1
+#ifndef OSG_PerContextVertexArrayState
+#define OSG_PerContextVertexArrayState 1
 
 #include <osg/Referenced>
 #include <osg/GLExtensions>
@@ -21,17 +21,18 @@
 
 namespace osg {
 
-class OSG_EXPORT VertexArrayState : public osg::Referenced
+class OSG_EXPORT PerContextVertexArrayState : public osg::Referenced
 {
 public:
 
-        VertexArrayState(osg::State* state);
+        PerContextVertexArrayState(osg::State* state, GLint basevertex = 0);
 
         struct ArrayDispatch : public osg::Referenced
         {
-            ArrayDispatch():
+            ArrayDispatch(GLint & base):
                 array(0),
                 modifiedCount(0xffffffff),
+                basevertex(base),
                 active(false) {}
 
             virtual const char* className() const = 0; // { return "ArrayDispatch"; }
@@ -52,13 +53,14 @@ public:
 
             const osg::Array*   array;
             unsigned int        modifiedCount;
+            GLint  &     basevertex;
             bool                active;
         };
 
         typedef std::vector< ref_ptr<ArrayDispatch> >       ArrayDispatchList;
 
-        void setCurrentVertexBufferObject(osg::GLBufferObject* vbo) { _currentVBO = vbo; }
-        GLBufferObject* getCurrentVertexBufferObject() { return _currentVBO; }
+        inline void setCurrentVertexBufferObject(osg::GLBufferObject* vbo) { _currentVBO = vbo; }
+        inline GLBufferObject* getCurrentVertexBufferObject() { return _currentVBO; }
 
         inline void bindVertexBufferObject(osg::GLBufferObject* vbo)
         {
@@ -82,8 +84,8 @@ public:
         }
 
 
-        void setCurrentElementBufferObject(osg::GLBufferObject* ebo) { _currentEBO = ebo; }
-        GLBufferObject* getCurrentElementBufferObject() { return _currentEBO; }
+        inline void setCurrentElementBufferObject(osg::GLBufferObject* ebo) { _currentEBO = ebo; }
+        inline GLBufferObject* getCurrentElementBufferObject() { return _currentEBO; }
 
         inline void bindElementBufferObject(osg::GLBufferObject* ebo)
         {
@@ -166,10 +168,10 @@ public:
 
         void deleteVertexArrayObject();
 
-        GLuint getVertexArrayObject() const { return _vertexArrayObject; }
-
+        inline GLuint getVertexArrayObject() const { return _vertexArrayObject; }
 
         void setRequiresSetArrays(bool flag) { _requiresSetArrays = flag; }
+
         bool getRequiresSetArrays() const { return _requiresSetArrays; }
 
         void dirty();
@@ -188,7 +190,6 @@ public:
 
         GLuint                          _vertexArrayObject;
 
-
         osg::ref_ptr<ArrayDispatch>     _vertexArray;
         osg::ref_ptr<ArrayDispatch>     _normalArray;
         osg::ref_ptr<ArrayDispatch>     _colorArray;
@@ -205,10 +206,11 @@ public:
         GLBufferObject*                 _currentEBO;
 
         bool                            _requiresSetArrays;
+        GLint _basevertex;
 };
 
 
-inline void VertexArrayState::lazyDisablingOfVertexAttributes()
+inline void PerContextVertexArrayState::lazyDisablingOfVertexAttributes()
 {
     _activeDispatchers.swap(_previous_activeDispatchers);
     _activeDispatchers.clear();
@@ -223,7 +225,7 @@ inline void VertexArrayState::lazyDisablingOfVertexAttributes()
     }
 }
 
-inline void VertexArrayState::applyDisablingOfVertexAttributes(osg::State& state)
+inline void PerContextVertexArrayState::applyDisablingOfVertexAttributes(osg::State& state)
 {
     for(ActiveDispatchers::iterator itr = _previous_activeDispatchers.begin();
         itr != _previous_activeDispatchers.end();
@@ -240,7 +242,7 @@ inline void VertexArrayState::applyDisablingOfVertexAttributes(osg::State& state
     _previous_activeDispatchers.clear();
 }
 
-inline void VertexArrayState::disableTexCoordArrayAboveAndIncluding(osg::State& state, unsigned int index)
+inline void PerContextVertexArrayState::disableTexCoordArrayAboveAndIncluding(osg::State& state, unsigned int index)
 {
     for(unsigned int i=index; i<_texCoordArrays.size(); ++i)
     {
@@ -248,7 +250,7 @@ inline void VertexArrayState::disableTexCoordArrayAboveAndIncluding(osg::State& 
     }
 }
 
-inline void VertexArrayState::disableVertexAttribArrayAboveAndIncluding(osg::State& state, unsigned int index)
+inline void PerContextVertexArrayState::disableVertexAttribArrayAboveAndIncluding(osg::State& state, unsigned int index)
 {
     for(unsigned int i=index; i<_vertexAttribArrays.size(); ++i)
     {
@@ -256,8 +258,21 @@ inline void VertexArrayState::disableVertexAttribArrayAboveAndIncluding(osg::Sta
     }
 }
 
+/// Per Context VAS container
+class OSG_EXPORT VertexArrayState : public osg::Object{
+public:
+META_Object(osg,VertexArrayState)
+    VertexArrayState();
+    ~VertexArrayState();
+    VertexArrayState(const VertexArrayState& val, const CopyOp& copyop = CopyOp::SHALLOW_COPY);
 
+    typedef buffered_object< osg::ref_ptr<PerContextVertexArrayState> > PerContextVertexArrayStateList;
 
+    inline  PerContextVertexArrayStateList& getPCVertexArrayStates()const{return  _pcvas;}
+
+protected:
+    mutable PerContextVertexArrayStateList _pcvas;
+};
 }
 
 #endif

--- a/include/osgParticle/ParticleSystem
+++ b/include/osgParticle/ParticleSystem
@@ -265,7 +265,7 @@ namespace osgParticle
           * for all graphics contexts. */
         virtual void releaseGLObjects(osg::State* state=0) const;
 
-        virtual osg::VertexArrayState* createVertexArrayState(osg::RenderInfo& renderInfo) const;
+        virtual osg::PerContextVertexArrayState* createVertexArrayState(osg::RenderInfo& renderInfo) const;
 
         void adjustEstimatedMaxNumOfParticles(int delta) {  _estimatedMaxNumOfParticles += delta; }
 

--- a/include/osgTerrain/GeometryPool
+++ b/include/osgTerrain/GeometryPool
@@ -66,7 +66,7 @@ class OSGTERRAIN_EXPORT SharedGeometry : public osg::Drawable
         const VertexToHeightFieldMapping& getVertexToHeightFieldMapping() const { return _vertexToHeightFieldMapping; }
 
 
-        osg::VertexArrayState* createVertexArrayState(osg::RenderInfo& renderInfo) const;
+        osg::PerContextVertexArrayState* createVertexArrayState(osg::RenderInfo& renderInfo) const;
 
         void compileGLObjects(osg::RenderInfo& renderInfo) const;
 

--- a/include/osgText/TextBase
+++ b/include/osgText/TextBase
@@ -295,7 +295,7 @@ protected:
 
     void initArraysAndBuffers();
 
-    osg::VertexArrayState* createVertexArrayState(osg::RenderInfo& renderInfo) const;
+    osg::PerContextVertexArrayState* createVertexArrayState(osg::RenderInfo& renderInfo) const;
 
     void positionCursor(const osg::Vec2 & endOfLine_coords, osg::Vec2 & cursor, unsigned int linelength);
     String::iterator computeLastCharacterOnLine(osg::Vec2& cursor, String::iterator first,String::iterator last);

--- a/src/osg/CMakeLists.txt
+++ b/src/osg/CMakeLists.txt
@@ -55,6 +55,7 @@ SET(TARGET_H
     ${HEADER_PATH}/ColorMaski
     ${HEADER_PATH}/ColorMatrix
     ${HEADER_PATH}/ComputeBoundsVisitor
+    ${HEADER_PATH}/ComputeDispatch
     ${HEADER_PATH}/ContextData
     ${HEADER_PATH}/ConvexPlanarOccluder
     ${HEADER_PATH}/ConvexPlanarPolygon
@@ -267,6 +268,7 @@ SET(TARGET_SRC
     ColorMaski.cpp
     ColorMatrix.cpp
     ComputeBoundsVisitor.cpp
+    ComputeDispatch.cpp
     ContextData.cpp
     ConvexPlanarOccluder.cpp
     ConvexPlanarPolygon.cpp

--- a/src/osg/ComputeDispatch.cpp
+++ b/src/osg/ComputeDispatch.cpp
@@ -1,0 +1,12 @@
+#include <osg/ComputeDispatch>
+using namespace osg;
+
+
+ComputeDispatch::ComputeDispatch(const ComputeDispatch&o,const osg::CopyOp& copyop): Drawable(o,copyop), _numGroupsX(o._numGroupsX), _numGroupsY(o._numGroupsY), _numGroupsZ(o._numGroupsZ)
+{
+
+}
+
+void ComputeDispatch::drawImplementation(RenderInfo& renderInfo) const{
+    renderInfo.getState()->get<GLExtensions>()->glDispatchCompute(_numGroupsX, _numGroupsY, _numGroupsZ);
+}

--- a/src/osg/Drawable.cpp
+++ b/src/osg/Drawable.cpp
@@ -331,7 +331,7 @@ void Drawable::releaseGLObjects(State* state) const
             }
         }
 
-        VertexArrayState* vas = contextID <_vertexArrayStateList.size() ? _vertexArrayStateList[contextID].get() : 0;
+        PerContextVertexArrayState* vas = contextID <_vertexArrayStateList.size() ? _vertexArrayStateList[contextID].get() : 0;
         if (vas)
         {
             vas->release();
@@ -453,7 +453,7 @@ void Drawable::dirtyGLObjects()
 
     for(i=0; i<_vertexArrayStateList.size(); ++i)
     {
-        VertexArrayState* vas = _vertexArrayStateList[i].get();
+        PerContextVertexArrayState* vas = _vertexArrayStateList[i].get();
         if (vas) vas->dirty();
     }
 }
@@ -630,7 +630,7 @@ void Drawable::draw(RenderInfo& renderInfo) const
     {
         unsigned int contextID = renderInfo.getContextID();
 
-        VertexArrayState* vas = _vertexArrayStateList[contextID].get();
+        PerContextVertexArrayState* vas = _vertexArrayStateList[contextID].get();
         if (!vas)
         {
             _vertexArrayStateList[contextID] = vas = createVertexArrayState(renderInfo);
@@ -696,9 +696,9 @@ void Drawable::draw(RenderInfo& renderInfo) const
 
 #endif
 
-VertexArrayState* Drawable::createVertexArrayState(RenderInfo& renderInfo) const
+PerContextVertexArrayState* Drawable::createVertexArrayState(RenderInfo& renderInfo) const
 {
-    VertexArrayState* vos = new osg::VertexArrayState(renderInfo.getState());
+    PerContextVertexArrayState* vos = new osg::PerContextVertexArrayState(renderInfo.getState());
     vos->assignAllDispatchers();
     return vos;
 }

--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -688,13 +688,13 @@ void Geometry::releaseGLObjects(State* state) const
 
     if (state)
     {
-        if (_vertexArrayStateList[state->getContextID()].valid())
+        if (_vas->getPCVertexArrayStates()[state->getContextID()].valid())
         {
-            _vertexArrayStateList[state->getContextID()]->release();
-            _vertexArrayStateList[state->getContextID()] = 0;
+            _vas->getPCVertexArrayStates()[state->getContextID()]->release();
+            _vas->getPCVertexArrayStates()[state->getContextID()] = 0;
         }
     }
-    else _vertexArrayStateList.clear();
+    else _vas->getPCVertexArrayStates().clear();
 
     ArrayList arrays;
     if (getArrayList(arrays))
@@ -724,7 +724,11 @@ PerContextVertexArrayState* Geometry::createVertexArrayState(RenderInfo& renderI
 {
     State& state = *renderInfo.getState();
 
-    PerContextVertexArrayState* vas = new osg::PerContextVertexArrayState(&state);
+    PerContextVertexArrayState* vas ;
+    if( vas = _vas->getPCVertexArrayStates()[state.getContextID()])
+        return vas;
+
+    _vas->getPCVertexArrayStates()[renderInfo.getContextID()] = vas = new osg::PerContextVertexArrayState(&state);
 
     // OSG_NOTICE<<"Creating new osg::VertexArrayState "<< vas<<std::endl;
 
@@ -815,7 +819,7 @@ void Geometry::compileGLObjects(RenderInfo& renderInfo) const
         {
             PerContextVertexArrayState* vas = 0;
 
-            _vertexArrayStateList[contextID] = vas = createVertexArrayState(renderInfo);
+            _vas->getPCVertexArrayStates()[contextID] = vas = createVertexArrayState(renderInfo);
 
             State::SetCurrentVertexArrayStateProxy setVASProxy(state, vas);
 

--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -720,11 +720,11 @@ void Geometry::releaseGLObjects(State* state) const
 
 }
 
-VertexArrayState* Geometry::createVertexArrayState(RenderInfo& renderInfo) const
+PerContextVertexArrayState* Geometry::createVertexArrayState(RenderInfo& renderInfo) const
 {
     State& state = *renderInfo.getState();
 
-    VertexArrayState* vas = new osg::VertexArrayState(&state);
+    PerContextVertexArrayState* vas = new osg::PerContextVertexArrayState(&state);
 
     // OSG_NOTICE<<"Creating new osg::VertexArrayState "<< vas<<std::endl;
 
@@ -813,7 +813,7 @@ void Geometry::compileGLObjects(RenderInfo& renderInfo) const
 
         if (state.useVertexArrayObject(_useVertexArrayObject))
         {
-            VertexArrayState* vas = 0;
+            PerContextVertexArrayState* vas = 0;
 
             _vertexArrayStateList[contextID] = vas = createVertexArrayState(renderInfo);
 
@@ -869,7 +869,7 @@ void Geometry::drawImplementation(RenderInfo& renderInfo) const
     if (usingVertexBufferObjects && !usingVertexArrayObjects)
     {
         // unbind the VBO's if any are used.
-        osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
+        osg::PerContextVertexArrayState* vas = state.getCurrentVertexArrayState();
         vas->unbindVertexBufferObject();
         vas->unbindElementBufferObject();
     }
@@ -880,7 +880,7 @@ void Geometry::drawImplementation(RenderInfo& renderInfo) const
 void Geometry::drawVertexArraysImplementation(RenderInfo& renderInfo) const
 {
     State& state = *renderInfo.getState();
-    VertexArrayState* vas = state.getCurrentVertexArrayState();
+    PerContextVertexArrayState* vas = state.getCurrentVertexArrayState();
 
     bool handleVertexAttributes = !_vertexAttribList.empty();
 

--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -29,6 +29,7 @@ Geometry::Geometry():
     _supportsVertexBufferObjects = true;
     _useVertexBufferObjects = false;
 #endif
+     _vas = new osg::VertexArrayState();
 }
 
 Geometry::Geometry(const Geometry& geometry,const CopyOp& copyop):

--- a/src/osg/Program.cpp
+++ b/src/osg/Program.cpp
@@ -1108,8 +1108,4 @@ Program::ProgramBinary* Program::PerContextProgram::compileProgramBinary(osg::St
 void Program::PerContextProgram::useProgram() const
 {
     _extensions->glUseProgram( _glProgramHandle  );
-    if ( _program->_numGroupsX>0 && _program->_numGroupsY>0 && _program->_numGroupsZ>0 )
-    {
-        _extensions->glDispatchCompute( _program->_numGroupsX, _program->_numGroupsY, _program->_numGroupsZ );
-    }
 }

--- a/src/osg/State.cpp
+++ b/src/osg/State.cpp
@@ -207,11 +207,11 @@ void State::initializeExtensionProcs()
 
 
     // Set up up global VertexArrayState object
-    _globalVertexArrayState = new VertexArrayState(this);
+    _globalVertexArrayState = new PerContextVertexArrayState(this);
     _globalVertexArrayState->assignAllDispatchers();
     // if (_useVertexArrayObject) _globalVertexArrayState->generateVertexArrayObject();
 
-    setCurrentToGloabalVertexArrayState();
+    setCurrentToGlobalVertexArrayState();
 
 
     setGLExtensionFuncPtr(_glClientActiveTexture,"glClientActiveTexture","glClientActiveTextureARB");

--- a/src/osgParticle/ParticleSystem.cpp
+++ b/src/osgParticle/ParticleSystem.cpp
@@ -60,6 +60,7 @@ osgParticle::ParticleSystem::ParticleSystem()
     // we don't support display lists because particle systems
     // are dynamic, and they always changes between frames
     setSupportsDisplayList(false);
+    _vas = new osg::VertexArrayState();
 }
 
 osgParticle::ParticleSystem::ParticleSystem(const ParticleSystem& copy, const osg::CopyOp& copyop)

--- a/src/osgParticle/ParticleSystem.cpp
+++ b/src/osgParticle/ParticleSystem.cpp
@@ -657,11 +657,11 @@ void osgParticle::ParticleSystem::releaseGLObjects(osg::State* state) const
     }
 }
 
-osg::VertexArrayState* osgParticle::ParticleSystem::createVertexArrayState(osg::RenderInfo& renderInfo) const
+osg::PerContextVertexArrayState* osgParticle::ParticleSystem::createVertexArrayState(osg::RenderInfo& renderInfo) const
 {
     osg::State& state = *renderInfo.getState();
 
-    osg::VertexArrayState* vas = new osg::VertexArrayState(&state);
+    osg::PerContextVertexArrayState* vas = new osg::PerContextVertexArrayState(&state);
 
     vas->assignVertexArrayDispatcher();
     vas->assignNormalArrayDispatcher();
@@ -794,7 +794,7 @@ void osgParticle::ParticleSystem::ArrayData::dirty()
 
 void osgParticle::ParticleSystem::ArrayData::dispatchArrays(osg::State& state)
 {
-    osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
+    osg::PerContextVertexArrayState* vas = state.getCurrentVertexArrayState();
 
     vas->lazyDisablingOfVertexAttributes();
 

--- a/src/osgTerrain/GeometryPool.cpp
+++ b/src/osgTerrain/GeometryPool.cpp
@@ -858,7 +858,7 @@ void SharedGeometry::compileGLObjects(osg::RenderInfo& renderInfo) const
 
             osg::PerContextVertexArrayState* vas = 0;
 
-            _vertexArrayStateList[contextID] = vas = createVertexArrayState(renderInfo);
+            _vas->getPCVertexArrayStates()[contextID] = vas = createVertexArrayState(renderInfo);
 
             // OSG_NOTICE<<"  setting up VertexArrayObject "<<vas<<std::endl;
 

--- a/src/osgTerrain/GeometryPool.cpp
+++ b/src/osgTerrain/GeometryPool.cpp
@@ -778,6 +778,7 @@ SharedGeometry::SharedGeometry()
 {
     setSupportsDisplayList(false);
     _supportsVertexBufferObjects = true;
+     _vas = new osg::VertexArrayState();
 }
 
 SharedGeometry::SharedGeometry(const SharedGeometry& rhs,const osg::CopyOp& copyop):

--- a/src/osgTerrain/GeometryPool.cpp
+++ b/src/osgTerrain/GeometryPool.cpp
@@ -796,13 +796,13 @@ SharedGeometry::~SharedGeometry()
 {
 }
 
-osg::VertexArrayState* SharedGeometry::createVertexArrayState(osg::RenderInfo& renderInfo) const
+osg::PerContextVertexArrayState* SharedGeometry::createVertexArrayState(osg::RenderInfo& renderInfo) const
 {
     osg::State& state = *renderInfo.getState();
 
-    osg::VertexArrayState* vas = new osg::VertexArrayState(&state);
+    osg::PerContextVertexArrayState* vas = new osg::PerContextVertexArrayState(&state);
 
-    // OSG_NOTICE<<"Creating new osg::VertexArrayState "<< vas<<std::endl;
+    // OSG_NOTICE<<"Creating new osg::PerContextVertexArrayState "<< vas<<std::endl;
 
     if (_vertexArray.valid()) vas->assignVertexArrayDispatcher();
     if (_colorArray.valid()) vas->assignColorArrayDispatcher();
@@ -811,13 +811,13 @@ osg::VertexArrayState* SharedGeometry::createVertexArrayState(osg::RenderInfo& r
 
     if (state.useVertexArrayObject(_useVertexArrayObject))
     {
-        // OSG_NOTICE<<"  Setup VertexArrayState to use VAO "<<vas<<std::endl;
+        // OSG_NOTICE<<"  Setup PerContextVertexArrayState to use VAO "<<vas<<std::endl;
 
         vas->generateVertexArrayObject();
     }
     else
     {
-        // OSG_NOTICE<<"  Setup VertexArrayState to without using VAO "<<vas<<std::endl;
+        // OSG_NOTICE<<"  Setup PerContextVertexArrayState to without using VAO "<<vas<<std::endl;
     }
 
     return vas;
@@ -856,7 +856,7 @@ void SharedGeometry::compileGLObjects(osg::RenderInfo& renderInfo) const
         if (state.useVertexArrayObject(_useVertexArrayObject))
         {
 
-            osg::VertexArrayState* vas = 0;
+            osg::PerContextVertexArrayState* vas = 0;
 
             _vertexArrayStateList[contextID] = vas = createVertexArrayState(renderInfo);
 
@@ -907,7 +907,7 @@ void SharedGeometry::drawImplementation(osg::RenderInfo& renderInfo) const
     // OSG_NOTICE<<"SharedGeometry::drawImplementation "<<computeDiagonals<<std::endl;
 
     osg::State& state = *renderInfo.getState();
-    osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
+    osg::PerContextVertexArrayState* vas = state.getCurrentVertexArrayState();
 
 
     // state.checkGLErrors("Before SharedGeometry::drawImplementation.");

--- a/src/osgText/Text.cpp
+++ b/src/osgText/Text.cpp
@@ -1119,7 +1119,7 @@ void Text::drawImplementationSinglePass(osg::State& state, const osg::Vec4& colo
 {
     if (colorMultiplier.a()==0.0f || _color.a()==0.0f) return;
 
-    osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
+    osg::PerContextVertexArrayState* vas = state.getCurrentVertexArrayState();
     bool usingVertexBufferObjects = state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects);
     bool usingVertexArrayObjects = usingVertexBufferObjects && state.useVertexArrayObject(_useVertexArrayObject);
     bool requiresSetArrays = !usingVertexBufferObjects || !usingVertexArrayObjects || vas->getRequiresSetArrays();
@@ -1199,7 +1199,7 @@ void Text::drawImplementation(osg::State& state, const osg::Vec4& colorMultiplie
 
     state.Normal(_normal.x(), _normal.y(), _normal.z());
 
-    osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
+    osg::PerContextVertexArrayState* vas = state.getCurrentVertexArrayState();
     bool usingVertexBufferObjects = state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects);
     bool usingVertexArrayObjects = usingVertexBufferObjects && state.useVertexArrayObject(_useVertexArrayObject);
     bool requiresSetArrays = !usingVertexBufferObjects || !usingVertexArrayObjects || vas->getRequiresSetArrays();

--- a/src/osgText/Text.cpp
+++ b/src/osgText/Text.cpp
@@ -59,6 +59,7 @@ Text::Text():
     }
 
     assignStateSet();
+    _vas = new osg::VertexArrayState();
 }
 
 Text::Text(const Text& text,const osg::CopyOp& copyop):

--- a/src/osgText/Text3D.cpp
+++ b/src/osgText/Text3D.cpp
@@ -22,6 +22,7 @@ Text3D::Text3D():
     _renderMode(PER_GLYPH)
 {
     _glyphNormalized = true;
+     _vas = new osg::VertexArrayState();
 }
 
 Text3D::Text3D(const Text3D & text3D, const osg::CopyOp & copyop):

--- a/src/osgText/Text3D.cpp
+++ b/src/osgText/Text3D.cpp
@@ -505,7 +505,7 @@ void Text3D::drawImplementation(osg::RenderInfo& renderInfo) const
         // OSG_NOTICE<<"No need to apply matrix "<<std::endl;
     }
 
-    osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
+    osg::PerContextVertexArrayState* vas = state.getCurrentVertexArrayState();
     bool usingVertexBufferObjects = state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects);
     bool usingVertexArrayObjects = usingVertexBufferObjects && state.useVertexArrayObject(_useVertexArrayObject);
     bool requiresSetArrays = !usingVertexBufferObjects || !usingVertexArrayObjects || vas->getRequiresSetArrays();

--- a/src/osgText/TextBase.cpp
+++ b/src/osgText/TextBase.cpp
@@ -54,6 +54,8 @@ TextBase::TextBase():
     setSupportsDisplayList(false);
 
     initArraysAndBuffers();
+
+    _vas = new osg::VertexArrayState();
 }
 
 TextBase::TextBase(const TextBase& textBase,const osg::CopyOp& copyop):

--- a/src/osgText/TextBase.cpp
+++ b/src/osgText/TextBase.cpp
@@ -109,11 +109,11 @@ void TextBase::initArraysAndBuffers()
     _texcoords->setBufferObject(_vbo.get());
 }
 
-osg::VertexArrayState* TextBase::createVertexArrayState(osg::RenderInfo& renderInfo) const
+osg::PerContextVertexArrayState* TextBase::createVertexArrayState(osg::RenderInfo& renderInfo) const
 {
     State& state = *renderInfo.getState();
 
-    VertexArrayState* vas = new osg::VertexArrayState(&state);
+    PerContextVertexArrayState* vas = new osg::PerContextVertexArrayState(&state);
 
     // OSG_NOTICE<<"Creating new osg::VertexArrayState "<< vas<<std::endl;
 


### PR DESCRIPTION
1st and 2nd commit/
It's a beginning of answer for the desactivation of Drawable VAS
This design actually already helps me a lot to implement tricks like "pingpong TransformFeedback buffer set" or "baseVertex primsets"

3rd commit/
Add ComputeDispatch and modify example
(i added a vas property test in draw Drawable::draw...perhaps there's better:
I might interact with state in PCProgram::useprogram in order to disable vao but i don't know where to reenable it ...perhaps at the end of CD::drawimpl ...
)

@robertosfield 
Would like your opinion on it 