### PR TITLE
fix vc2017 compile warning 'unsigned int' to 'const char'

### DIFF
--- a/include/osgWidget/Util
+++ b/include/osgWidget/Util
@@ -48,12 +48,17 @@ inline std::ostream& info()
     return _notify();
 }
 
+inline char lowerCaseChar(const char in)
+{
+    return (unsigned char)(::tolower((int)((unsigned char)in)));
+}
+
 inline std::string lowerCase(const std::string& str)
 {
     std::string s = str;
 
     // TODO: Why can't I specify std::tolower?
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    std::transform(s.begin(), s.end(), s.begin(), lowerCaseChar);
 
     return s;
 }


### PR DESCRIPTION
Hi Robert,
vs 2017 gives me a rather large compiler warning:

C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\include\algorithm(911): warning C4244: '=': conversion from 'int' to 'char', possible loss of data (compiling source file E:\osg\35\laurens\OpenSceneGraph\src\osgWidget\Window.cpp)
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\include\algorithm(924): note: see reference to function template instantiation '_OutIt std::_Transform_no_deprecate<_InIt,_OutIt,int(__cdecl *)(int)>(_InIt,_InIt,_OutIt,_Fn &)' being compiled
        with
        [
            _OutIt=std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,
            _InIt=std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,
            _Fn=int (__cdecl *)(int)
        ] (compiling source file E:\osg\35\laurens\OpenSceneGraph\src\osgWidget\Window.cpp)
E:\osg\35\laurens\OpenSceneGraph\include\osgWidget/Util(56): note: see reference to function template instantiation '_OutIt std::transform<std::_String_iterator<std::_String_val<std::_Simple_types<_Ty>>>,std::_String_iterator<std::_String_val<std::_Simple_types<_Ty>>>,int(__cdecl *)(int)>(_InIt,_InIt,_OutIt,_Fn)' being compiled
        with
        [
            _OutIt=std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,
            _Ty=char,
            _InIt=std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,
            _Fn=int (__cdecl *)(int)
        ] (compiling source file E:\osg\35\laurens\OpenSceneGraph\src\osgWidget\Window.cpp)
        ] (compiling source file E:\osg\35\laurens\OpenSceneGraph\src\osgWidget\WindowManager.cpp)
        + 14 other occurrances

The issue is that "int std::tolower(int c)" is used with a char type both for input and for output. 
Apart from the (rather large) warning, I see only problems with the current code in case "char" is signed - don't know if that's still in use anywhere. That should be fixed by this PR too.
Regards, Laurens.