### PR TITLE
Remove texture attribute member override

### DIFF
--- a/include/osg/TextureAttribute
+++ b/include/osg/TextureAttribute
@@ -32,8 +32,6 @@ class TextureAttribute : public StateAttribute
 
         virtual bool isTextureAttribute() const { return true; }
 
-        virtual unsigned int getMember() const { return _textureUnit; }
-
     protected:
         virtual ~TextureAttribute() {}
 


### PR DESCRIPTION
base issue:
StateSet::removeTextureAttribute doesn't work for tu other than 0
fix:
texture attribute member should be 0 to be retrieved correctly in StateSet methods
I'm not sure of it but there can't be several texatt on the same tu at a time..no?
Further I can't be agree on the TextureAttribute::_textureunit member as a single Tex can be shared on differnent texture unit among statesets (so having tu member of textture is really a BAD thing)...but perhaps there a pipeline conformance reason (and but it sure shouldn't be exposed as getmember)
