### PR TITLE
remove _EXT from GL_MAX_ARRAY_TEXTURE_LAYERS_EXT 

### DIFF
--- a/src/osg/GLExtensions.cpp
+++ b/src/osg/GLExtensions.cpp
@@ -969,7 +969,7 @@ GLExtensions::GLExtensions(unsigned int in_contextID):
     max2DSize = 0;
     if (validContext) glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max2DSize);
     maxLayerCount = 0;
-    if (validContext) glGetIntegerv(GL_MAX_ARRAY_TEXTURE_LAYERS_EXT, &maxLayerCount);
+    if (validContext) glGetIntegerv(GL_MAX_ARRAY_TEXTURE_LAYERS, &maxLayerCount);
 
     // Bindless textures
     setGLExtensionFuncPtr(glGetTextureHandle,             "glGetTextureHandle", "glGetTextureHandleARB","glGetTextureHandleNV", validContext);

--- a/src/osg/Image.cpp
+++ b/src/osg/Image.cpp
@@ -1274,7 +1274,7 @@ void Image::readImageFromCurrentTexture(unsigned int contextID, bool copyMipMaps
 
     if (extensions->isTexture2DArraySupported)
     {
-        glGetBooleanv(GL_TEXTURE_BINDING_2D_ARRAY_EXT, &binding2DArray);
+        glGetBooleanv(GL_TEXTURE_BINDING_2D_ARRAY, &binding2DArray);
     }
 
     GLenum textureMode = binding1D ? GL_TEXTURE_1D : binding2D ? GL_TEXTURE_2D : bindingRect ? GL_TEXTURE_RECTANGLE : binding3D ? GL_TEXTURE_3D : binding2DArray ? GL_TEXTURE_2D_ARRAY : 0;


### PR DESCRIPTION
and GL_TEXTURE_BINDI…NG_2D_ARRAY_EXT

to fix a compile error on windows.
Regards, Laurens.