### PR TITLE
remove unused variable "maxBonePerVertex"

### DIFF
--- a/src/osgAnimation/RigTransformHardware.cpp
+++ b/src/osgAnimation/RigTransformHardware.cpp
@@ -194,7 +194,6 @@ bool RigTransformHardware::buildPalette(const BoneMap& boneMap, const RigGeometr
     _bonePalette.clear();
     _boneNameToPalette.clear();
 
-    IndexWeightList::size_type maxBonePerVertex = 0;
     BoneNameCountMap boneNameCountMap;
 
     const VertexInfluenceMap &vertexInfluenceMap = *rig.getInfluenceMap();


### PR DESCRIPTION
Hi Robert,
chasing vs 2017 compiler warning
C4189: 'maxBonePerVertex': local variable is initialized but not referenced
Variable can simply be removed.
Laurens.