### PR TITLE
Do not cull inactive culling drawables

### DIFF
--- a/src/osgUtil/CullVisitor.cpp
+++ b/src/osgUtil/CullVisitor.cpp
@@ -1003,7 +1003,7 @@ void CullVisitor::apply(osg::Drawable& drawable)
 
     if (_computeNearFar && bb.valid())
     {
-        if (!updateCalculatedNearFar(matrix,drawable,false)) return;
+        if (drawable.isCullingActive() && !updateCalculatedNearFar(matrix,drawable,false)) return;
     }
 
     // need to track how push/pops there are, so we can unravel the stack correctly.


### PR DESCRIPTION
Drawable that had  `setCullingActive(false)` could still be culled without this fix