### PR TITLE
add wrapper for osg::DrawIndirectBufferObject

### DIFF
--- a/src/osgWrappers/serializers/osg/VertexBufferObject.cpp
+++ b/src/osgWrappers/serializers/osg/VertexBufferObject.cpp
@@ -3,9 +3,20 @@
 #include <osgDB/InputStream>
 #include <osgDB/OutputStream>
 
+namespace wrapper_osgVertexBufferObject{
 REGISTER_OBJECT_WRAPPER( VertexBufferObject,
                          new osg::VertexBufferObject,
                          osg::VertexBufferObject,
                          "osg::Object osg::BufferObject osg::VertexBufferObject" )
 {
+}
+}
+
+namespace wrapper_osgDrawIndirectBufferObject{
+REGISTER_OBJECT_WRAPPER( DrawIndirectBufferObject,
+                         new osg::DrawIndirectBufferObject,
+                         osg::DrawIndirectBufferObject,
+                         "osg::Object osg::BufferObject osg::DrawIndirectBufferObject" )
+{
+}
 }


### PR DESCRIPTION
a quick pr to add wrapper for osg::DrawIndirectBufferObject (reject it if you think it would deserve a file for itself)
