### PR TITLE
osgViewer::ViewerBase setThreadingModel function fixed

### DIFF
--- a/src/osgViewer/ViewerBase.cpp
+++ b/src/osgViewer/ViewerBase.cpp
@@ -205,11 +205,13 @@ void ViewerBase::setThreadingModel(ThreadingModel threadingModel)
 {
     if (_threadingModel == threadingModel) return;
 
+    bool needSetUpThreading = _threadsRunning;
+
     if (_threadsRunning) stopThreading();
 
     _threadingModel = threadingModel;
 
-    setUpThreading();
+    if (needSetUpThreading) setUpThreading();
 }
 
 ViewerBase::ThreadingModel ViewerBase::suggestBestThreadingModel()


### PR DESCRIPTION
I was wonder why heavy multithreaded osgViewer::Viewer - based programs works well when running with ENV. variable

**OSG_THREADING=DrawThreadPerContext osgviewer-based-program** (osgviewer etc.) 60 FPS

and works bad (10FPS with lags etc.) when running (with arguments) like
**osgviewer-based-program --DrawThreadPerContext**

The reason was that osgViewer::ViewerBase setThreadingModel function starts threading by calling setUpThreading. I think it should not, it should only change threading model. Of course, it must restart if Viewer already threading.

Maybe there is also another issue associated with affinity when threading model changed dynamically.

The reason of using **needSetUpThreading** additional flag is that function setUpThreading is virtual and can possibly use _threadingModel variable.


