### PR TITLE
Add 'dump scene to file' handler

### DIFF
--- a/applications/osgviewer/osgviewer.cpp
+++ b/applications/osgviewer/osgviewer.cpp
@@ -19,6 +19,7 @@
 
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
+#include <osgViewer/DumpSceneHandler>
 
 #include <osgGA/TrackballManipulator>
 #include <osgGA/FlightManipulator>
@@ -146,6 +147,9 @@ int main(int argc, char** argv)
 
     // add the screen capture handler
     viewer.addEventHandler(new osgViewer::ScreenCaptureHandler);
+
+    // add the dump scene handler
+    viewer.addEventHandler(new osgViewer::DumpSceneHandler);
 
     // load the data
     osg::ref_ptr<osg::Node> loadedModel = osgDB::readRefNodeFiles(arguments);

--- a/include/osgViewer/DumpSceneHandler
+++ b/include/osgViewer/DumpSceneHandler
@@ -1,0 +1,45 @@
+/* -*-c++-*- OpenSceneGraph - Copyright (C) 2018 Ralf Habacker, Daniel Wendt
+*
+* This library is open source and may be redistributed and/or modified under
+* the terms of the OpenSceneGraph Public License (OSGPL) version 0.0 or
+* (at your option) any later version.  The full license is in LICENSE file
+* included with this distribution, and on the openscenegraph.org website.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* OpenSceneGraph Public License for more details.
+*/
+
+#ifndef OSGVIEWER_DUMPSCENEHANDLER_H
+#define OSGVIEWER_DUMPSCENEHANDLER_H
+
+#include <osgGA/GUIEventHandler>
+#include <osgViewer/Viewer>
+
+namespace osgViewer {
+
+/**
+ * Event handler for dumping the current scene to a file in the working directory
+ */
+class OSGVIEWER_EXPORT DumpSceneHandler : public osgGA::GUIEventHandler
+{
+public:
+    /** set filename to save the scene into, by default autoincrement is enabled */
+    DumpSceneHandler(const std::string &filename="scenedump.osgt");
+
+    void setAutoIncrementFilename(bool autoinc = true) { _autoinc = autoinc ? 0 : -1; }
+
+    virtual bool handle(const osgGA::GUIEventAdapter &ea, osgGA::GUIActionAdapter &aa);
+
+    void getUsage(osg::ApplicationUsage &usage) const;
+
+private:
+    std::string _filename;
+    int _autoinc;
+    std::string generateFileName() const;
+};
+
+}
+
+#endif

--- a/src/osgViewer/CMakeLists.txt
+++ b/src/osgViewer/CMakeLists.txt
@@ -34,11 +34,13 @@ SET(TARGET_H
     ${HEADER_PATH}/Viewer
     ${HEADER_PATH}/ViewerBase
     ${HEADER_PATH}/ViewerEventHandlers
+    ${HEADER_PATH}/DumpSceneHandler
 )
 
 SET(LIB_COMMON_FILES
     ${CONFIG_SOURCE_FILES}
     CompositeViewer.cpp
+    DumpSceneHandler.cpp
     GraphicsWindow.cpp
     HelpHandler.cpp
     Keystone.cpp

--- a/src/osgViewer/DumpSceneHandler.cpp
+++ b/src/osgViewer/DumpSceneHandler.cpp
@@ -1,0 +1,66 @@
+/* -*-c++-*- OpenSceneGraph - Copyright (C) 2018 Ralf Habacker, Daniel Wendt
+*
+* This library is open source and may be redistributed and/or modified under
+* the terms of the OpenSceneGraph Public License (OSGPL) version 0.0 or
+* (at your option) any later version.  The full license is in LICENSE file
+* included with this distribution, and on the openscenegraph.org website.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* OpenSceneGraph Public License for more details.
+*/
+
+#include <osgDB/WriteFile>
+#include <osgDB/FileNameUtils>
+#include <osgViewer/DumpSceneHandler>
+
+#include <iomanip>
+#include <sstream>
+
+namespace osgViewer {
+
+DumpSceneHandler::DumpSceneHandler(const std::string &filename) :
+    _filename(filename),
+    _autoinc(0)
+{
+}
+
+std::string DumpSceneHandler::generateFileName() const
+{
+    std::stringstream ss;
+    ss << osgDB::getNameLessExtension(_filename);
+    if (_autoinc != -1)
+    {
+        ss << "_"<<std::setfill('0') << std::setw(2) << _autoinc;
+    }
+    ss << "."<<osgDB::getFileExtension(_filename);
+    return ss.str();
+}
+
+bool DumpSceneHandler::handle(const osgGA::GUIEventAdapter &ea, osgGA::GUIActionAdapter &aa)
+{
+    osgViewer::View* view = dynamic_cast<osgViewer::View*>(&aa);
+    if (!view)
+        return false;
+
+   if (ea.getKey() == osgGA::GUIEventAdapter::KEY_D && ea.getEventType() == osgGA::GUIEventAdapter::KEYUP)
+    {
+        if (_filename.empty())
+            return false;
+
+        std::string filename = generateFileName();
+        if (_autoinc != -1)
+            _autoinc++;
+        OSG_INFO << "dumping scene to '" << filename << "'" << std::endl;
+        return osgDB::writeNodeFile(*view->getSceneData(), filename) ? false : true;
+    }
+    return false;
+}
+
+void DumpSceneHandler::getUsage(osg::ApplicationUsage& usage) const
+{
+    usage.addKeyboardMouseBinding('d', "Dump scene to file.");
+}
+
+}


### PR DESCRIPTION
Refactored to make it similar to RecordCameraPathHandler, which has be added to osg viewer