### PR TITLE
Fix FindCollada.cmake for vcpkg installs

### DIFF
--- a/CMakeModules/FindCOLLADA.cmake
+++ b/CMakeModules/FindCOLLADA.cmake
@@ -25,11 +25,11 @@ ENDIF()
 
 IF(APPLE)
     SET(COLLADA_BUILDNAME "mac")
-  SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
+    SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
 ELSEIF(MINGW)
     SET(COLLADA_BUILDNAME "mingw")
-  SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
-ELSEIF(MSVC_VERSION EQUAL 1900 OR MSVC_VERSION EQUAL 1910 )
+    SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
+ELSEIF(MSVC_VERSION GREATER_EQUAL 1900 )
     SET(COLLADA_BUILDNAME "vc14")
     SET(COLLADA_BOOST_BUILDNAME "vc140")
 ELSEIF(MSVC_VERSION EQUAL 1800)
@@ -58,6 +58,7 @@ ENDIF()
 
 
 FIND_PATH(COLLADA_INCLUDE_DIR dae.h
+    PATHS
     ${COLLADA_DOM_ROOT}/include
     $ENV{COLLADA_DIR}/include
     $ENV{COLLADA_DIR}
@@ -65,27 +66,19 @@ FIND_PATH(COLLADA_INCLUDE_DIR dae.h
     /Library/Frameworks
     /opt/local/Library/Frameworks #macports
     /usr/local/include
-    /usr/local/include/colladadom
-    /usr/local/include/collada-dom
-    /usr/local/include/collada-dom2.5
-    /usr/local/include/collada-dom2.4
-    /usr/local/include/collada-dom2.2
-    /opt/local/include/collada-dom
-    /opt/local/include/collada-dom2.5
-    /opt/local/include/collada-dom2.4
-    /opt/local/include/collada-dom2.2
     /usr/include/
-    /usr/include/colladadom
-    /usr/include/collada-dom
-    /usr/include/collada-dom2.5
-    /usr/include/collada-dom2.4
-    /usr/include/collada-dom2.2
     /sw/include # Fink
     /opt/local/include # DarwinPorts
     /opt/csw/include # Blastwave
     /opt/include
     /usr/freeware/include
     ${ACTUAL_3DPARTY_DIR}/include
+    PATH_SUFFIXES
+    colladadom
+    collada-dom
+    collada-dom2.5
+    collada-dom2.4
+    collada-dom2.2
 )
 
 FIND_LIBRARY(COLLADA_DYNAMIC_LIBRARY


### PR DESCRIPTION
* Handle MSVC_VERSION versions > 1910
* Specify PATH_SUFFIXES rather than individual PATHS for FIND_PATH