### PR TITLE
Fixed the position of the viewport for the camera

### DIFF
--- a/examples/osgviewerMFC/MFC_OSG.cpp
+++ b/examples/osgviewerMFC/MFC_OSG.cpp
@@ -104,7 +104,7 @@ void cOSG::InitCameraConfig(void)
     camera->setGraphicsContext(gc);
 
     // Set the viewport for the Camera
-    camera->setViewport(new osg::Viewport(traits->x, traits->y, traits->width, traits->height));
+    camera->setViewport(new osg::Viewport(0, 0, traits->width, traits->height));
 
     // set the draw and read buffers up for a double buffered window with rendering going to back buffer
     camera->setDrawBuffer(GL_BACK);


### PR DESCRIPTION
The position of viewport doesn't setup properly, some part of viewer is out of CMFC_OSG_MDIView,  and not visible.