### PR TITLE
write binary file with a specific so version

### DIFF
--- a/include/osgDB/OutputStream
+++ b/include/osgDB/OutputStream
@@ -219,7 +219,7 @@ protected:
     osg::ref_ptr<OutputException> _exception;
     osg::ref_ptr<const osgDB::Options> _options;
 	
-	int _targetFileVersion;
+    int _targetFileVersion;
 };
 
 void OutputStream::throwException( const std::string& msg )

--- a/include/osgDB/OutputStream
+++ b/include/osgDB/OutputStream
@@ -79,7 +79,7 @@ public:
     OutputStream( const osgDB::Options* options );
     virtual ~OutputStream();
 
-    void setFileVersion( const std::string& d, int v ) { _domainVersionMap[d] = v; }
+    void setFileVersion( const std::string& d, int v );
     int getFileVersion( const std::string& d=std::string() ) const;
 
     bool isBinary() const { return _out->isBinary(); }
@@ -147,13 +147,13 @@ public:
     OutputStream& operator<<( const osg::BoundingSphered& bb );
 
     OutputStream& operator<<( const osg::Image* img ) { writeImage(img); return *this; }
-    OutputStream& operator<<( const osg::Array* a ) { writeObject(a); return *this; }
-    OutputStream& operator<<( const osg::PrimitiveSet* p ) { writeObject(p); return *this; }
+    OutputStream& operator<<( const osg::Array* a ) { if (_targetFileVersion >= 112) writeObject(a); else writeArray(a); return *this; }
+    OutputStream& operator<<( const osg::PrimitiveSet* p ) { if (_targetFileVersion >= 112) writeObject(p); else writePrimitiveSet(p); return *this; }
     OutputStream& operator<<( const osg::Object* obj ) { writeObject(obj); return *this; }
 
     OutputStream& operator<<( const osg::ref_ptr<osg::Image>& ptr ) { writeImage(ptr.get()); return *this; }
-    OutputStream& operator<<( const osg::ref_ptr<osg::Array>& ptr ) { writeObject(ptr.get()); return *this; }
-    OutputStream& operator<<( const osg::ref_ptr<osg::PrimitiveSet>& ptr ) { writeObject(ptr.get()); return *this; }
+    OutputStream& operator<<( const osg::ref_ptr<osg::Array>& ptr ) { if (_targetFileVersion >= 112) writeObject(ptr.get()); else writeArray(ptr.get()); return *this; }
+    OutputStream& operator<<( const osg::ref_ptr<osg::PrimitiveSet>& ptr ) { if (_targetFileVersion >= 112) writeObject(ptr.get()); else writePrimitiveSet(ptr.get()); return *this; }
 
     template<typename T> OutputStream& operator<<( const osg::ref_ptr<T>& ptr ) { writeObject(ptr.get()); return *this; }
 
@@ -218,6 +218,8 @@ protected:
     osg::ref_ptr<OutputIterator> _out;
     osg::ref_ptr<OutputException> _exception;
     osg::ref_ptr<const osgDB::Options> _options;
+	
+	int _targetFileVersion;
 };
 
 void OutputStream::throwException( const std::string& msg )

--- a/include/osgDB/OutputStream
+++ b/include/osgDB/OutputStream
@@ -79,7 +79,7 @@ public:
     OutputStream( const osgDB::Options* options );
     virtual ~OutputStream();
 
-    void setFileVersion( const std::string& d, int v );
+    void setFileVersion( const std::string& d, int v ) { _domainVersionMap[d] = v; }
     int getFileVersion( const std::string& d=std::string() ) const;
 
     bool isBinary() const { return _out->isBinary(); }
@@ -147,13 +147,13 @@ public:
     OutputStream& operator<<( const osg::BoundingSphered& bb );
 
     OutputStream& operator<<( const osg::Image* img ) { writeImage(img); return *this; }
-    OutputStream& operator<<( const osg::Array* a ) { if (_targetFileVersion >= 112) writeObject(a); else writeArray(a); return *this; }
-    OutputStream& operator<<( const osg::PrimitiveSet* p ) { if (_targetFileVersion >= 112) writeObject(p); else writePrimitiveSet(p); return *this; }
+    OutputStream& operator<<( const osg::Array* a ) { writeObject(a); return *this; }
+    OutputStream& operator<<( const osg::PrimitiveSet* p ) { writeObject(p); return *this; }
     OutputStream& operator<<( const osg::Object* obj ) { writeObject(obj); return *this; }
 
     OutputStream& operator<<( const osg::ref_ptr<osg::Image>& ptr ) { writeImage(ptr.get()); return *this; }
-    OutputStream& operator<<( const osg::ref_ptr<osg::Array>& ptr ) { if (_targetFileVersion >= 112) writeObject(ptr.get()); else writeArray(ptr.get()); return *this; }
-    OutputStream& operator<<( const osg::ref_ptr<osg::PrimitiveSet>& ptr ) { if (_targetFileVersion >= 112) writeObject(ptr.get()); else writePrimitiveSet(ptr.get()); return *this; }
+    OutputStream& operator<<( const osg::ref_ptr<osg::Array>& ptr ) { writeObject(ptr.get()); return *this; }
+    OutputStream& operator<<( const osg::ref_ptr<osg::PrimitiveSet>& ptr ) { writeObject(ptr.get()); return *this; }
 
     template<typename T> OutputStream& operator<<( const osg::ref_ptr<T>& ptr ) { writeObject(ptr.get()); return *this; }
 
@@ -218,8 +218,6 @@ protected:
     osg::ref_ptr<OutputIterator> _out;
     osg::ref_ptr<OutputException> _exception;
     osg::ref_ptr<const osgDB::Options> _options;
-	
-	int _targetFileVersion;
 };
 
 void OutputStream::throwException( const std::string& msg )

--- a/src/osgDB/OutputStream.cpp
+++ b/src/osgDB/OutputStream.cpp
@@ -70,7 +70,7 @@ OutputStream::OutputStream( const osgDB::Options* options )
             _targetFileVersion = version;
     }
 	
-	if (_targetFileVersion < 99) _useRobustBinaryFormat = false;
+    if (_targetFileVersion < 99) _useRobustBinaryFormat = false;
 }
 
 OutputStream::~OutputStream()
@@ -406,7 +406,7 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         {
             const osg::DrawArrays* da = static_cast<const osg::DrawArrays*>(p);
             *this << MAPPEE(PrimitiveType, da->getMode());
-			if (_targetFileVersion > 96) *this << da->getNumInstances();
+            if (_targetFileVersion > 96) *this << da->getNumInstances();
             *this << da->getFirst() << da->getCount() << std::endl;
         }
         break;
@@ -415,8 +415,8 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         {
             const osg::DrawArrayLengths* dl = static_cast<const osg::DrawArrayLengths*>(p);
             *this << MAPPEE(PrimitiveType, dl->getMode());
-			if (_targetFileVersion > 96) *this << dl->getNumInstances();
-			*this << dl->getFirst();
+            if (_targetFileVersion > 96) *this << dl->getNumInstances();
+            *this << dl->getFirst();
             writeArrayImplementation( dl, dl->size(), 4 );
         }
         break;
@@ -425,7 +425,7 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         {
             const osg::DrawElementsUByte* de = static_cast<const osg::DrawElementsUByte*>(p);
             *this << MAPPEE(PrimitiveType, de->getMode());
-			if (_targetFileVersion > 96) *this << de->getNumInstances();
+            if (_targetFileVersion > 96) *this << de->getNumInstances();
             writeArrayImplementation( de, de->size(), 4 );
         }
         break;
@@ -434,7 +434,7 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         {
             const osg::DrawElementsUShort* de = static_cast<const osg::DrawElementsUShort*>(p);
             *this << MAPPEE(PrimitiveType, de->getMode());
-			if (_targetFileVersion > 96) *this << de->getNumInstances();
+            if (_targetFileVersion > 96) *this << de->getNumInstances();
             writeArrayImplementation( de, de->size(), 4 );
         }
         break;
@@ -443,7 +443,7 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         {
             const osg::DrawElementsUInt* de = static_cast<const osg::DrawElementsUInt*>(p);
             *this << MAPPEE(PrimitiveType, de->getMode());
-			if (_targetFileVersion > 96) *this << de->getNumInstances();
+            if (_targetFileVersion > 96) *this << de->getNumInstances();
             writeArrayImplementation( de, de->size(), 4 );
         }
         break;

--- a/src/osgDB/OutputStream.cpp
+++ b/src/osgDB/OutputStream.cpp
@@ -79,8 +79,8 @@ OutputStream::~OutputStream()
 
 void OutputStream::setFileVersion( const std::string& d, int v )
 {
-	if (d.empty()) _targetFileVersion = v;
-	else _domainVersionMap[d] = v;
+    if (d.empty()) _targetFileVersion = v;
+    else _domainVersionMap[d] = v;
 }
 
 int OutputStream::getFileVersion( const std::string& d ) const

--- a/src/osgDB/OutputStream.cpp
+++ b/src/osgDB/OutputStream.cpp
@@ -25,7 +25,7 @@
 using namespace osgDB;
 
 OutputStream::OutputStream( const osgDB::Options* options )
-:   _writeImageHint(WRITE_USE_IMAGE_HINT), _useSchemaData(false), _useRobustBinaryFormat(true)
+:   _writeImageHint(WRITE_USE_IMAGE_HINT), _useSchemaData(false), _useRobustBinaryFormat(true), _targetFileVersion(OPENSCENEGRAPH_SOVERSION)
 {
     BEGIN_BRACKET.set( "{", +INDENT_VALUE );
     END_BRACKET.set( "}", -INDENT_VALUE );
@@ -61,15 +61,31 @@ OutputStream::OutputStream( const osgDB::Options* options )
                 _domainVersionMap[keyAndValue.front()] = atoi(keyAndValue.back().c_str());
         }
     }
+
+    if (!options->getPluginStringData("TargetFileVersion").empty())
+    {
+        std::string strVersion = options->getPluginStringData("TargetFileVersion");
+        int version = std::stoi(strVersion);
+        if (version > 0 && version <= OPENSCENEGRAPH_SOVERSION)
+            _targetFileVersion = version;
+    }
+	
+	if (_targetFileVersion < 99) _useRobustBinaryFormat = false;
 }
 
 OutputStream::~OutputStream()
 {
 }
 
+void OutputStream::setFileVersion( const std::string& d, int v )
+{
+	if (d.empty()) _targetFileVersion = v;
+	else _domainVersionMap[d] = v;
+}
+
 int OutputStream::getFileVersion( const std::string& d ) const
 {
-    if ( d.empty() ) return OPENSCENEGRAPH_SOVERSION;
+    if ( d.empty() ) return _targetFileVersion;
     VersionMap::const_iterator itr = _domainVersionMap.find(d);
     return itr==_domainVersionMap.end() ? 0 : itr->second;
 }
@@ -389,15 +405,18 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         *this << MAPPEE(PrimitiveType, ID_DRAWARRAYS);
         {
             const osg::DrawArrays* da = static_cast<const osg::DrawArrays*>(p);
-            *this << MAPPEE(PrimitiveType, da->getMode()) << da->getNumInstances()
-                  << da->getFirst() << da->getCount() << std::endl;
+            *this << MAPPEE(PrimitiveType, da->getMode());
+			if (_targetFileVersion > 96) *this << da->getNumInstances();
+            *this << da->getFirst() << da->getCount() << std::endl;
         }
         break;
     case osg::PrimitiveSet::DrawArrayLengthsPrimitiveType:
         *this << MAPPEE(PrimitiveType, ID_DRAWARRAY_LENGTH);
         {
             const osg::DrawArrayLengths* dl = static_cast<const osg::DrawArrayLengths*>(p);
-            *this << MAPPEE(PrimitiveType, dl->getMode()) << dl->getNumInstances() << dl->getFirst();
+            *this << MAPPEE(PrimitiveType, dl->getMode());
+			if (_targetFileVersion > 96) *this << dl->getNumInstances();
+			*this << dl->getFirst();
             writeArrayImplementation( dl, dl->size(), 4 );
         }
         break;
@@ -405,7 +424,8 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         *this << MAPPEE(PrimitiveType, ID_DRAWELEMENTS_UBYTE);
         {
             const osg::DrawElementsUByte* de = static_cast<const osg::DrawElementsUByte*>(p);
-            *this << MAPPEE(PrimitiveType, de->getMode()) << de->getNumInstances();
+            *this << MAPPEE(PrimitiveType, de->getMode());
+			if (_targetFileVersion > 96) *this << de->getNumInstances();
             writeArrayImplementation( de, de->size(), 4 );
         }
         break;
@@ -413,7 +433,8 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         *this << MAPPEE(PrimitiveType, ID_DRAWELEMENTS_USHORT);
         {
             const osg::DrawElementsUShort* de = static_cast<const osg::DrawElementsUShort*>(p);
-            *this << MAPPEE(PrimitiveType, de->getMode()) << de->getNumInstances();
+            *this << MAPPEE(PrimitiveType, de->getMode());
+			if (_targetFileVersion > 96) *this << de->getNumInstances();
             writeArrayImplementation( de, de->size(), 4 );
         }
         break;
@@ -421,7 +442,8 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         *this << MAPPEE(PrimitiveType, ID_DRAWELEMENTS_UINT);
         {
             const osg::DrawElementsUInt* de = static_cast<const osg::DrawElementsUInt*>(p);
-            *this << MAPPEE(PrimitiveType, de->getMode()) << de->getNumInstances();
+            *this << MAPPEE(PrimitiveType, de->getMode());
+			if (_targetFileVersion > 96) *this << de->getNumInstances();
             writeArrayImplementation( de, de->size(), 4 );
         }
         break;
@@ -440,7 +462,8 @@ void OutputStream::writeImage( const osg::Image* img )
     bool newID = false;
     unsigned int id = findOrCreateObjectID( img, newID );
 
-    *this << PROPERTY("ClassName") << name << std::endl;   // Write object name
+	if (_targetFileVersion > 94) *this << PROPERTY("ClassName") << name << std::endl;   // Write object name
+	
     *this << PROPERTY("UniqueID") << id << std::endl;      // Write image ID
     if ( getException() ) return;
 
@@ -710,7 +733,7 @@ void OutputStream::start( OutputIterator* outIterator, OutputStream::WriteType t
 
     if ( isBinary() )
     {
-        *this << (unsigned int)type << (unsigned int)OPENSCENEGRAPH_SOVERSION;
+        *this << (unsigned int)type << (unsigned int)_targetFileVersion;
 
         bool useCompressSource = false;
         unsigned int attributes = 0;

--- a/src/osgDB/OutputStream.cpp
+++ b/src/osgDB/OutputStream.cpp
@@ -65,7 +65,7 @@ OutputStream::OutputStream( const osgDB::Options* options )
     if (!options->getPluginStringData("TargetFileVersion").empty())
     {
         std::string strVersion = options->getPluginStringData("TargetFileVersion");
-        int version = std::stoi(strVersion);
+        int version = atoi(strVersion.c_str());
         if (version > 0 && version <= OPENSCENEGRAPH_SOVERSION)
             _targetFileVersion = version;
     }

--- a/src/osgDB/OutputStream.cpp
+++ b/src/osgDB/OutputStream.cpp
@@ -462,7 +462,7 @@ void OutputStream::writeImage( const osg::Image* img )
     bool newID = false;
     unsigned int id = findOrCreateObjectID( img, newID );
 
-	if (_targetFileVersion > 94) *this << PROPERTY("ClassName") << name << std::endl;   // Write object name
+    if (_targetFileVersion > 94) *this << PROPERTY("ClassName") << name << std::endl;   // Write object name
 	
     *this << PROPERTY("UniqueID") << id << std::endl;      // Write image ID
     if ( getException() ) return;

--- a/src/osgDB/OutputStream.cpp
+++ b/src/osgDB/OutputStream.cpp
@@ -25,7 +25,7 @@
 using namespace osgDB;
 
 OutputStream::OutputStream( const osgDB::Options* options )
-:   _writeImageHint(WRITE_USE_IMAGE_HINT), _useSchemaData(false), _useRobustBinaryFormat(true), _targetFileVersion(OPENSCENEGRAPH_SOVERSION)
+:   _writeImageHint(WRITE_USE_IMAGE_HINT), _useSchemaData(false), _useRobustBinaryFormat(true)
 {
     BEGIN_BRACKET.set( "{", +INDENT_VALUE );
     END_BRACKET.set( "}", -INDENT_VALUE );
@@ -61,31 +61,15 @@ OutputStream::OutputStream( const osgDB::Options* options )
                 _domainVersionMap[keyAndValue.front()] = atoi(keyAndValue.back().c_str());
         }
     }
-
-    if (!options->getPluginStringData("TargetFileVersion").empty())
-    {
-        std::string strVersion = options->getPluginStringData("TargetFileVersion");
-        int version = std::stoi(strVersion);
-        if (version > 0 && version <= OPENSCENEGRAPH_SOVERSION)
-            _targetFileVersion = version;
-    }
-	
-	if (_targetFileVersion < 99) _useRobustBinaryFormat = false;
 }
 
 OutputStream::~OutputStream()
 {
 }
 
-void OutputStream::setFileVersion( const std::string& d, int v )
-{
-	if (d.empty()) _targetFileVersion = v;
-	else _domainVersionMap[d] = v;
-}
-
 int OutputStream::getFileVersion( const std::string& d ) const
 {
-    if ( d.empty() ) return _targetFileVersion;
+    if ( d.empty() ) return OPENSCENEGRAPH_SOVERSION;
     VersionMap::const_iterator itr = _domainVersionMap.find(d);
     return itr==_domainVersionMap.end() ? 0 : itr->second;
 }
@@ -405,18 +389,15 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         *this << MAPPEE(PrimitiveType, ID_DRAWARRAYS);
         {
             const osg::DrawArrays* da = static_cast<const osg::DrawArrays*>(p);
-            *this << MAPPEE(PrimitiveType, da->getMode());
-			if (_targetFileVersion > 96) *this << da->getNumInstances();
-            *this << da->getFirst() << da->getCount() << std::endl;
+            *this << MAPPEE(PrimitiveType, da->getMode()) << da->getNumInstances()
+                  << da->getFirst() << da->getCount() << std::endl;
         }
         break;
     case osg::PrimitiveSet::DrawArrayLengthsPrimitiveType:
         *this << MAPPEE(PrimitiveType, ID_DRAWARRAY_LENGTH);
         {
             const osg::DrawArrayLengths* dl = static_cast<const osg::DrawArrayLengths*>(p);
-            *this << MAPPEE(PrimitiveType, dl->getMode());
-			if (_targetFileVersion > 96) *this << dl->getNumInstances();
-			*this << dl->getFirst();
+            *this << MAPPEE(PrimitiveType, dl->getMode()) << dl->getNumInstances() << dl->getFirst();
             writeArrayImplementation( dl, dl->size(), 4 );
         }
         break;
@@ -424,8 +405,7 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         *this << MAPPEE(PrimitiveType, ID_DRAWELEMENTS_UBYTE);
         {
             const osg::DrawElementsUByte* de = static_cast<const osg::DrawElementsUByte*>(p);
-            *this << MAPPEE(PrimitiveType, de->getMode());
-			if (_targetFileVersion > 96) *this << de->getNumInstances();
+            *this << MAPPEE(PrimitiveType, de->getMode()) << de->getNumInstances();
             writeArrayImplementation( de, de->size(), 4 );
         }
         break;
@@ -433,8 +413,7 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         *this << MAPPEE(PrimitiveType, ID_DRAWELEMENTS_USHORT);
         {
             const osg::DrawElementsUShort* de = static_cast<const osg::DrawElementsUShort*>(p);
-            *this << MAPPEE(PrimitiveType, de->getMode());
-			if (_targetFileVersion > 96) *this << de->getNumInstances();
+            *this << MAPPEE(PrimitiveType, de->getMode()) << de->getNumInstances();
             writeArrayImplementation( de, de->size(), 4 );
         }
         break;
@@ -442,8 +421,7 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
         *this << MAPPEE(PrimitiveType, ID_DRAWELEMENTS_UINT);
         {
             const osg::DrawElementsUInt* de = static_cast<const osg::DrawElementsUInt*>(p);
-            *this << MAPPEE(PrimitiveType, de->getMode());
-			if (_targetFileVersion > 96) *this << de->getNumInstances();
+            *this << MAPPEE(PrimitiveType, de->getMode()) << de->getNumInstances();
             writeArrayImplementation( de, de->size(), 4 );
         }
         break;
@@ -462,8 +440,7 @@ void OutputStream::writeImage( const osg::Image* img )
     bool newID = false;
     unsigned int id = findOrCreateObjectID( img, newID );
 
-	if (_targetFileVersion > 94) *this << PROPERTY("ClassName") << name << std::endl;   // Write object name
-	
+    *this << PROPERTY("ClassName") << name << std::endl;   // Write object name
     *this << PROPERTY("UniqueID") << id << std::endl;      // Write image ID
     if ( getException() ) return;
 
@@ -733,7 +710,7 @@ void OutputStream::start( OutputIterator* outIterator, OutputStream::WriteType t
 
     if ( isBinary() )
     {
-        *this << (unsigned int)type << (unsigned int)_targetFileVersion;
+        *this << (unsigned int)type << (unsigned int)OPENSCENEGRAPH_SOVERSION;
 
         bool useCompressSource = false;
         unsigned int attributes = 0;


### PR DESCRIPTION
when write binary file, like osgb file, users can set plugin string data, such as "TargetFileVersion=80", to options object, then the features of output file will be limitted to so version 80.