### PR TITLE
Including osg/Geode to fix osgManipulator build

### DIFF
--- a/include/osgManipulator/TrackballDragger
+++ b/include/osgManipulator/TrackballDragger
@@ -18,6 +18,7 @@
 #include <osgManipulator/RotateCylinderDragger>
 #include <osgManipulator/RotateSphereDragger>
 #include <osg/ShapeDrawable>
+#include <osg/Geode>
 #include <osg/Geometry>
 #include <osg/LineWidth>
 


### PR DESCRIPTION
Hi Robert!

Just a small change to fix the osgManipulator build.  TrackballDragger needs <osg/Geode> included since IntersectVisitor was removed.

Thanks!

Jason