### PR TITLE
missing gles2 check

### DIFF
--- a/src/osgViewer/GraphicsWindowIOS.mm
+++ b/src/osgViewer/GraphicsWindowIOS.mm
@@ -556,8 +556,10 @@ typedef std::map<void*, unsigned int> TouchPointsIdMapping;
                               0, 0, _backingWidth, _backingHeight,
                               GL_COLOR_BUFFER_BIT, GL_LINEAR);
         }
+#   if OSG_GLES2_FEATURES
         else
             glResolveMultisampleFramebufferAPPLE();
+#   endif
 #   else
         glResolveMultisampleFramebufferAPPLE();
 #   endif


### PR DESCRIPTION
fixes the compile error when targeting gles3 only