### PR TITLE
getGLExtensionFuncPtr: support gl4es wrapper on Android.

### DIFF
--- a/src/osg/GLExtensions.cpp
+++ b/src/osg/GLExtensions.cpp
@@ -339,6 +339,8 @@ OSG_INIT_SINGLETON_PROXY(GLExtensionDisableStringInitializationProxy, osg::getGL
             static void *handle = dlopen("libGLESv1_CM.so", RTLD_NOW);
         #elif defined(OSG_GLES2_AVAILABLE)
             static void *handle = dlopen("libGLESv2.so", RTLD_NOW);
+        #elif defined(OSG_GL1_AVAILABLE)
+            static void *handle = dlopen("libGL.so", RTLD_NOW);
         #endif
         return dlsym(handle, funcName);
 


### PR DESCRIPTION
On Android it's possible to have `libGL.so` with the gl4es wrapper: https://github.com/ptitSeb/gl4es which translates GL1 calls into GLESv1/GLESv2

This pull request fixes compilation error when OSG is built with `OSG_GL1_AVAILABLE` for Android.

(This is useful for porting projects that use OSG but also depend on the underlying OpenGL implementation, e.g. openmw)
