### PR TITLE
When GL3 build is enabled, default context requested is version 3.3, …

### DIFF
--- a/src/osg/DisplaySettings.cpp
+++ b/src/osg/DisplaySettings.cpp
@@ -240,7 +240,11 @@ void DisplaySettings::setDefaults()
 
     _implicitBufferAttachmentRenderMask = DEFAULT_IMPLICIT_BUFFER_ATTACHMENT;
     _implicitBufferAttachmentResolveMask = DEFAULT_IMPLICIT_BUFFER_ATTACHMENT;
+#ifdef OSG_GL3_FEATURES
+    _glContextVersion = "3.3";
+#else
     _glContextVersion = "1.0";
+#endif
     _glContextFlags = 0;
     _glContextProfileMask = 0;
 

--- a/src/osg/GraphicsContext.cpp
+++ b/src/osg/GraphicsContext.cpp
@@ -239,7 +239,11 @@ GraphicsContext::Traits::Traits(DisplaySettings* ds):
             swapBarrier(0),
             useMultiThreadedOpenGLEngine(false),
             useCursor(true),
+#ifdef OSG_GL3_FEATURES
+            glContextVersion("3.3"),
+#else
             glContextVersion("1.0"),
+#endif
             glContextFlags(0),
             glContextProfileMask(0),
             sharedContext(0),


### PR DESCRIPTION
…enabling core profile by default.