### PR TITLE
remove unused variable "newArrays"

### DIFF
--- a/examples/osganalysis/osganalysis.cpp
+++ b/examples/osganalysis/osganalysis.cpp
@@ -256,9 +256,7 @@ public:
     {
         OSG_NOTICE<<"Reallocating Arrays"<<std::endl;
 
-        typedef std::vector< osg::ref_ptr<osg::Array> > ArrayVector;
         typedef std::vector< osg::ref_ptr<osg::Geometry> > GeometryVector;
-        ArrayVector newArrays;
         GeometryVector newGeometries;
         for(GeometryMap::iterator itr = _geometryMap.begin();
             itr != _geometryMap.end();


### PR DESCRIPTION
Hi Robert,
chasing vs 2017 compiler warning
OpenSceneGraph\examples\osganalysis\osganalysis.cpp(259): warning C4458: declaration of 'ArrayVector' hides class member
I found the local typedef and the variable unused. Seems to me those can be removed.
Laurens.