### PR TITLE
fix msvc warning C4458: declaration of 'Cameras' hides class member

### DIFF
--- a/src/osgViewer/CompositeViewer.cpp
+++ b/src/osgViewer/CompositeViewer.cpp
@@ -1093,9 +1093,9 @@ void CompositeViewer::eventTraversal()
                 osg::GraphicsContext* gc = event->getGraphicsContext();
                 if (gc)
                 {
-                    typedef osg::GraphicsContext::Cameras Cameras;
-                    Cameras& cameras = gc->getCameras();
-                    for(Cameras::iterator citr = cameras.begin();
+                    typedef osg::GraphicsContext::Cameras CamList;
+                    CamList& cameras = gc->getCameras();
+                    for(CamList::iterator citr = cameras.begin();
                         citr != cameras.end();
                         ++citr)
                     {


### PR DESCRIPTION
Hi Robert,
Compiling OpenScenGraph-3.6 with visual studio 2017 I get a single warning:
OpenSceneGraph\src\osgViewer\CompositeViewer.cpp(1096): warning C4458: declaration of 'Cameras' hides class member
OpenSceneGraph\include\osgViewer/ViewerBase(263): note: see declaration of 'osgViewer::ViewerBase::Cameras' (compiling source file E:\osg\36\laurens\OpenSceneGraph\src\osgViewer\CompositeViewer.cpp)
I suppose this patch will work for master as well, but I don't have the 3.7 tree ready for testing yet so I did not check.
Regards, Laurens.