### PR TITLE
Fbo camera with dynamic color buffer attachment fixes

### DIFF
--- a/include/osgUtil/SceneView
+++ b/include/osgUtil/SceneView
@@ -570,6 +570,30 @@ class OSGUTIL_EXPORT SceneView : public osg::Object, public osg::CullSettings
         unsigned int                                _dynamicObjectCount;
 
         bool                                        _resetColorMaskToAllEnabled;
+
+        /** Indicates if stereo is toggled on */
+        bool                                        _stereo;
+
+        /** Struct to store and restore buffer states from and to a RenderStage */
+        struct RenderStageBuffers {
+            void store(const RenderStage *rs) {
+                _drawBuffer = rs->getDrawBuffer();
+                _drawBufferApplyMask = rs->getDrawBufferApplyMask();
+                _readBuffer = rs->getReadBuffer();
+                _readBufferApplyMask = rs->getReadBufferApplyMask();
+            }
+            void restore(RenderStage *rs) const {
+                rs->setDrawBuffer(_drawBuffer, _drawBufferApplyMask);
+                rs->setReadBuffer(_readBuffer, _readBufferApplyMask);
+            }
+            GLenum _drawBuffer;
+            bool   _drawBufferApplyMask;
+            GLenum _readBuffer;
+            bool   _readBufferApplyMask;
+        };
+
+        /** Used to restore buffer states when toggling stereo off */
+        RenderStageBuffers                          _renderStageBuffers;
 };
 
 }


### PR DESCRIPTION
The main issue I am trying to address here affects Camera's that use an FBO and attach their color buffer dynamically.
A camera must call setImplicitBufferAttachmentMask() to disable IMPLICIT_COLOR_BUFFER_ATTACHMENT in order to trigger the issue.
Once that is true, RenderStage will do some tricks to force the glCheckFramebufferStatus() call to succeed.
It does that by forcing glDrawBuffer/glReadBuffer to GL_NONE and does that permanently.
It will also force the RenderStage draw and read buffer states to GL_NONE.
This has most of the time no visible effects because for some reason related to stereo mode, SceneView will work around it.

But if the camera does not have an explicit draw buffer set then the workaround is not effective and glitches start to appear.
In that configuration the only glDrawBuffer call that happens is the one from the "trick" setting it to GL_NONE.
If the camera relies on the default (by not setting draw buffer explictly) then the GL_NONE sticks.
This explains why the new osgEarth rex engine is not working on Qt and maybe OSX.

The proposed fix is to make the "trick" less permanent. The glDrawBuffer is set to GL_NONE as before but only for the duration of the check.
This is acheived by using glPushAttrib() and glPopAttrib(). 
The fix also disables dubious calls to setDrawBuffer(GL_NONE, false) after the FBO is applied successfuly. 
I tested the fix only with GL 4.3 (the requirement to have a color buffer has been lifted after 4.1).

This issue can be reproduced with osgviewer by commenting out the following two lines in SingleWindow.cpp:

    view.getCamera()->setDrawBuffer(buffer);
    view.getCamera()->setReadBuffer(buffer);

With that change, osgviewer will render earth files as a black rectangle (with osgEarth 2.9). 


The "workaround" in SceneView comes from code that is documented as needed to restore draw buffer when toggling Stereo off.
The issue is that it does it on each frame if the camera draw buffer was explictly set and not just when toggling Stereo off !
Morevover, it looks like it does it partially.
The proposed fix is to _fully_ restore the draw buffer only when toggling Stereo off and not on each frame.

This issue is minor and does not need to be addressed to fix the main issue described above.
Note that if you address this issue then you must also address the main issue !
