### PR TITLE
renderstage: added comment about draw buffer related issues

### DIFF
--- a/src/osgUtil/CullVisitor.cpp
+++ b/src/osgUtil/CullVisitor.cpp
@@ -1595,6 +1595,7 @@ void CullVisitor::apply(osg::Camera& camera)
 
             rtts->setCamera(&camera);
 
+            // Note #1: here is an example of render stage setup that will be wiped if an FBO is used
             if ( camera.getInheritanceMask() & DRAW_BUFFER )
             {
                 // inherit draw buffer from above.

--- a/src/osgUtil/SceneView.cpp
+++ b/src/osgUtil/SceneView.cpp
@@ -1333,6 +1333,14 @@ void SceneView::draw()
     {
 
         // Need to restore draw buffer when toggling Stereo off.
+        // Wrong #2 : if the comment above is still relevant then the restoring should be done
+        // only if this SceneView switched from a stereo mode to a non stereo node (this class needs to track that switch).
+        // As mentioned, wrong #2 has the side effect of "fixing" wrong #1, but only if the draw buffer was set explicitly on the camera.
+        // A camera might not do that in order to use defaults.
+        // Also note that the code below restores the state only partially. The draw buffer apply state is forced to true.
+        // This will then cause glDrawBuffer() to be called on each frame (very minor impact on performance).
+        // Finally it is important to fix wrong #1 if wrong #2 is fixed.
+        // At this stage one might think that everything is ok, but alas there remains wrong #3 in RenderStage...
         if( 0 == ( _camera->getInheritanceMask() & DRAW_BUFFER ) )
         {
             _renderStage->setDrawBuffer(_camera->getDrawBuffer());


### PR DESCRIPTION
I think I found one of those "two wrongs make a right" situation.
Might sound ok at first until you realize that you will have to add more "wrongs" to cover corner cases.

In the commit I have listed the 3 wrongs that work together.
The three wrongs should be read in order to get the global picture. Wrong #1 is in RenderStage.cpp.

The issues described in the commit affect osgEarth cameras that attach their color buffer in a deferred manner.
They ask OSG to not implicitly create a color buffer by calling setImplicitBufferAttachmentMask(0, 0).

When this happens and the draw buffer is not set explictly on the main camera (which happens when using Qt) then the draw buffer state is messed up and OSG ends up rendering to a GL_NONE draw buffer.

If you are ok with this analysis, then I can propose tested fixes for all the listed issues.

See https://github.com/gwaldron/osgearth/issues/853 for more details.