### PR TITLE
add flexier Image Unit Binding implementation 

### DIFF
--- a/include/osg/ImageTexture
+++ b/include/osg/ImageTexture
@@ -1,0 +1,108 @@
+/* -*-c++-*- OpenSceneGraph - Copyright (C) 1998-2006 Robert Osfield
+ *
+ * This library is open source and may be redistributed and/or modified under
+ * the terms of the OpenSceneGraph Public License (OSGPL) version 0.0 or
+ * (at your option) any later version.  The full license is in LICENSE file
+ * included with this distribution, and on the openscenegraph.org website.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * OpenSceneGraph Public License for more details.
+*/
+/// author: Julien Valentin 2017 (mp3butcher@hotmail.com) 
+
+#ifndef _GLImageUnitBinding_H
+#define _GLImageUnitBinding_H
+
+#include <osg/Export>
+#include <osg/Texture>
+
+namespace osg{
+    /** Bind texture to an image unit (available only if GL version is 4.2 or greater)
+    * The format parameter for the image unit need not exactly match the texture internal format,
+    * but if it is set to 0, the texture internal format will be used.
+    * See http://www.opengl.org/registry/specs/ARB/shader_image_load_store.txt
+    * void bindToImageUnit(unsigned int unit, GLenum access, GLenum format=0, int level=0, bool layered=false, int layer=0);
+    **/
+    class OSG_EXPORT ImageTextureBinding : public osg::StateAttribute {
+        public:
+            /** Type of access that will be performed on the texture image. */
+            enum ImageAccess
+            {
+                 NOT_USED = 0,
+                 READ_ONLY = GL_READ_ONLY_ARB,
+                 WRITE_ONLY = GL_WRITE_ONLY_ARB,
+                 READ_WRITE = GL_READ_WRITE_ARB
+            };
+
+            ImageTextureBinding(
+                            GLuint imageunit = 0,
+                            osg::Texture* target = 0,
+                            ImageAccess access = READ_ONLY,
+                            GLenum format = GL_RGBA8,
+                            int level = 0,
+                            bool layered = GL_FALSE,
+                            int layer = 0) : osg::StateAttribute(), 
+                _target(target),
+                _imageunit(imageunit),
+                _level(level),
+                _layered(layered),
+                _layer(layer),
+                _access(access),
+                _format(format) {}
+
+            ImageTextureBinding( const  ImageTextureBinding&o,osg::CopyOp op=osg::CopyOp::SHALLOW_COPY):
+                osg::StateAttribute(o,op),
+                _target(o._target),
+                _imageunit(o._imageunit),
+                _level(o._level),
+                _layered(o._layered),
+                _layer(o._layer),
+                _access(o._access),
+                _format(o._format){}
+            virtual ~ImageTextureBinding(){}
+
+            META_StateAttribute(osg,ImageTextureBinding,IMAGE)
+
+            GLuint getImageUnit() const { return _imageunit; }
+            void setImageUnit(GLuint i) { _imageunit=i; }
+
+            GLint getLevel() const { return _level; }
+            void setLevel(GLint i){ _level=i; }
+
+            GLboolean getIsLayered() const { return _layered; }
+            void setIsLayered( GLboolean i) { _layered=i; }
+
+            GLint getLayer() const { return _layer; }
+            void setLayer(GLint i) { _layer=i; }
+
+            GLenum getAccess()const { return _access; }
+            void setAccess(ImageAccess i) { _access=i; }
+
+            GLenum getFormat()const { return _format; }
+            void setFormat(GLenum i) { _format=i; }
+
+            const osg::Texture *getTexture() const { return _target.get();}
+            void setTexture(osg::Texture* target) { _target=target; }
+
+            virtual void apply(osg::State&state) const;
+
+            virtual int compare(const osg::StateAttribute &sa) const;
+
+            virtual unsigned getMember() const {
+                return static_cast<unsigned int>(_imageunit);
+            }
+        protected:
+            osg::ref_ptr<osg::Texture> _target;
+            GLuint _imageunit;
+            GLint _level;
+            GLboolean _layered;
+            GLint _layer;
+            GLenum _access;
+            GLenum _format;
+
+    };
+}
+#endif
+

--- a/include/osg/ImageTexture
+++ b/include/osg/ImageTexture
@@ -60,16 +60,17 @@ namespace osg{
                 _layered(o._layered),
                 _layer(o._layer),
                 _access(o._access),
-                _format(o._format){}
-            virtual ~ImageTextureBinding(){}
+                _format(o._format) {}
+        
+            virtual ~ImageTextureBinding() {}
 
-            META_StateAttribute(osg,ImageTextureBinding,IMAGE)
+            META_StateAttribute(osg,ImageTextureBinding, IMAGETEXTURE)
 
             GLuint getImageUnit() const { return _imageunit; }
             void setImageUnit(GLuint i) { _imageunit=i; }
 
             GLint getLevel() const { return _level; }
-            void setLevel(GLint i){ _level=i; }
+            void setLevel(GLint i) { _level=i; }
 
             GLboolean getIsLayered() const { return _layered; }
             void setIsLayered( GLboolean i) { _layered=i; }
@@ -90,9 +91,8 @@ namespace osg{
 
             virtual int compare(const osg::StateAttribute &sa) const;
 
-            virtual unsigned getMember() const {
-                return static_cast<unsigned int>(_imageunit);
-            }
+            virtual unsigned getMember() const { return static_cast<unsigned int>(_imageunit); }
+        
         protected:
             osg::ref_ptr<osg::Texture> _target;
             GLuint _imageunit;

--- a/include/osg/StateAttribute
+++ b/include/osg/StateAttribute
@@ -207,7 +207,8 @@ class OSG_EXPORT StateAttribute : public Object
             VIEWPORTINDEXED,
             DEPTHRANGEINDEXED,
             SCISSORINDEXED,
-            IMAGE,
+            
+            IMAGETEXTURE,
 
             CAPABILITY = 100
         };

--- a/include/osg/StateAttribute
+++ b/include/osg/StateAttribute
@@ -207,6 +207,7 @@ class OSG_EXPORT StateAttribute : public Object
             VIEWPORTINDEXED,
             DEPTHRANGEINDEXED,
             SCISSORINDEXED,
+            IMAGE,
 
             CAPABILITY = 100
         };

--- a/src/osg/CMakeLists.txt
+++ b/src/osg/CMakeLists.txt
@@ -96,6 +96,7 @@ SET(TARGET_H
     ${HEADER_PATH}/ImageSequence
     ${HEADER_PATH}/ImageStream
     ${HEADER_PATH}/ImageUtils
+    ${HEADER_PATH}/ImageTexture
     ${HEADER_PATH}/io_utils
     ${HEADER_PATH}/KdTree
     ${HEADER_PATH}/Light
@@ -307,6 +308,7 @@ SET(TARGET_SRC
     ImageSequence.cpp
     ImageStream.cpp
     ImageUtils.cpp
+    ImageTexture.cpp
     KdTree.cpp
     Light.cpp
     LightModel.cpp

--- a/src/osg/ImageTexture.cpp
+++ b/src/osg/ImageTexture.cpp
@@ -1,0 +1,28 @@
+#include <osg/ImageTexture>
+
+using namespace osg;
+
+int ImageTextureBinding::compare(const osg::StateAttribute &sa)const{
+    COMPARE_StateAttribute_Types(ImageTextureBinding,sa)
+    // Compare each parameter in turn against the rhs.
+    COMPARE_StateAttribute_Parameter(_target)
+    COMPARE_StateAttribute_Parameter(_imageunit)
+    COMPARE_StateAttribute_Parameter(_access)
+    COMPARE_StateAttribute_Parameter(_format)
+    COMPARE_StateAttribute_Parameter(_layered)
+    COMPARE_StateAttribute_Parameter(_level)
+    return 0;
+}
+
+void ImageTextureBinding::apply(osg::State&state)const{
+    if(_target.valid()){
+      osg::Texture::TextureObject *to = _target->getTextureObject( state.getContextID() );
+      if( !to ){
+          // _target never been applied yet
+          _target->apply(state);
+          to = _target->getTextureObject( state.getContextID() );
+      }
+      state.get<osg::GLExtensions>()->glBindImageTexture(_imageunit, to->id(), _level, _layered, _layer, _access, _format);
+    }
+
+}

--- a/src/osg/ImageTexture.cpp
+++ b/src/osg/ImageTexture.cpp
@@ -2,7 +2,8 @@
 
 using namespace osg;
 
-int ImageTextureBinding::compare(const osg::StateAttribute &sa)const{
+int ImageTextureBinding::compare(const osg::StateAttribute &sa) const
+{
     COMPARE_StateAttribute_Types(ImageTextureBinding,sa)
     // Compare each parameter in turn against the rhs.
     COMPARE_StateAttribute_Parameter(_target)
@@ -14,15 +15,18 @@ int ImageTextureBinding::compare(const osg::StateAttribute &sa)const{
     return 0;
 }
 
-void ImageTextureBinding::apply(osg::State&state)const{
-    if(_target.valid()){
-      osg::Texture::TextureObject *to = _target->getTextureObject( state.getContextID() );
-      if( !to ){
-          // _target never been applied yet
-          _target->apply(state);
-          to = _target->getTextureObject( state.getContextID() );
-      }
-      state.get<osg::GLExtensions>()->glBindImageTexture(_imageunit, to->id(), _level, _layered, _layer, _access, _format);
+void ImageTextureBinding::apply(osg::State&state) const
+{
+    if(_target.valid())
+    {
+        osg::Texture::TextureObject *to = _target->getTextureObject( state.getContextID() );
+        if( !to )
+        {
+            // _target never been applied yet
+            _target->apply(state);
+            to = _target->getTextureObject( state.getContextID() );
+        }
+        state.get<osg::GLExtensions>()->glBindImageTexture(_imageunit, to->id(), _level, _layered, _layer, _access, _format);
     }
 
 }


### PR DESCRIPTION
allow differents IUBs for a single Texture
(perhaps naming should be changed)
todo if accepted: feature has already been tested but the old impl must be removed)