### PR TITLE
Detecting the windows version at build time breaks cross-compilation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,10 +344,14 @@ ENDIF()
 
 
 IF(WIN32 AND NOT ANDROID)
+    OPTION(OSG_DETERMINE_WIN_VERSION "Wheter to automatically determine current Windows version" ON)
+
+	IF(OSG_DETERMINE_WIN_VERSION)
     # Check window version
     INCLUDE (OsgDetermineWinVersion)
     get_WIN32_WINNT(WIN_VERSION)
     ADD_DEFINITIONS(-D_WIN32_WINNT=${WIN_VERSION})
+    ENDIF(OSG_DETERMINE_WIN_VERSION)
 
     IF(MSVC)
         # This option is to enable the /MP switch for Visual Studio 2005 and above compilers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,11 +346,11 @@ ENDIF()
 IF(WIN32 AND NOT ANDROID)
     OPTION(OSG_DETERMINE_WIN_VERSION "Wheter to automatically determine current Windows version" ON)
 
-	IF(OSG_DETERMINE_WIN_VERSION)
-    # Check window version
-    INCLUDE (OsgDetermineWinVersion)
-    get_WIN32_WINNT(WIN_VERSION)
-    ADD_DEFINITIONS(-D_WIN32_WINNT=${WIN_VERSION})
+    IF(OSG_DETERMINE_WIN_VERSION)
+        # Check window version
+        INCLUDE (OsgDetermineWinVersion)
+        get_WIN32_WINNT(WIN_VERSION)
+        ADD_DEFINITIONS(-D_WIN32_WINNT=${WIN_VERSION})
     ENDIF(OSG_DETERMINE_WIN_VERSION)
 
     IF(MSVC)


### PR DESCRIPTION
I have made this auto-detection optional (default ON).