### PR TITLE
Make the culling be disabled at the drawable level 

### DIFF
--- a/src/osgPlugins/logo/ReaderWriterLOGO.cpp
+++ b/src/osgPlugins/logo/ReaderWriterLOGO.cpp
@@ -321,7 +321,7 @@ class LOGOReaderWriter : public osgDB::ReaderWriter
             if( ld->hasLogos() )
                 geode->addDrawable( ld );
 
-            geode->setCullingActive(false);
+            ld->setCullingActive(false);
             return geode;
         }
 };


### PR DESCRIPTION
Logos were culled when the center of the scene bounding sphere was culled.
This PR corrects this on master