### PR TITLE
AutoTransform must never cache its bounding sphere when auto-scaling …

### DIFF
--- a/include/osg/AutoTransform
+++ b/include/osg/AutoTransform
@@ -125,7 +125,6 @@ class OSG_EXPORT AutoTransform : public Transform
 
         osg::Matrixd computeMatrix(const osg::NodeVisitor* nv) const;
 
-        mutable bool                    _matrixInitalized;
         mutable osg::Matrixd            _cachedMatrix;
 
         enum AxisAligned

--- a/src/osg/AutoTransform.cpp
+++ b/src/osg/AutoTransform.cpp
@@ -25,7 +25,6 @@ AutoTransform::AutoTransform():
     _minimumScale(0.0),
     _maximumScale(DBL_MAX),
     _autoScaleTransitionWidthRatio(0.25),
-    _matrixInitalized(false),
     _axis(0.0f,0.0f,1.0f),
     _normal(0.0f,-1.0f,0.0f),
     _cachedMode(NO_ROTATION),
@@ -46,7 +45,6 @@ AutoTransform::AutoTransform(const AutoTransform& pat,const CopyOp& copyop):
     _minimumScale(pat._minimumScale),
     _maximumScale(pat._maximumScale),
     _autoScaleTransitionWidthRatio(pat._autoScaleTransitionWidthRatio),
-    _matrixInitalized(false),
     _axis(pat._axis),
     _normal(pat._normal),
     _cachedMode(pat._cachedMode),
@@ -135,8 +133,6 @@ bool AutoTransform::computeWorldToLocalMatrix(Matrix& matrix,NodeVisitor* nv) co
 
 osg::Matrixd AutoTransform::computeMatrix(const osg::NodeVisitor* nv) const
 {
-    _matrixInitalized = true;
-
     Quat rotation = _rotation;
     osg::Vec3d scale = _scale;
 
@@ -306,7 +302,7 @@ BoundingSphere AutoTransform::computeBound() const
 {
     BoundingSphere bsphere;
 
-    if ( getAutoScaleToScreen() && !_matrixInitalized )
+    if ( getAutoScaleToScreen() )
         return bsphere;
 
     bsphere = Transform::computeBound();


### PR DESCRIPTION
…its children to screen

When auto-scaling its children to screen the bounding sphere changes by each scene modification (in the extreme case it changes for each frame). The bounding sphere is only newly calculated when it or one of its children have dirty bounds. But this actually means that mostly the cached bounding sphere does not correspond with the real bounding sphere.
This can cause problems during culling: the AutoTransform node is culled because of a wrong (not updated) bounding sphere. A demonstration of this phenomenon is shown in a modified osgautotransform.cpp file as mentioned on http://forum.openscenegraph.org/viewtopic.php?t=17173&highlight=autotransform+culling.

To solve the issue AutoTransform::computeBound always returns an invalid bounding sphere when the flag "_autoScaleToScreen" is set.