### PR TITLE
Remove OSG_EXPORT from deprecated_osg::Geometry in inventor plugin.

### DIFF
--- a/src/osgPlugins/Inventor/DeprecatedGeometry.h
+++ b/src/osgPlugins/Inventor/DeprecatedGeometry.h
@@ -45,7 +45,7 @@ namespace deprecated_osg {
  * it is recommended that you should migrate your code to work just with osg::Geometry as existing
  * deprecated_osg::Geometry will be removed in future release.
 */
-class OSG_EXPORT Geometry : public osg::Geometry
+class Geometry : public osg::Geometry
 {
     public:
         Geometry() : osg::Geometry() {}


### PR DESCRIPTION
Hi Robert,
I compiled the coin library for windows, and found that the Inventor plugin in the 3.5.x tree doesn't compile on windows, due to a wrong __declspec(dllimport) modifier. This was introduced when the code was moved into the plugin (and removed from the main osg.dll) on 4 september 2016 - apparently it's not compiled on windows very often.
Regards, Laurens.