### PR TITLE
Remove duplicated and incorrect fetching of 'map_bump' attributes in obj plugin

### DIFF
--- a/src/osgPlugins/obj/obj.cpp
+++ b/src/osgPlugins/obj/obj.cpp
@@ -506,7 +506,7 @@ bool Model::readMTL(std::istream& fin)
                     material->maps.push_back(parseTextureMap(strip(line+7),Material::Map::SPECULAR_EXPONENT));
                 }
                 // modelling tools and convertors variously produce bump, map_bump, and map_Bump so parse them all
-                else if (strncasecmp(line,"bump ",5)==0 || strncasecmp(line,"map_bump ",9)==0)
+                else if (strncasecmp(line,"bump ",5)==0)
                 {
                     material->maps.push_back(parseTextureMap(strip(line+5),Material::Map::BUMP));
                 }


### PR DESCRIPTION
Parsing key 'map_bump' was processed in the block, where the attributes
for 'bump' are extracted and results into having parts of the key in the
extracted filename, generating an invalid filename.

The mentioned string compare could be removed without loosing any features,
because the key 'map_bump' is parsed correctly some lines below.