### PR TITLE
Not for merging: osg graphicobjects homogenization proposal

### DIFF
--- a/include/osg/BufferObject
+++ b/include/osg/BufferObject
@@ -94,7 +94,7 @@ class State;
 class BufferData;
 class BufferObject;
 
-class BufferObjectProfile
+class BufferObjectProfile : public GraphicsObjectProfile
 {
     public:
         BufferObjectProfile():
@@ -209,13 +209,11 @@ class OSG_EXPORT GLBufferObject : public GraphicsObject
         }
 
         /** release GLBufferObject to the orphan list to be reused or deleted.*/
-        void release();
+        virtual void release();
 
-        inline bool isDirty() const { return _dirty; }
+        virtual GraphicsObjectProfile &getProfile(){ return _profile; }
 
-        void dirty() { _dirty = true; }
-
-        void clear();
+        virtual void clear();
 
         void compileBuffer();
 
@@ -401,7 +399,46 @@ class OSG_EXPORT GLBufferObjectManager : public GraphicsObjectManager
 };
 
 
-class OSG_EXPORT BufferObject : public Object
+///Base container class for all Object requiring PerContext OpenGL GraphicObjects
+class OSG_EXPORT PerContextGraphicObject : public Object
+{
+public:
+    PerContextGraphicObject(){}
+    PerContextGraphicObject(const PerContextGraphicObject&o,osg::CopyOp copy=CopyOp::SHALLOW_COPY):Object(o,copy){}
+    typedef osg::buffered_object< osg::ref_ptr<GraphicsObject> > GLGraphicsObjects;
+    inline void setGraphicsObject(unsigned int contextID, GraphicsObject* glbo) const { _glBufferObjects[contextID] = glbo; }
+    inline GraphicsObject* getGraphicsObject(unsigned int contextID) const { return _glBufferObjects[contextID].get(); }
+    inline void resizeGLObjectBuffers(unsigned int maxSize) const { _glBufferObjects.resize(maxSize); }
+
+    inline GraphicsObject* getOrCreateGraphicsObject(unsigned int contextID) const
+    {
+        if (!_glBufferObjects[contextID]) _glBufferObjects[contextID] = createGraphicsObject(contextID);
+        return _glBufferObjects[contextID].get();
+    }
+    int comparePerContextObjects(const PerContextGraphicObject& rhs) const
+    {
+        if (_glBufferObjects.size()<rhs._glBufferObjects.size()) return -1;
+        if (rhs._glBufferObjects.size()<_glBufferObjects.size()) return 1;
+        for(unsigned int i=0; i<_glBufferObjects.size(); ++i)
+        {
+            if (_glBufferObjects[i] < rhs._glBufferObjects[i]) return -1;
+            else if (rhs._glBufferObjects[i] < _glBufferObjects[i]) return 1;
+        }
+        return 0;
+    }
+    virtual GraphicsObject* createGraphicsObject(unsigned int contextID) const=0;
+
+    virtual void dirty();
+    /** If State is non-zero, this function releases OpenGL objects for
+      * the specified graphics context. Otherwise, releases OpenGL objects
+      * for all graphics contexts. */
+    virtual void releaseGLObjects(State* state=0) const;
+protected:
+    virtual ~PerContextGraphicObject(){}
+    mutable GLGraphicsObjects _glBufferObjects;
+};
+
+class OSG_EXPORT BufferObject : public PerContextGraphicObject
 {
     public:
 
@@ -437,16 +474,8 @@ class OSG_EXPORT BufferObject : public Object
         /** Get whether the BufferObject should use a GLBufferObject just for copying the BufferData and release it immmediately.*/
         bool getCopyDataAndReleaseGLBufferObject() const { return _copyDataAndReleaseGLBufferObject; }
 
-
-        void dirty();
-
         /** Resize any per context GLObject buffers to specified size. */
         virtual void resizeGLObjectBuffers(unsigned int maxSize);
-
-        /** If State is non-zero, this function releases OpenGL objects for
-          * the specified graphics context. Otherwise, releases OpenGL objects
-          * for all graphics contexts. */
-        void releaseGLObjects(State* state=0) const;
 
         unsigned int addBufferData(BufferData* bd);
         void removeBufferData(unsigned int index);
@@ -458,11 +487,12 @@ class OSG_EXPORT BufferObject : public Object
 
         unsigned int getNumBufferData() const { return static_cast<unsigned int>(_bufferDataList.size()); }
 
-        void setGLBufferObject(unsigned int contextID, GLBufferObject* glbo) { _glBufferObjects[contextID] = glbo; }
+        inline void setGLBufferObject(unsigned int contextID, GLBufferObject* glbo) { setGraphicsObject(contextID, glbo); }
 
-        GLBufferObject* getGLBufferObject(unsigned int contextID) const { return _glBufferObjects[contextID].get(); }
+        GLBufferObject* getGLBufferObject(unsigned int contextID) const { return (GLBufferObject*)getGraphicsObject(contextID); }
 
-        GLBufferObject* getOrCreateGLBufferObject(unsigned int contextID) const;
+        virtual GraphicsObject* createGraphicsObject(unsigned int contextID) const;
+        inline GLBufferObject* getOrCreateGLBufferObject(unsigned int contextID) const{return (GLBufferObject*)getOrCreateGraphicsObject(contextID);}
 
         unsigned int computeRequiredBufferSize() const;
 
@@ -474,7 +504,6 @@ class OSG_EXPORT BufferObject : public Object
         ~BufferObject();
 
         typedef std::vector< BufferData* > BufferDataList;
-        typedef osg::buffered_object< osg::ref_ptr<GLBufferObject> > GLBufferObjects;
 
         BufferObjectProfile     _profile;
 
@@ -482,7 +511,6 @@ class OSG_EXPORT BufferObject : public Object
 
         BufferDataList          _bufferDataList;
 
-        mutable GLBufferObjects _glBufferObjects;
 };
 
 class OSG_EXPORT BufferData : public Object
@@ -519,15 +547,26 @@ class OSG_EXPORT BufferData : public Object
         virtual osg::Image* asImage() { return 0; }
         virtual const osg::Image* asImage() const { return 0; }
 
+        inline void setGraphicsObject(PerContextGraphicObject* bufferObject){ _bufferObject = bufferObject; }
+        inline PerContextGraphicObject* getGraphicsObject() { return _bufferObject.get(); }
+        inline const PerContextGraphicObject* getGraphicsObject() const { return _bufferObject.get(); }
+
+        //retro compat (dont use with image)
         void setBufferObject(BufferObject* bufferObject);
-        BufferObject* getBufferObject() { return _bufferObject.get(); }
-        const BufferObject* getBufferObject() const { return _bufferObject.get(); }
+        inline BufferObject* getBufferObject() { return (BufferObject*)_bufferObject.get(); }
+        inline const BufferObject* getBufferObject() const { return (BufferObject*)_bufferObject.get(); }
+
 
         void setBufferIndex(unsigned int index) { _bufferIndex = index; }
         unsigned int getBufferIndex() const { return _bufferIndex; }
 
-        GLBufferObject* getGLBufferObject(unsigned int contextID) const { return _bufferObject.valid() ? _bufferObject->getGLBufferObject(contextID) : 0; }
-        GLBufferObject* getOrCreateGLBufferObject(unsigned int contextID) const { return _bufferObject.valid() ? _bufferObject->getOrCreateGLBufferObject(contextID) : 0; }
+        GraphicsObject* getGLGraphicsObject(unsigned int contextID) const { return _bufferObject.valid() ? _bufferObject->getGraphicsObject(contextID) : 0; }
+        GraphicsObject* getOrCreateGLGraphicsObject(unsigned int contextID) const { return _bufferObject.valid() ? _bufferObject->getOrCreateGraphicsObject(contextID) : 0; }
+
+
+        GLBufferObject* getGLBufferObject(unsigned int contextID) const { return (GLBufferObject*)getGLGraphicsObject(contextID); }
+        GLBufferObject* getOrCreateGLBufferObject(unsigned int contextID) const { return (GLBufferObject*)getOrCreateGLGraphicsObject(contextID); }
+
 
         struct ModifiedCallback : public virtual osg::Object
         {
@@ -581,7 +620,7 @@ protected:
         unsigned int                    _modifiedCount;
 
         unsigned int                    _bufferIndex;
-        osg::ref_ptr<BufferObject>      _bufferObject;
+        osg::ref_ptr<PerContextGraphicObject>      _bufferObject;
         osg::ref_ptr<ModifiedCallback>  _modifiedCallback;
 
         unsigned int _numClients;
@@ -674,7 +713,7 @@ class OSG_EXPORT PixelBufferObject : public BufferObject
         Image* getImage();
         const Image* getImage() const;
 
-        bool isPBOSupported(unsigned int contextID) const { return _glBufferObjects[contextID]->isPBOSupported(); }
+        bool isPBOSupported(unsigned int contextID) const { return getGLBufferObject(contextID)->isPBOSupported(); }
 
     protected:
 

--- a/include/osg/GLObjects
+++ b/include/osg/GLObjects
@@ -42,14 +42,26 @@ extern OSG_EXPORT void deleteAllGLObjects(unsigned int contextID);
   * also doesn't remove the associated OpenGL resource so discard should only be
   * called when the associated graphics context is being/has been closed. */
 extern OSG_EXPORT void discardAllGLObjects(unsigned int contextID);
+class OSG_EXPORT GraphicsObjectProfile : public osg::Referenced
+{
+    public:
+    GraphicsObjectProfile(){}
+protected:
+    ~GraphicsObjectProfile(){}
+};
 
 class OSG_EXPORT GraphicsObject : public osg::Referenced
 {
     public:
-        GraphicsObject();
-
+        GraphicsObject():_dirty(true) {}
+        virtual void release()=0;
+        virtual void clear()=0;
+        virtual GraphicsObjectProfile & getProfile()=0;
+        virtual void dirty() { _dirty = true; }
+        inline bool isDirty() const { return _dirty; }
     protected:
         virtual ~GraphicsObject();
+        bool _dirty;
 };
 
 

--- a/include/osg/Image
+++ b/include/osg/Image
@@ -170,7 +170,7 @@
 #endif
 
 namespace osg {
-
+class TextureGraphicObject;
 // forward declare
 class NodeVisitor;
 
@@ -268,7 +268,9 @@ class OSG_EXPORT Image : public BufferData
           * If source is NULL then no operation happens, this Image is left unchanged.
         */
         virtual void copySubImage(int s_offset, int t_offset, int r_offset, const osg::Image* source);
-
+        inline const TextureGraphicObject* getTextureGraphicObject() const { return (TextureGraphicObject*)getGraphicsObject();}
+        //TextureGraphicObject* getTextureGraphicObject() const { return (TextureGraphicObject*)getGraphicsObject();}
+        void setTextureGraphicObject(TextureGraphicObject*u);
 
         enum Origin
         {
@@ -496,19 +498,23 @@ class OSG_EXPORT Image : public BufferData
         virtual bool isImageTranslucent() const;
 
         /** Set the optional PixelBufferObject used to map the image memory efficiently to graphics memory. */
-        void setPixelBufferObject(PixelBufferObject* buffer) { setBufferObject(buffer); }
+        void setPixelBufferObject(PixelBufferObject* buffer) { setGraphicsObject(buffer); }
 
         /** Get the PixelBufferObject.*/
-        PixelBufferObject* getPixelBufferObject() { return dynamic_cast<PixelBufferObject*>(getBufferObject()); }
+        PixelBufferObject* getPixelBufferObject() { return dynamic_cast<PixelBufferObject*>(getGraphicsObject()); }
 
         /** Get the const PixelBufferObject.*/
-        const PixelBufferObject* getPixelBufferObject() const { return dynamic_cast<const PixelBufferObject*>(getBufferObject()); }
+        const PixelBufferObject* getPixelBufferObject() const { return dynamic_cast<const PixelBufferObject*>(getGraphicsObject()); }
 
         /** Return whether the update(NodeVisitor* nv) should be required on each frame to enable proper working of osg::Image.*/
         virtual bool requiresUpdateCall() const { return false; }
 
         /** update method for osg::Image subclasses that update themselves during the update traversal.*/
         virtual void update(NodeVisitor* /*nv*/) {}
+
+
+        /** unload data from memory (make sure associated GLObject won't get dirty before calling this) */
+        virtual void unrefData(){ deallocateData(); }
 
         /** Convenience update callback class that can be attached to a StateAttribute (such as Textures) to ensure
           * that the Image::update(NodeVisitor*) method is called during the update traversal.  This callback

--- a/include/osg/Image
+++ b/include/osg/Image
@@ -170,7 +170,7 @@
 #endif
 
 namespace osg {
-class TextureGraphicObject;
+class TextureObject;
 // forward declare
 class NodeVisitor;
 
@@ -268,9 +268,9 @@ class OSG_EXPORT Image : public BufferData
           * If source is NULL then no operation happens, this Image is left unchanged.
         */
         virtual void copySubImage(int s_offset, int t_offset, int r_offset, const osg::Image* source);
-        inline const TextureGraphicObject* getTextureGraphicObject() const { return (TextureGraphicObject*)getGraphicsObject();}
-        //TextureGraphicObject* getTextureGraphicObject() const { return (TextureGraphicObject*)getGraphicsObject();}
-        void setTextureGraphicObject(TextureGraphicObject*u);
+        inline const osg::TextureObject* getTextureObject() const { return (osg::TextureObject*)getGraphicsObject();}
+        //osg::TextureObject* getosg::TextureObject() const { return (osg::TextureObject*)getGraphicsObject();}
+        void setTextureObject(osg::TextureObject*u);
 
         enum Origin
         {

--- a/include/osg/PrimitiveSet
+++ b/include/osg/PrimitiveSet
@@ -174,6 +174,7 @@ class OSG_EXPORT PrimitiveSet : public BufferData
             _numInstances(prim._numInstances),
             _mode(prim._mode) {}
 
+
         virtual bool isSameKindAs(const Object* obj) const { return dynamic_cast<const PrimitiveSet*>(obj)!=NULL; }
         virtual const char* libraryName() const { return "osg"; }
         virtual const char* className() const { return "PrimitiveSet"; }

--- a/include/osg/Program
+++ b/include/osg/Program
@@ -410,6 +410,15 @@ class OSG_EXPORT Program : public osg::StateAttribute
             void addShaderToAttach(Shader* shader);
             void addShaderToDetach(Shader* shader);
             bool getGlProgramInfoLog(std::string& log) const;
+            virtual void release(){}
+            virtual void dirty(){}
+            virtual void clear(){}
+
+
+            ///TODO determine a ProgramObjectProfile characterizing how to generate the prog
+            class ProgramObjectProfile: public GraphicsObjectProfile{};
+            virtual GraphicsObjectProfile& getProfile(){  return _profil; }
+            ProgramObjectProfile _profil;
         };
 
         /** Get the PCP for a particular GL context */

--- a/include/osg/Texture
+++ b/include/osg/Texture
@@ -416,7 +416,7 @@ namespace osg {
 // forward declare
 class TextureObjectSet;
 class TextureObjectManager;
-class TextureGraphicObject;
+//class TextureObject;
 
 
 /** Texture pure virtual base class that encapsulates OpenGL texture
@@ -1255,12 +1255,12 @@ protected:
     double              _generateTime;
 };
 
-class OSG_EXPORT TextureGraphicObject : public PerContextGraphicObject{
+class OSG_EXPORT TextureObject : public PerContextGraphicObject{
 
 public:
-    TextureGraphicObject();
-    TextureGraphicObject(const TextureGraphicObject& ubo, const CopyOp& copyop=CopyOp::SHALLOW_COPY);
-    META_Object(osg, TextureGraphicObject);
+    TextureObject();
+    TextureObject(const TextureObject& ubo, const CopyOp& copyop=CopyOp::SHALLOW_COPY);
+    META_Object(osg, TextureObject);
 
     inline void setTextureObject(unsigned int contextID, Texture::TextureObject* glbo) const { setGraphicsObject(contextID, glbo); }
     inline Texture::TextureObject* getTextureObject(unsigned int contextID) const { return  (Texture::TextureObject* )getGraphicsObject(contextID) ; }
@@ -1270,12 +1270,12 @@ public:
 ///retro compat
 Texture::TextureObject* Texture::getTextureObject(unsigned int contextID) const
 {
-    return ((TextureGraphicObject*)(getBufferData()->getGraphicsObject()))->getTextureObject(contextID);
+    return ((osg::TextureObject*)(getBufferData()->getGraphicsObject()))->getTextureObject(contextID);
 }
 
 void Texture::setTextureObject(unsigned int contextID, Texture::TextureObject* to)
 {
-    ((TextureGraphicObject*)getBufferData()->getGraphicsObject())->setTextureObject(contextID,to);
+    ((osg::TextureObject*)getBufferData()->getGraphicsObject())->setTextureObject(contextID,to);
 }
 }
 

--- a/include/osg/Texture
+++ b/include/osg/Texture
@@ -407,12 +407,16 @@
 
 //#define OSG_COLLECT_TEXTURE_APPLIED_STATS 1
 
+///force an image with NULL data on texture without image setted
+#define FIX_DEPRECATED_IMAGELESS_TEXTURE 1
+
 namespace osg {
 
 
 // forward declare
 class TextureObjectSet;
 class TextureObjectManager;
+class TextureGraphicObject;
 
 
 /** Texture pure virtual base class that encapsulates OpenGL texture
@@ -654,17 +658,15 @@ class OSG_EXPORT Texture : public osg::StateAttribute
 
         class TextureObject;
 
-        /** Returns a pointer to the TextureObject for the current context. */
-        inline TextureObject* getTextureObject(unsigned int contextID) const
+          /** Returns a pointer to the TextureObject for the current context.* /
+             inline osg::TextureObject* getTextureObject() const
         {
-            return _textureObjectBuffer[contextID].get();
-        }
+                   return static_cast<osg::TextureObject*>(getBufferData()->getBufferObject());
+        }*/
 
-        inline void setTextureObject(unsigned int contextID, TextureObject* to)
-        {
-            _textureObjectBuffer[contextID] = to;
-        }
-
+        ///retro compat
+        inline TextureObject* getTextureObject(unsigned int contextID) const;
+        inline void setTextureObject(unsigned int contextID, TextureObject* to);
         /** Forces a recompile on next apply() of associated OpenGL texture
           * objects. */
         void dirtyTextureObject();
@@ -885,7 +887,7 @@ class OSG_EXPORT Texture : public osg::StateAttribute
 
     public:
 
-        struct OSG_EXPORT TextureProfile
+        struct OSG_EXPORT TextureProfile : public GraphicsObjectProfile
         {
             inline TextureProfile(GLenum target):
                 _target(target),
@@ -1069,9 +1071,6 @@ class OSG_EXPORT Texture : public osg::StateAttribute
 
             inline bool isReusable() const { return _allocated && _profile._width!=0; }
 
-            /** release TextureObject to the orphan list to be reused or deleted.*/
-            void release();
-
             GLuint              _id;
             TextureProfile      _profile;
             TextureObjectSet*   _set;
@@ -1081,7 +1080,11 @@ class OSG_EXPORT Texture : public osg::StateAttribute
             bool                _allocated;
             unsigned int        _frameLastUsed;
             double              _timeStamp;
-
+            /** release TextureObject to the orphan list to be reused or deleted.*/
+            virtual void release();
+            virtual void dirty(){ if(_texture)_texture->dirtyTextureObject(); }
+            virtual void clear(){}
+            virtual GraphicsObjectProfile & getProfile(){ return _profile;}
         protected:
             virtual ~TextureObject();
 
@@ -1116,7 +1119,7 @@ class OSG_EXPORT Texture : public osg::StateAttribute
     protected:
 
         typedef buffered_object< ref_ptr<TextureObject> >  TextureObjectBuffer;
-        mutable TextureObjectBuffer         _textureObjectBuffer;
+        //mutable TextureObjectBuffer         _textureObjectBuffer;
         mutable ref_ptr<GraphicsContext>    _readPBuffer;
 
 };
@@ -1254,6 +1257,29 @@ protected:
     unsigned int        _numGenerated;
     double              _generateTime;
 };
+
+class OSG_EXPORT TextureGraphicObject : public PerContextGraphicObject{
+
+public:
+    TextureGraphicObject();
+    TextureGraphicObject(const TextureGraphicObject& ubo, const CopyOp& copyop=CopyOp::SHALLOW_COPY);
+    META_Object(osg, TextureGraphicObject);
+
+    inline void setTextureObject(unsigned int contextID, Texture::TextureObject* glbo) const { setGraphicsObject(contextID, glbo); }
+    inline Texture::TextureObject* getTextureObject(unsigned int contextID) const { return  (Texture::TextureObject* )getGraphicsObject(contextID) ; }
+
+    virtual GraphicsObject* createGraphicsObject(unsigned int contextID) const;
+};
+///retro compat
+Texture::TextureObject* Texture::getTextureObject(unsigned int contextID) const
+{
+    return ((TextureGraphicObject*)(getBufferData()->getGraphicsObject()))->getTextureObject(contextID);
+}
+
+void Texture::setTextureObject(unsigned int contextID, Texture::TextureObject* to)
+{
+    ((TextureGraphicObject*)getBufferData()->getGraphicsObject())->setTextureObject(contextID,to);
+}
 }
 
 #endif

--- a/include/osg/Texture2D
+++ b/include/osg/Texture2D
@@ -146,7 +146,9 @@ class OSG_EXPORT Texture2D : public Texture
           * of two. */
         void copyTexSubImage2D(State& state, int xoffset, int yoffset, int x, int y, int width, int height );
 
-
+#ifdef FIX_DEPRECATED_IMAGELESS_TEXTURE
+        virtual void compileGLObjects(State& state) const;
+#endif
         /** Bind the texture object. If the texture object hasn't already been
           * compiled, create the texture mipmap levels. */
         virtual void apply(State& state) const;

--- a/src/osg/BindImageTexture.cpp
+++ b/src/osg/BindImageTexture.cpp
@@ -19,14 +19,13 @@ void BindImageTexture::apply(osg::State&state) const
 {
     if(_target.valid())
     {
-        Texture::TextureObject *to = _target->getTextureObject( state.getContextID() );
         GLBufferObject *globj = _target->getBufferData()->getBufferObject()->getGLBufferObject( state.getContextID() );
         if( !globj || globj->isDirty() )
         {
             // _target never been applied yet
             _target->apply(state);
-            to = _target->getTextureObject( state.getContextID() );
         }
+        Texture::TextureObject *to = _target->getTextureObject( state.getContextID() );
         state.get<osg::GLExtensions>()->glBindImageTexture(_imageunit, to->id(), _level, _layered, _layer, _access, _format);
     }
 

--- a/src/osg/BindImageTexture.cpp
+++ b/src/osg/BindImageTexture.cpp
@@ -19,7 +19,7 @@ void BindImageTexture::apply(osg::State&state) const
 {
     if(_target.valid())
     {
-        GLBufferObject *globj = _target->getBufferData()->getBufferObject()->getGLBufferObject( state.getContextID() );
+        GraphicsObject *globj = _target->getBufferData()->getGLGraphicsObject( state.getContextID() );
         if( !globj || globj->isDirty() )
         {
             // _target never been applied yet

--- a/src/osg/GLObjects.cpp
+++ b/src/osg/GLObjects.cpp
@@ -43,11 +43,12 @@ void osg::discardAllGLObjects(unsigned int contextID)
 //
 // GraphicsObject
 //
+/*
 GraphicsObject::GraphicsObject()
 {
 //    OSG_NOTICE<<"GraphicsObject::GraphicsObject() "<<this<<std::endl;
 }
-
+*/
 GraphicsObject::~GraphicsObject()
 {
 //    OSG_NOTICE<<"GraphicsObject::~GraphicsObject() "<<this<<std::endl;

--- a/src/osg/Image.cpp
+++ b/src/osg/Image.cpp
@@ -218,9 +218,9 @@ Image::Image()
     _dimensionsChangedCallbacks()
 {
     setDataVariance(STATIC);
-    setTextureGraphicObject(new osg::TextureGraphicObject());
+    setTextureObject(new osg::TextureObject());
 }
-void Image::setTextureGraphicObject(TextureGraphicObject*u)  { setGraphicsObject(u);}
+void Image::setTextureObject(osg::TextureObject*u)  { setGraphicsObject(u);}
 Image::Image(const Image& image,const CopyOp& copyop):
     BufferData(image,copyop),
     _fileName(image._fileName),
@@ -255,7 +255,7 @@ Image::Image(const Image& image,const CopyOp& copyop):
             OSG_WARN<<"Warning: Image::Image(const Image&, const CopyOp&) out of memory, no image copy made."<<std::endl;
         }
     }
-    setTextureGraphicObject(new osg::TextureGraphicObject());
+    setTextureObject(new osg::TextureObject());
 }
 
 Image::~Image()

--- a/src/osg/Image.cpp
+++ b/src/osg/Image.cpp
@@ -218,8 +218,9 @@ Image::Image()
     _dimensionsChangedCallbacks()
 {
     setDataVariance(STATIC);
+    setTextureGraphicObject(new osg::TextureGraphicObject());
 }
-
+void Image::setTextureGraphicObject(TextureGraphicObject*u)  { setGraphicsObject(u);}
 Image::Image(const Image& image,const CopyOp& copyop):
     BufferData(image,copyop),
     _fileName(image._fileName),
@@ -254,6 +255,7 @@ Image::Image(const Image& image,const CopyOp& copyop):
             OSG_WARN<<"Warning: Image::Image(const Image&, const CopyOp&) out of memory, no image copy made."<<std::endl;
         }
     }
+    setTextureGraphicObject(new osg::TextureGraphicObject());
 }
 
 Image::~Image()

--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -485,7 +485,7 @@ void TextureObjectSet::deleteAllTextureObjects()
         ref_ptr<Texture> original_texture = glto->getTexture();
         if (original_texture.valid())
         {
-            static_cast<TextureGraphicObject*>(const_cast<PerContextGraphicObject*>(original_texture->getBufferData()->getGraphicsObject()))->setTextureObject(_contextID,0);
+            static_cast<osg::TextureObject*>(const_cast<PerContextGraphicObject*>(original_texture->getBufferData()->getGraphicsObject()))->setTextureObject(_contextID,0);
             //original_texture->setTextureObject(_contextID,0);
         }
     }
@@ -2079,7 +2079,7 @@ void Texture::computeRequiredTextureDimensions(State& state, const osg::Image& i
 
 bool Texture::areAllTextureObjectsLoaded() const
 {
-    osg::TextureGraphicObject* to = (osg::TextureGraphicObject*) getBufferData()->getGraphicsObject();
+    osg::TextureObject* to = (osg::TextureObject*) getBufferData()->getGraphicsObject();
 
     for(unsigned int i=0;i<DisplaySettings::instance()->getMaxNumberOfGraphicsContexts();++i)
     {
@@ -2833,7 +2833,7 @@ void Texture::releaseGLObjects(State* state) const
 //    if (state) OSG_NOTICE<<"Texture::releaseGLObjects contextID="<<state->getContextID()<<std::endl;
 //    else OSG_NOTICE<<"Texture::releaseGLObjects no State "<<std::endl;
     if (getImage(0))    ///delegation to Image
-        getImage(0)->getTextureGraphicObject()->releaseGLObjects(state);
+        getImage(0)->getTextureObject()->releaseGLObjects(state);
 
    /*
     if (!state) const_cast<Texture*>(this)->dirtyTextureObject();
@@ -2849,10 +2849,10 @@ void Texture::releaseGLObjects(State* state) const
     } */
 }
 
-TextureGraphicObject::TextureGraphicObject():PerContextGraphicObject(){}
-TextureGraphicObject::TextureGraphicObject(const TextureGraphicObject& ubo, const CopyOp& copyop):PerContextGraphicObject(ubo,copyop){}
+TextureObject::TextureObject():PerContextGraphicObject(){}
+TextureObject::TextureObject(const osg::TextureObject& ubo, const CopyOp& copyop):PerContextGraphicObject(ubo,copyop){}
 
-GraphicsObject* TextureGraphicObject::createGraphicsObject(unsigned int contextID) const
+GraphicsObject* osg::TextureObject::createGraphicsObject(unsigned int contextID) const
 {
     // OSG_NOTICE<<"TextureObject::getOrCreateGLBufferObject() _glBufferObjects[contextID]->getProfile()._size() = "<<_glBufferObjects[contextID]->getProfile()._size<<std::endl;
 OSG_FATAL<<"can't create TextureObject without a Texture: createGraphicsObject interface can't be used until i'll' add a new interface attribute(ex: HostSideGLCreator)"<<std::endl;

--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -485,7 +485,8 @@ void TextureObjectSet::deleteAllTextureObjects()
         ref_ptr<Texture> original_texture = glto->getTexture();
         if (original_texture.valid())
         {
-            original_texture->setTextureObject(_contextID,0);
+            static_cast<TextureGraphicObject*>(const_cast<PerContextGraphicObject*>(original_texture->getBufferData()->getGraphicsObject()))->setTextureObject(_contextID,0);
+            //original_texture->setTextureObject(_contextID,0);
         }
     }
 
@@ -1026,8 +1027,9 @@ osg::ref_ptr<Texture::TextureObject> TextureObjectManager::generateTextureObject
 
 Texture::TextureObject* Texture::generateAndAssignTextureObject(unsigned int contextID, GLenum target) const
 {
-    _textureObjectBuffer[contextID] = generateTextureObject(this, contextID, target);
-    return _textureObjectBuffer[contextID].get();
+    const_cast<BufferData*>(getBufferData())->getBufferObject()->setGraphicsObject(contextID,generateTextureObject(this, contextID, target));
+    //_textureObjectBuffer[contextID] = generateTextureObject(this, contextID, target);
+    return getTextureObject(contextID);//_textureObjectBuffer[contextID].get();
 }
 
 Texture::TextureObject* Texture::generateAndAssignTextureObject(
@@ -1040,8 +1042,9 @@ Texture::TextureObject* Texture::generateAndAssignTextureObject(
                                              GLsizei   depth,
                                              GLint     border) const
 {
-    _textureObjectBuffer[contextID] = generateTextureObject(this, contextID, target, numMipmapLevels, internalFormat, width, height, depth, border);
-    return _textureObjectBuffer[contextID].get();
+    //_textureObjectBuffer[contextID] =
+    const_cast<BufferData*>(getBufferData())->getBufferObject()->setGraphicsObject(contextID,generateTextureObject(this, contextID, target, numMipmapLevels, internalFormat, width, height, depth, border));
+    return getTextureObject(contextID);//_textureObjectBuffer[contextID].get();
 }
 
 TextureObjectSet* TextureObjectManager::getTextureObjectSet(const Texture::TextureProfile& profile)
@@ -1326,14 +1329,14 @@ int Texture::compareTexture(const Texture& rhs) const
 
 int Texture::compareTextureObjects(const Texture& rhs) const
 {
-    if (_textureObjectBuffer.size()<rhs._textureObjectBuffer.size()) return -1;
+   /* if (_textureObjectBuffer.size()<rhs._textureObjectBuffer.size()) return -1;
     if (rhs._textureObjectBuffer.size()<_textureObjectBuffer.size()) return 1;
     for(unsigned int i=0; i<_textureObjectBuffer.size(); ++i)
     {
         if (_textureObjectBuffer[i] < rhs._textureObjectBuffer[i]) return -1;
         else if (rhs._textureObjectBuffer[i] < _textureObjectBuffer[i]) return 1;
-    }
-    return 0;
+    }*/
+    return getBufferData()->getBufferObject()->comparePerContextObjects(*rhs.getBufferData()->getBufferObject());
 }
 
 void Texture::setWrap(WrapParameter which, WrapMode wrap)
@@ -1420,14 +1423,15 @@ void Texture::setLODBias(float anis)
 /** Force a recompile on next apply() of associated OpenGL texture objects.*/
 void Texture::dirtyTextureObject()
 {
-    for(unsigned int i=0; i<_textureObjectBuffer.size();++i)
+    getBufferData()->getBufferObject()->releaseGLObjects();
+   /* for(unsigned int i=0; i<_textureObjectBuffer.size();++i)
     {
         if (_textureObjectBuffer[i].valid())
         {
             _textureObjectBuffer[i]->release();
             _textureObjectBuffer[i] = 0;
         }
-    }
+    }*/
 }
 
 void Texture::dirtyTextureParameters()
@@ -2075,9 +2079,11 @@ void Texture::computeRequiredTextureDimensions(State& state, const osg::Image& i
 
 bool Texture::areAllTextureObjectsLoaded() const
 {
+    osg::TextureGraphicObject* to = (osg::TextureGraphicObject*) getBufferData()->getGraphicsObject();
+
     for(unsigned int i=0;i<DisplaySettings::instance()->getMaxNumberOfGraphicsContexts();++i)
     {
-        if (_textureObjectBuffer[i]==0) return false;
+        if (to->getTextureObject(i)==0) return false;
     }
     return true;
 }
@@ -2818,7 +2824,6 @@ void Texture::compileGLObjects(State& state) const
 
 void Texture::resizeGLObjectBuffers(unsigned int maxSize)
 {
-    _textureObjectBuffer.resize(maxSize);
     _texParametersDirtyList.resize(maxSize);
     _texMipmapGenerationDirtyList.resize(maxSize);
 }
@@ -2827,7 +2832,10 @@ void Texture::releaseGLObjects(State* state) const
 {
 //    if (state) OSG_NOTICE<<"Texture::releaseGLObjects contextID="<<state->getContextID()<<std::endl;
 //    else OSG_NOTICE<<"Texture::releaseGLObjects no State "<<std::endl;
+    if (getImage(0))    ///delegation to Image
+        getImage(0)->getTextureGraphicObject()->releaseGLObjects(state);
 
+   /*
     if (!state) const_cast<Texture*>(this)->dirtyTextureObject();
     else
     {
@@ -2838,7 +2846,18 @@ void Texture::releaseGLObjects(State* state) const
 
             _textureObjectBuffer[contextID] = 0;
         }
-    }
+    } */
+}
+
+TextureGraphicObject::TextureGraphicObject():PerContextGraphicObject(){}
+TextureGraphicObject::TextureGraphicObject(const TextureGraphicObject& ubo, const CopyOp& copyop):PerContextGraphicObject(ubo,copyop){}
+
+GraphicsObject* TextureGraphicObject::createGraphicsObject(unsigned int contextID) const
+{
+    // OSG_NOTICE<<"TextureObject::getOrCreateGLBufferObject() _glBufferObjects[contextID]->getProfile()._size() = "<<_glBufferObjects[contextID]->getProfile()._size<<std::endl;
+OSG_FATAL<<"can't create TextureObject without a Texture: createGraphicsObject interface can't be used until i'll' add a new interface attribute(ex: HostSideGLCreator)"<<std::endl;
+   //unused return osg::get<TextureObjectManager>(contextID)->generateTextureObject(this);//static_cast<Texture::TextureProfile&>(_glBufferObjects[contextID]->getProfile()));
+return 0;
 }
 
 }

--- a/src/osg/Texture1D.cpp
+++ b/src/osg/Texture1D.cpp
@@ -137,7 +137,7 @@ void Texture1D::apply(State& state) const
     // get the texture object for the current contextID.
     TextureObject* textureObject = getTextureObject(contextID);
     const BufferObject* bo=getBufferData()->getBufferObject();
-    osg::TextureGraphicObject * To=(osg::TextureGraphicObject * )(bo);
+    osg::TextureObject * To=(osg::TextureObject * )(bo);
 
     if (textureObject)
     {

--- a/src/osg/Texture1D.cpp
+++ b/src/osg/Texture1D.cpp
@@ -136,6 +136,8 @@ void Texture1D::apply(State& state) const
 
     // get the texture object for the current contextID.
     TextureObject* textureObject = getTextureObject(contextID);
+    const BufferObject* bo=getBufferData()->getBufferObject();
+    osg::TextureGraphicObject * To=(osg::TextureGraphicObject * )(bo);
 
     if (textureObject)
     {
@@ -149,8 +151,10 @@ void Texture1D::apply(State& state) const
 
             if (!textureObject->match(GL_TEXTURE_1D, new_numMipmapLevels, _internalFormat, new_width, 1, 1, _borderWidth))
             {
-                _textureObjectBuffer[contextID]->release();
-                _textureObjectBuffer[contextID] = 0;
+                //_textureObjectBuffer[contextID]->release();
+                textureObject->release();
+                To->setTextureObject( contextID,0);
+                //_textureObjectBuffer[contextID] = 0;
                 textureObject = 0;
             }
         }
@@ -213,13 +217,14 @@ void Texture1D::apply(State& state) const
 
         textureObject->setAllocated(_numMipmapLevels,_internalFormat,_textureWidth,1,1,0);
 
-        _textureObjectBuffer[contextID] = textureObject;
+        To->setTextureObject(contextID, textureObject);
+        //_textureObjectBuffer[contextID] = textureObject;
 
-        // unref image data?
+        // unref image: release data but keep textureobject
         if (isSafeToUnrefImageData(state) && _image->getDataVariance()==STATIC)
         {
             Texture1D* non_const_this = const_cast<Texture1D*>(this);
-            non_const_this->_image = NULL;
+            non_const_this->_image ->unrefData();
         }
 
     }

--- a/src/osg/Texture2D.cpp
+++ b/src/osg/Texture2D.cpp
@@ -184,8 +184,8 @@ void Texture2D::apply(State& state) const
     const unsigned int contextID = state.getContextID();
 
     // get the texture object for the current contextID.
-    TextureObject* textureObject = getTextureObject(contextID);
-    const osg::TextureGraphicObject * to= getImage()->getTextureGraphicObject();
+    const osg::TextureObject * to = getImage()->getTextureObject();
+    Texture::TextureObject* textureObject = to->getTextureObject(contextID);
     if (textureObject)
     {
         bool textureObjectInvalidated = false;

--- a/src/osg/Texture2DArray.cpp
+++ b/src/osg/Texture2DArray.cpp
@@ -246,7 +246,7 @@ void Texture2DArray::apply(State& state) const
 
     // get the texture object for the current contextID.
     TextureObject* textureObject = getTextureObject(contextID);
-    osg::TextureGraphicObject * to= ( osg::TextureGraphicObject*)( getBufferData()->getBufferObject());
+    osg::TextureObject * to= ( osg::TextureObject*)( getBufferData()->getBufferObject());
     GLsizei textureDepth = computeTextureDepth();
 
     if (textureObject && textureDepth>0)

--- a/src/osg/Texture2DArray.cpp
+++ b/src/osg/Texture2DArray.cpp
@@ -246,7 +246,7 @@ void Texture2DArray::apply(State& state) const
 
     // get the texture object for the current contextID.
     TextureObject* textureObject = getTextureObject(contextID);
-
+    osg::TextureGraphicObject * to= ( osg::TextureGraphicObject*)( getBufferData()->getBufferObject());
     GLsizei textureDepth = computeTextureDepth();
 
     if (textureObject && textureDepth>0)
@@ -264,8 +264,10 @@ void Texture2DArray::apply(State& state) const
 
             if (!textureObject->match(GL_TEXTURE_2D_ARRAY_EXT, new_numMipmapLevels, _internalFormat, new_width, new_height, textureDepth, _borderWidth))
             {
-                _textureObjectBuffer[contextID]->release();
-                _textureObjectBuffer[contextID] = 0;
+                textureObject->release();
+                to->setTextureObject(contextID,0);
+                //_textureObjectBuffer[contextID]->release();
+                //_textureObjectBuffer[contextID] = 0;
                 textureObject = 0;
             }
         }

--- a/src/osg/Texture3D.cpp
+++ b/src/osg/Texture3D.cpp
@@ -215,6 +215,7 @@ void Texture3D::apply(State& state) const
     // get the texture object for the current contextID.
     TextureObject* textureObject = getTextureObject(contextID);
 
+    osg::TextureGraphicObject * to= ( osg::TextureGraphicObject*)( getBufferData()->getBufferObject());
     if (textureObject)
     {
         if (_image.valid() && getModifiedCount(contextID) != _image->getModifiedCount())
@@ -229,8 +230,10 @@ void Texture3D::apply(State& state) const
 
             if (!textureObject->match(GL_TEXTURE_3D, new_numMipmapLevels, _internalFormat, new_width, new_height, new_depth, _borderWidth))
             {
-                _textureObjectBuffer[contextID]->release();
-                _textureObjectBuffer[contextID] = 0;
+                textureObject->release();
+                to->setTextureObject(contextID,0);
+                //_textureObjectBuffer[contextID]->release();
+                //_textureObjectBuffer[contextID] = 0;
                 textureObject = 0;
             }
         }

--- a/src/osg/Texture3D.cpp
+++ b/src/osg/Texture3D.cpp
@@ -215,7 +215,7 @@ void Texture3D::apply(State& state) const
     // get the texture object for the current contextID.
     TextureObject* textureObject = getTextureObject(contextID);
 
-    osg::TextureGraphicObject * to= ( osg::TextureGraphicObject*)( getBufferData()->getBufferObject());
+    osg::TextureObject * to= ( osg::TextureObject*)( getBufferData()->getBufferObject());
     if (textureObject)
     {
         if (_image.valid() && getModifiedCount(contextID) != _image->getModifiedCount())

--- a/src/osg/TextureCubeMap.cpp
+++ b/src/osg/TextureCubeMap.cpp
@@ -205,7 +205,8 @@ void TextureCubeMap::apply(State& state) const
         return;
 
     // get the texture object for the current contextID.
-    TextureObject* textureObject = getTextureObject(contextID);
+    const TextureGraphicObject * to = getImage(0)->getTextureGraphicObject();
+    TextureObject* textureObject = to->getTextureObject(contextID);
 
     if (textureObject)
     {
@@ -222,8 +223,10 @@ void TextureCubeMap::apply(State& state) const
 
             if (!textureObject->match(GL_TEXTURE_CUBE_MAP, new_numMipmapLevels, _internalFormat, new_width, new_height, 1, _borderWidth))
             {
-                _textureObjectBuffer[contextID]->release();
-                _textureObjectBuffer[contextID] = 0;
+                textureObject->release();
+                to->setGraphicsObject(contextID,0);
+               // _textureObjectBuffer[contextID]->release();
+               // _textureObjectBuffer[contextID] = 0;
                 textureObject = 0;
             }
         }

--- a/src/osg/TextureCubeMap.cpp
+++ b/src/osg/TextureCubeMap.cpp
@@ -205,7 +205,7 @@ void TextureCubeMap::apply(State& state) const
         return;
 
     // get the texture object for the current contextID.
-    const TextureGraphicObject * to = getImage(0)->getTextureGraphicObject();
+    const osg::TextureObject * to = getImage(0)->getTextureObject();
     TextureObject* textureObject = to->getTextureObject(contextID);
 
     if (textureObject)

--- a/src/osg/TextureRectangle.cpp
+++ b/src/osg/TextureRectangle.cpp
@@ -168,7 +168,8 @@ void TextureRectangle::apply(State& state) const
     const unsigned int contextID = state.getContextID();
 
     // get the texture object for the current contextID.
-    TextureObject* textureObject = getTextureObject(contextID);
+    const TextureGraphicObject *to = getImage(0)->getTextureGraphicObject();
+    TextureObject* textureObject = to->getTextureObject(contextID);
 
     if (textureObject)
     {
@@ -184,8 +185,10 @@ void TextureRectangle::apply(State& state) const
 
             if (!textureObject->match(GL_TEXTURE_RECTANGLE, new_numMipmapLevels, _internalFormat, new_width, new_height, 1, _borderWidth))
             {
-                _textureObjectBuffer[contextID]->release();
-                _textureObjectBuffer[contextID] = 0;
+                textureObject->release();
+                to->setTextureObject(contextID,0);
+               // _textureObjectBuffer[contextID]->release();
+              //  _textureObjectBuffer[contextID] = 0;
                 textureObject = 0;
             }
         }

--- a/src/osg/TextureRectangle.cpp
+++ b/src/osg/TextureRectangle.cpp
@@ -168,8 +168,8 @@ void TextureRectangle::apply(State& state) const
     const unsigned int contextID = state.getContextID();
 
     // get the texture object for the current contextID.
-    const TextureGraphicObject *to = getImage(0)->getTextureGraphicObject();
-    TextureObject* textureObject = to->getTextureObject(contextID);
+    const osg::TextureObject *to = getImage(0)->getTextureObject();
+    Texture::TextureObject* textureObject = to->getTextureObject(contextID);
 
     if (textureObject)
     {


### PR DESCRIPTION
**Not candidate to merge but would require community feeback as i change a lot of things**
sorry in advance for the 16 files changes in one commit :~/
but i need to know if this fits your insights about osg

I'll try to remove non pertinents stuff before you look at it (I fail believing a GLProfileInterface can be usefull)

ChangeLog (in absence of commit history)
- introduce a osg::TextureObject ( buffered_objectPCTOs  [PCTO==Texture::TextureObject] )
- inject a base class  PerContextGraphicObject  (base of BufferObject, TextureObject  (bufferedPCTOs), ProgramsObject ..) that is just a per context GL object container interface
- deprecate Image less Texture by adding an Image with NULL data  and make unrefimageafterapply just deallocate Image (may require further data==0 tests to ensure retrocomp)
- remove buffered_objectPCTOs from Texture to use  the osg::TextureObject  of its Image instead

It fixes the bug without rollback and bring some homogenity ...

If it's okay I'll  redo the pr step by step including involved changes in serializers