### PR TITLE
avoid visual studio warning about gethostbyname being deprecated.

### DIFF
--- a/src/osgPlugins/osc/ip/win32/NetworkingUtils.cpp
+++ b/src/osgPlugins/osc/ip/win32/NetworkingUtils.cpp
@@ -28,7 +28,7 @@
 	WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 #include "ip/NetworkingUtils.h"
-
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
 #include <winsock2.h>   // this must come first to prevent errors with MSVC7
 #include <windows.h>
 #include <stdlib.h>


### PR DESCRIPTION
avoid visual studio warning about gethostbyname being deprecated by #define _WINSOCK_DEPRECATED_NO_WARNINGS

I guess gethostbyname will still be supported by windows for a while.