### PR TITLE
resolve av sync failure with ffmpeg 3.2 and up

### DIFF
--- a/src/osgPlugins/ffmpeg/FFmpegClocks.cpp
+++ b/src/osgPlugins/ffmpeg/FFmpegClocks.cpp
@@ -155,8 +155,7 @@ double FFmpegClocks::videoSynchClock(const AVFrame * const frame, const double t
 
     // Update the video clock to take into account the frame delay
 
-    double frame_delay = time_base;
-    frame_delay += frame->repeat_pict * (frame_delay * 0.5);
+    double frame_delay = time_base * (1 + frame->repeat_pict);
 
     m_video_clock += frame_delay;
 


### PR DESCRIPTION
playing .mp4 movie with audio will start to stutter in audio and video after about 10 seconds.