### PR TITLE
Addition of radius parameter for ClusterCullingCallback's constructor

### DIFF
--- a/include/osg/ClusterCullingCallback
+++ b/include/osg/ClusterCullingCallback
@@ -28,7 +28,7 @@ class OSG_EXPORT ClusterCullingCallback : public DrawableCullCallback, public No
 
         ClusterCullingCallback();
         ClusterCullingCallback(const ClusterCullingCallback& ccc,const CopyOp& copyop);
-        ClusterCullingCallback(const osg::Vec3& controlPoint, const osg::Vec3& normal, float deviation);
+        ClusterCullingCallback(const osg::Vec3& controlPoint, const osg::Vec3& normal, float deviation, float radius=-1.0f);
         ClusterCullingCallback(const osg::Drawable* drawable);
 
         META_Object(osg,ClusterCullingCallback);

--- a/src/osg/ClusterCullingCallback.cpp
+++ b/src/osg/ClusterCullingCallback.cpp
@@ -40,10 +40,10 @@ ClusterCullingCallback::ClusterCullingCallback(const ClusterCullingCallback& ccc
 {
 }
 
-ClusterCullingCallback::ClusterCullingCallback(const osg::Vec3& controlPoint, const osg::Vec3& normal, float deviation):
+ClusterCullingCallback::ClusterCullingCallback(const osg::Vec3& controlPoint, const osg::Vec3& normal, float deviation, float radius):
     _controlPoint(controlPoint),
     _normal(normal),
-    _radius(-1.0f),
+    _radius(radius),
     _deviation(deviation)
 {
 }


### PR DESCRIPTION
The radius parameter is already present in ClusterCullingCallback's set method but has been forgotten in the constructor.

The change is backwards compatible.