### PR TITLE
fix bug: potentially uninitialized local variable 'hr' used

### DIFF
--- a/examples/osgdirectinput/DirectInputRegistry.cpp
+++ b/examples/osgdirectinput/DirectInputRegistry.cpp
@@ -204,7 +204,7 @@ BOOL CALLBACK DirectInputRegistry::EnumJoysticksCallback( const DIDEVICEINSTANCE
     {
         hr = device->CreateDevice( didInstance->guidInstance,
                                    &(DirectInputRegistry::instance()->getJoyStick()), NULL );
+        if ( SUCCEEDED(hr) ) return DIENUM_STOP;
     }
-    if ( FAILED(hr) ) return DIENUM_CONTINUE;
-    return DIENUM_STOP;
+    return DIENUM_CONTINUE;
 }


### PR DESCRIPTION
Hi Robert,
a compiler warning from vs2017 pointed me to a bug in examples\osgdirectinput
As I have no joystick I can't test any of the code, but here's a fix anyway.

Regards, Laurens. 