### PR TITLE
remove include/osgQt from doxyfiles; add osgPresentation and osgUI

### DIFF
--- a/doc/Doxyfiles/auto_Doxyfile
+++ b/doc/Doxyfiles/auto_Doxyfile
@@ -99,15 +99,16 @@ INPUT                  = ${OpenSceneGraph_SOURCE_DIR}/include/osg \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgGA \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgManipulator \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgParticle \
+                         ${OpenSceneGraph_SOURCE_DIR}/include/osgPresentation \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgShadow \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgSim \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgTerrain \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgText \
+                         ${OpenSceneGraph_SOURCE_DIR}/include/osgUI \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgUtil \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgViewer \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgVolume \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgWidget \
-                         ${OpenSceneGraph_SOURCE_DIR}/include/osgQt \
                          ${OpenSceneGraph_SOURCE_DIR}/doc/Doxyfiles/auto_Mainpage
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *include* \

--- a/doc/Doxyfiles/core_Doxyfile
+++ b/doc/Doxyfiles/core_Doxyfile
@@ -89,15 +89,16 @@ INPUT                  = ${OpenSceneGraph_SOURCE_DIR}/include/osg \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgGA \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgManipulator \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgParticle \
+                         ${OpenSceneGraph_SOURCE_DIR}/include/osgPresentation \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgShadow \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgSim \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgTerrain \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgText \
+                         ${OpenSceneGraph_SOURCE_DIR}/include/osgUI \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgUtil \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgViewer \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgVolume \
                          ${OpenSceneGraph_SOURCE_DIR}/include/osgWidget \
-                         ${OpenSceneGraph_SOURCE_DIR}/include/osgQt \
                          ${OpenSceneGraph_SOURCE_DIR}/doc/Doxyfiles/auto_Mainpage
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *include* \

--- a/doc/Doxyfiles/doxyfile.cmake
+++ b/doc/Doxyfiles/doxyfile.cmake
@@ -90,7 +90,7 @@ INPUT                  = "${OpenSceneGraph_SOURCE_DIR}/include/osg" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgGA" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgManipulator" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgParticle" \
-                         "${OpenSceneGraph_SOURCE_DIR}/include/osgQt" \
+                         "${OpenSceneGraph_SOURCE_DIR}/include/osgPresentation" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgShadow" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgSim" \
                          "${OpenSceneGraph_SOURCE_DIR}/include/osgTerrain" \


### PR DESCRIPTION
Hi Robert,
just got doxygen working on my windows machine, an I got a few warnings:

1>------ Build started: Project: doc_openscenegraph, Configuration: Debug x64 ------
1>CUSTOMBUILD : warning : tag INPUT: input source `E:/osg/37/laurens/OpenSceneGraph/include/osgQt' does not exist
1>CUSTOMBUILD : warning : source E:/osg/37/laurens/OpenSceneGraph/include/osgQt is not a readable file or directory... skipping.

this PR gets rid of the warnings, and while I suspect only one of the doxyfiles is actually used in my configuration I guess it's better to update all three.
These changes are appropriate for the 3.6 tree too.
Regards, Laurens.