### PR TITLE
bugfix: GetScalarValue returns inverted values for booleans

### DIFF
--- a/include/osg/ValueObject
+++ b/include/osg/ValueObject
@@ -144,7 +144,7 @@ class ValueObject : public Object
             bool set;
             T value;
 
-            virtual void apply(bool in_value) { value = in_value ? 0 : 1; set = true; }
+            virtual void apply(bool in_value) { value = in_value ? 1 : 0; set = true; }
             virtual void apply(char in_value) { value = in_value; set = true; }
             virtual void apply(unsigned char in_value) { value = in_value; set = true; }
             virtual void apply(short in_value) { value = in_value; set = true; }
@@ -215,7 +215,7 @@ class ValueObject : public Object
 
 
         template<typename T>
-        class SetScalarValue : public ValueObject::GetValueVisitor
+        class SetScalarValue : public ValueObject::SetValueVisitor
         {
         public:
 


### PR DESCRIPTION
bugfix: 
-GetScalarValue returns inverted values for booleans
-SetScalarValue needs to be a SetValueVisitor

Hi Robert,
I saw a very strange line in the code you added last December, and while trying to test I found a second. I don't think this code gets used anywhere, but that makes it a lot simpler to fix it now.
Regards, Laurens.


test code: (after changing SetScalarValue to inherit from SetValueVisitor
	{
		OSG_NOTICE << "test bool" << std::endl;
		bool test = true;
		osg::TemplateValueObject<bool> *obj = new osg::TemplateValueObject<bool>("test", test);
		obj->getScalarValue(test);
		OSG_NOTICE << "test is supposed to be true; value:" << test << std::endl;
		obj->setScalarValue(test);
		obj->getScalarValue(test);
		OSG_NOTICE << "test set/get; value:" << test << std::endl;
		test = true;
		obj->setScalarValue(test);
		obj->getScalarValue(test);
		OSG_NOTICE << "test is supposed to be true; value:" << test << std::endl;
		test = false;
		obj->setScalarValue(test);
		obj->getScalarValue(test);
		OSG_NOTICE << "test is supposed to be false; value:" << test << std::endl;
	}

	{
		int test = true;
		OSG_NOTICE << "test int" << std::endl;
		osg::TemplateValueObject<int> *obj = new osg::TemplateValueObject<int>("test", test);
		obj->getScalarValue(test);
		OSG_NOTICE << "test is supposed to be true; value:" << test << std::endl;
		obj->setScalarValue(test);
		obj->getScalarValue(test);
		OSG_NOTICE << "test set/get; value:" << test << std::endl;
		test = true;
		obj->setScalarValue(test);
		obj->getScalarValue(test);
		OSG_NOTICE << "test is supposed to be true; value:" << test << std::endl;
		test = false;
		obj->setScalarValue(test);
		obj->getScalarValue(test);
		OSG_NOTICE << "test is supposed to be false; value:" << test << std::endl;
	}
output:
test bool
test is supposed to be true; value:0
test set/get; value:1
test is supposed to be true; value:0
test is supposed to be false; value:1
test int
test is supposed to be true; value:1
test set/get; value:1
test is supposed to be true; value:1
test is supposed to be false; value:0

