### PR TITLE
don't lose geometry during optimizer's merge pass

### DIFF
--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -1956,7 +1956,7 @@ bool Optimizer::MergeGeometryVisitor::mergeGroup(osg::Group& group)
                 ++mitr)
             {
                 DuplicateList& duplicateList = *mitr;
-                if (duplicateList.size()>1)
+                if (!duplicateList.empty())
                 {
                     osg::ref_ptr<osg::Geometry> lhs = duplicateList.front();
                     group.addChild(lhs.get());


### PR DESCRIPTION
We had problems where parts of our geometry was lost during optimization. The geometry was split into batches of ~10K elements and organized into multiple Geometry objects as children of a single Geode.