### PR TITLE
add definitions for TEXTURE_MIN_LOD TEXTURE_MIN_LOD TEXTURE_LOD_BIAS

### DIFF
--- a/include/osg/Texture
+++ b/include/osg/Texture
@@ -162,6 +162,18 @@
     #define GL_MIRRORED_REPEAT_IBM            0x8370
 #endif
 
+#ifndef GL_TEXTURE_MIN_LOD
+    #define GL_TEXTURE_MIN_LOD                0x813A
+#endif
+
+#ifndef GL_TEXTURE_MAX_LOD
+    #define GL_TEXTURE_MAX_LOD                0x813B
+#endif
+
+#ifndef GL_TEXTURE_LOD_BIAS
+    #define GL_TEXTURE_LOD_BIAS               0x8501
+#endif
+
 #ifndef GL_CLAMP_TO_EDGE
     #define GL_CLAMP_TO_EDGE                  0x812F
 #endif


### PR DESCRIPTION
Hi Robert,
compiling with visual studio 2017 I get:
OpenSceneGraph\src\osg\Texture.cpp(2024): error C2065: 'GL_TEXTURE_MIN_LOD': undeclared identifier
OpenSceneGraph\src\osg\Texture.cpp(2025): error C2065: 'GL_TEXTURE_MAX_LOD': undeclared identifier
OpenSceneGraph\src\osg\Texture.cpp(2028): error C2065: 'GL_TEXTURE_LOD_BIAS': undeclared identifier

so I added the definitions (found in glext.h - downloaded from kronos.org ) 
Regards, Laurens.