### PR TITLE
osgDB: Fix handling of return value of loadLibrary in Registry.

### DIFF
--- a/src/osgDB/Registry.cpp
+++ b/src/osgDB/Registry.cpp
@@ -582,7 +582,7 @@ void Registry::readCommandLine(osg::ArgumentParser& arguments)
     std::string value;
     while(arguments.read("-l",value))
     {
-        if (loadLibrary(value)!=NOT_LOADED)
+        if (loadLibrary(value)==NOT_LOADED)
         {
             OSG_NOTICE<<"Unable to load library : "<<value<<std::endl;
         }
@@ -591,7 +591,7 @@ void Registry::readCommandLine(osg::ArgumentParser& arguments)
     while(arguments.read("-e",value))
     {
         std::string libName = createLibraryNameForExtension(value);
-        if (loadLibrary(libName)!=NOT_LOADED)
+        if (loadLibrary(libName)==NOT_LOADED)
         {
             OSG_NOTICE<<"Unable to load library : "<<libName<<std::endl;
         }


### PR DESCRIPTION
"Unable to load ..." was printed if the library could be loaded, and it wasn't if not.

This incorrect, inverted logic was probably a copy-paste error.