### PR TITLE
Fix includes for MSVC 2015 build.

### DIFF
--- a/include/osgManipulator/TrackballDragger
+++ b/include/osgManipulator/TrackballDragger
@@ -19,6 +19,7 @@
 #include <osgManipulator/RotateSphereDragger>
 #include <osg/ShapeDrawable>
 #include <osg/Geometry>
+#include <osg/Geode>
 #include <osg/LineWidth>
 
 namespace osgManipulator {


### PR DESCRIPTION
Getting a build failure on MSVC 2015 due to missing Geode include in two of the trackball manipulators.  This fixes the build and seems like a reasonable place for it due to the ref_ptr<Geode> member variable.