### PR TITLE
OpenFlight: Textures now correctly export in GLCORE mode.

### DIFF
--- a/src/osgPlugins/OpenFlight/expGeometryRecords.cpp
+++ b/src/osgPlugins/OpenFlight/expGeometryRecords.cpp
@@ -63,7 +63,12 @@ bool
 FltExportVisitor::isTextured( int unit, const osg::Geometry& geom ) const
 {
     const osg::StateSet* ss = getCurrentStateSet();
+#ifdef OSG_GL_FIXED_FUNCTION_AVAILABLE
     bool texOn( ss->getTextureMode( unit, GL_TEXTURE_2D ) & osg::StateAttribute::ON );
+#else
+    // In this mode, osg::Texture::getModeUsage() is undefined, so just detect if a texture is present
+    bool texOn = (ss->getTextureAttribute(0, osg::StateAttribute::TEXTURE) != NULL);
+#endif
     bool hasCoords( geom.getTexCoordArray( unit ) != NULL );
 
     return( texOn && hasCoords );


### PR DESCRIPTION
I'm about to send a mailing list post about this change and why it's needed.  In short, check out osg::Texture::getModeUsage().  Because it has `ifdef OSG_GL_FIXED_FUNCTION_AVAILABLE` around it, the `GL_TEXTURE_2D` mode never gets set `ON`, it's kept at `INHERIT`.  That means `isTextured()` always returned false.