### PR TITLE
Not for merging yet: Immutable buffers + persistance mapping proposal

### DIFF
--- a/include/osg/BufferObject
+++ b/include/osg/BufferObject
@@ -1,5 +1,6 @@
 /* -*-c++-*- OpenSceneGraph - Copyright (C) 1998-2006 Robert Osfield
  * Copyright (C) 2012 David Callu
+ * Copyright (C) 2018 Julien Valentin
  *
  * This library is open source and may be redistributed and/or modified under
  * the terms of the OpenSceneGraph Public License (OSGPL) version 0.0 or
@@ -97,20 +98,24 @@ class BufferObject;
 class BufferObjectProfile
 {
     public:
+
         BufferObjectProfile():
             _target(0),
             _usage(0),
-            _size(0) {}
+            _size(0),
+            _mappingbitfield(0) {}
 
-        BufferObjectProfile(GLenum target, GLenum usage, unsigned int size):
+        BufferObjectProfile(GLenum target, GLenum usage, unsigned int size, GLbitfield mappingbitfield ):
             _target(target),
             _usage(usage),
-            _size(size) {}
+            _size(size),
+            _mappingbitfield(mappingbitfield) {}
 
         BufferObjectProfile(const BufferObjectProfile& bpo):
             _target(bpo._target),
             _usage(bpo._usage),
-            _size(bpo._size) {}
+            _size(bpo._size),
+            _mappingbitfield(bpo._mappingbitfield) {}
 
         bool operator < (const BufferObjectProfile& rhs) const
         {
@@ -118,6 +123,8 @@ class BufferObjectProfile
             else if (_target > rhs._target) return false;
             if (_usage < rhs._usage) return true;
             else if (_usage > rhs._usage) return false;
+            if (_mappingbitfield < rhs._mappingbitfield) return true;
+            else if (_mappingbitfield > rhs._mappingbitfield) return false;
             return _size < rhs._size;
         }
 
@@ -125,14 +132,16 @@ class BufferObjectProfile
         {
             return (_target == rhs._target) &&
                    (_usage == rhs._usage) &&
-                   (_size == rhs._size);
+                   (_size == rhs._size) &&
+                   (_mappingbitfield == rhs._mappingbitfield);
         }
 
-        void setProfile(GLenum target, GLenum usage, unsigned int size)
+        void setProfile(GLenum target, GLenum usage, unsigned int size, GLbitfield mappingbitfield )
         {
             _target = target;
             _usage = usage;
             _size = size;
+            _mappingbitfield = mappingbitfield;
         }
 
         BufferObjectProfile& operator = (const BufferObjectProfile& rhs)
@@ -140,12 +149,14 @@ class BufferObjectProfile
             _target = rhs._target;
             _usage = rhs._usage;
             _size = rhs._size;
+            _mappingbitfield = rhs._mappingbitfield;
             return *this;
         }
 
         GLenum _target;
         GLenum _usage;
-        GLenum _size;
+        GLuint _size;
+        GLbitfield _mappingbitfield;
 };
 
 // forward declare
@@ -427,6 +438,10 @@ class OSG_EXPORT BufferObject : public Object
         /** Get the type of usage the buffer object has been set up for.*/
         GLenum getUsage() const { return _profile._usage; }
 
+        /** Enable GL4 buffer storage features (override usage if setted) */
+        void setMappingBitfield(GLbitfield b){ if(_profile._mappingbitfield == b) return; _profile._mappingbitfield = b; }
+        GLbitfield getMappingBitfield() const { return _profile._mappingbitfield; }
+
         BufferObjectProfile& getProfile() { return _profile; }
         const BufferObjectProfile& getProfile() const { return _profile; }
 
@@ -436,7 +451,6 @@ class OSG_EXPORT BufferObject : public Object
 
         /** Get whether the BufferObject should use a GLBufferObject just for copying the BufferData and release it immmediately.*/
         bool getCopyDataAndReleaseGLBufferObject() const { return _copyDataAndReleaseGLBufferObject; }
-
 
         void dirty();
 

--- a/include/osg/BufferObject
+++ b/include/osg/BufferObject
@@ -273,6 +273,7 @@ class OSG_EXPORT GLBufferObject : public GraphicsObject
 
     public:
         GLExtensions*          _extensions;
+        GLvoid*                _persistantDMA;
 
 };
 

--- a/include/osg/BufferObject
+++ b/include/osg/BufferObject
@@ -508,7 +508,10 @@ class OSG_EXPORT BufferData : public Object
             Object(true),
             _modifiedCount(0),
             _bufferIndex(0),
-            _numClients(0) {}
+            _numClients(0),
+            _dmapinnedmemory(0),
+            _ext(0),
+            _contextid(0) {}
 
         /** Copy constructor using CopyOp to manage deep vs shallow copy.*/
         BufferData(const BufferData& bd,const CopyOp& copyop=CopyOp::SHALLOW_COPY):
@@ -516,7 +519,10 @@ class OSG_EXPORT BufferData : public Object
             _modifiedCount(0),
             _bufferIndex(0),
             _modifiedCallback(bd._modifiedCallback),
-            _numClients(0) {}
+            _numClients(0),
+            _dmapinnedmemory(0),
+            _ext(0),
+            _contextid(0) {}
 
         virtual bool isSameKindAs(const Object* obj) const { return dynamic_cast<const BufferData*>(obj)!=NULL; }
         virtual const char* libraryName() const { return "osg"; }
@@ -588,7 +594,9 @@ class OSG_EXPORT BufferData : public Object
         void addClient(osg::Object * /*client*/) { ++_numClients; }
 
         void removeClient(osg::Object * /*client*/) { --_numClients; }
-
+        virtual void setupPinnedMemory(GLvoid*p, GLExtensions *s,GLuint c) { _dmapinnedmemory=p; _ext=s;_contextid=c; }
+        GLvoid * getPinnedMemory() { return  _dmapinnedmemory; }
+        void commitPinnedMemoryChanges();
 protected:
 
         virtual ~BufferData();
@@ -600,6 +608,7 @@ protected:
         osg::ref_ptr<ModifiedCallback>  _modifiedCallback;
 
         unsigned int _numClients;
+        GLvoid * _dmapinnedmemory; ref_ptr<GLExtensions> _ext; GLuint _contextid;
 };
 
 

--- a/include/osg/GLExtensions
+++ b/include/osg/GLExtensions
@@ -390,6 +390,7 @@ class OSG_EXPORT GLExtensions : public osg::Referenced
         GLvoid* (GL_APIENTRY * glNamedBufferStorage) (GLuint buffer, GLsizei size, const void * data, GLbitfield flags);
         GLvoid* (GL_APIENTRY * glMapBuffer) (GLenum target, GLenum access);
         GLvoid* (GL_APIENTRY * glMapBufferRange)(GLenum target,  GLintptr offset,  GLsizeiptr length,  GLbitfield access);
+        GLvoid* (GL_APIENTRY * glFlushMappedBufferRange)(GLenum target,  GLintptr offset,  GLsizeiptr length);
         GLboolean (GL_APIENTRY * glUnmapBuffer) (GLenum target);
         void (GL_APIENTRY * glGetBufferParameteriv) (GLenum target, GLenum pname, GLint *params);
         void (GL_APIENTRY * glGetBufferPointerv) (GLenum target, GLenum pname, GLvoid* *params);

--- a/src/osg/BufferObject.cpp
+++ b/src/osg/BufferObject.cpp
@@ -122,7 +122,6 @@ void GLBufferObject::clear()
 void GLBufferObject::compileBuffer()
 {
     _dirty = false;
-_persistantDMA=0;
     _bufferEntries.reserve(_bufferObject->getNumBufferData());
 
     bool compileAll = false;

--- a/src/osg/GLExtensions.cpp
+++ b/src/osg/GLExtensions.cpp
@@ -726,6 +726,7 @@ GLExtensions::GLExtensions(unsigned int in_contextID):
     setGLExtensionFuncPtr(glNamedBufferStorage, "glNamedBufferStorage","glNamedBufferStorageARB", validContext);
     setGLExtensionFuncPtr(glMapBuffer, "glMapBuffer","glMapBufferARB", validContext);
     setGLExtensionFuncPtr(glMapBufferRange,  "glMapBufferRange", "glMapBufferRangeARB" , validContext);
+    setGLExtensionFuncPtr(glFlushMappedBufferRange,  "glFlushMappedBufferRange", "glFlushMappedBufferRangeARB" , validContext);
     setGLExtensionFuncPtr(glUnmapBuffer, "glUnmapBuffer","glUnmapBufferARB", validContext);
     setGLExtensionFuncPtr(glGetBufferParameteriv, "glGetBufferParameteriv","glGetBufferParameterivARB", validContext);
     setGLExtensionFuncPtr(glGetBufferPointerv, "glGetBufferPointerv","glGetBufferPointervARB", validContext);

--- a/src/osg/ImageUtils.cpp
+++ b/src/osg/ImageUtils.cpp
@@ -439,29 +439,29 @@ osg::Image* createImage3D(const ImageList& imageList,
 
     // compute nearest powers of two for each axis.
 
-    int size_s = 1;
-    int size_t = 1;
-    int size_r = 1;
+    int isize_s = 1;
+    int isize_t = 1;
+    int isize_r = 1;
 
     if (resizeToPowerOfTwo)
     {
-        while(size_s<max_s && size_s<s_maximumImageSize) size_s*=2;
-        while(size_t<max_t && size_t<t_maximumImageSize) size_t*=2;
-        while(size_r<total_r && size_r<r_maximumImageSize) size_r*=2;
+        while(isize_s<max_s && isize_s<s_maximumImageSize) isize_s*=2;
+        while(isize_t<max_t && isize_t<t_maximumImageSize) isize_t*=2;
+        while(isize_r<total_r && isize_r<r_maximumImageSize) isize_r*=2;
     }
     else
     {
-        size_s = max_s;
-        size_t = max_t;
-        size_r = total_r;
+        isize_s = max_s;
+        isize_t = max_t;
+        isize_r = total_r;
     }
 
     // now allocate the 3d texture;
     osg::ref_ptr<osg::Image> image_3d = new osg::Image;
-    image_3d->allocateImage(size_s,size_t,size_r,
+    image_3d->allocateImage(isize_s,isize_t,isize_r,
                             desiredPixelFormat,GL_UNSIGNED_BYTE);
 
-    unsigned int r_offset = (total_r<size_r) ? (size_r-total_r)/2 : 0;
+    unsigned int r_offset = (total_r<isize_r) ? (isize_r-total_r)/2 : 0;
 
     int curr_dest_r = r_offset;
 
@@ -486,8 +486,8 @@ osg::Image* createImage3D(const ImageList& imageList,
             int num_t = minimum(image->t(), image_3d->t());
             int num_r = minimum(image->r(), (image_3d->r() - curr_dest_r));
 
-            unsigned int s_offset_dest = (image->s()<size_s) ? (size_s - image->s())/2 : 0;
-            unsigned int t_offset_dest = (image->t()<size_t) ? (size_t - image->t())/2 : 0;
+            unsigned int s_offset_dest = (image->s()<isize_s) ? (isize_s - image->s())/2 : 0;
+            unsigned int t_offset_dest = (image->t()<isize_t) ? (isize_t - image->t())/2 : 0;
 
             copyImage(image, 0, 0, 0, num_s, num_t, num_r,
                       image_3d.get(), s_offset_dest, t_offset_dest, curr_dest_r, false);


### PR DESCRIPTION
Here's what I did for the moment on immutables buffer integration 
**Not candidate to merge for the moment
I pr just to make review easier**

In this implementation I made DMAbuffer a new attribute of BufferData.
The problem (if there's one) is that user should be aware to interact through this buffer and not vector interface.
I didn't find a way to use vector interface for both dma and ::new memory allocation policy without violating the standard (interact directly with vector allocator state of a boost::vector)
If this compromise is enough for community requirement I'll continue on this path (and make my PR cleaner)
