### PR TITLE
Remove call to nonexistent member seekpos() of std::fpos in VS 15.8

### DIFF
--- a/src/osgPlugins/osga/OSGA_Archive.cpp
+++ b/src/osgPlugins/osga/OSGA_Archive.cpp
@@ -70,10 +70,12 @@ inline std::streampos STREAM_POS( const OSGA_Archive::pos_type pos )
 
 inline OSGA_Archive::pos_type ARCHIVE_POS( const std::streampos & pos )
 {
-#if defined(_CPPLIB_VER)//newer Dinkumware(eg: one included with VC++ 2003,2005)
-    fpos_t position = pos.seekpos();
+#if (defined(_CPPLIB_VER) && defined(_MSC_VER) && _MSC_VER > 1914)   // VC++ 2017 version 15.8 or later
+	fpos_t position = pos;
+#elif (defined(_CPPLIB_VER) && defined(_MSC_VER)) // Dinkumware (eg: one included with VC++ 2003, 2005...)
+	fpos_t position = pos.seekpos();
 #else // older Dinkumware (eg: one included in Win Server 2003 Platform SDK )
-    fpos_t position = pos.get_fpos_t();
+	fpos_t position = pos.get_fpos_t();
 #endif
     std::streamoff offset = pos.operator std::streamoff( ) - _FPOSOFF( position );
 


### PR DESCRIPTION
Remove call to nonexistent member seekpos() of std::fpos in VS 2017 version 15.8. It has removed in our curent latest published release VS 15.8 preview 3(_MSC_VER=1915). So it failed with below issue：
error C2039: 'seekpos': is not a member of 'std::fpos<_Mbstatet>'

See http://eel.is/c++draft/fpos -- to get to an offset you can convert to int; now there is no seekpos member in VS15.8.
We have fixed this issue in vcpkg (Microsoft/vcpkg#3753).

The previous PR that we discussed here: https://github.com/openscenegraph/OpenSceneGraph/pull/567
I send the new one, please help approve. Thanks! 