### PR TITLE
FLT: Fix texture unit typo and code style from PR 568.

### DIFF
--- a/src/osgPlugins/OpenFlight/expGeometryRecords.cpp
+++ b/src/osgPlugins/OpenFlight/expGeometryRecords.cpp
@@ -67,7 +67,7 @@ FltExportVisitor::isTextured( int unit, const osg::Geometry& geom ) const
     bool texOn( ss->getTextureMode( unit, GL_TEXTURE_2D ) & osg::StateAttribute::ON );
 #else
     // In this mode, osg::Texture::getModeUsage() is undefined, so just detect if a texture is present
-    bool texOn = (ss->getTextureAttribute(0, osg::StateAttribute::TEXTURE) != NULL);
+    bool texOn( ss->getTextureAttribute( unit, osg::StateAttribute::TEXTURE ) != NULL );
 #endif
     bool hasCoords( geom.getTexCoordArray( unit ) != NULL );
 


### PR DESCRIPTION
Minor fix, as pointed out by @mp3butcher on https://github.com/openscenegraph/OpenSceneGraph/pull/568

Sorry for not noticing on first pass.  All my test cases only had texture unit 0 and I missed the typo.  Priority on this seems low, edge case of an edge case.

Includes minor update on code style to match the rest of the file.