### PR TITLE
updated osgviewerWX to remove deprecated calls in wxWidgets 3.x

### DIFF
--- a/examples/osgviewerWX/osgviewerWX.cpp
+++ b/examples/osgviewerWX/osgviewerWX.cpp
@@ -140,7 +140,8 @@ END_EVENT_TABLE()
 
 OSGCanvas::OSGCanvas(wxWindow *parent, wxWindowID id,
     const wxPoint& pos, const wxSize& size, long style, const wxString& name, int *attributes)
-    : wxGLCanvas(parent, id, pos, size, style|wxFULL_REPAINT_ON_RESIZE, name, attributes)
+    : wxGLCanvas(parent, id, attributes, pos, size, style|wxFULL_REPAINT_ON_RESIZE, name)
+    ,_context(this)
 {
     // default cursor to standard
     _oldCursor = *wxSTANDARD_CURSOR;
@@ -148,6 +149,11 @@ OSGCanvas::OSGCanvas(wxWindow *parent, wxWindowID id,
 
 OSGCanvas::~OSGCanvas()
 {
+}
+
+void OSGCanvas::SetContextCurrent()
+{
+	_context.SetCurrent(*this);
 }
 
 void OSGCanvas::OnPaint( wxPaintEvent& WXUNUSED(event) )
@@ -158,8 +164,6 @@ void OSGCanvas::OnPaint( wxPaintEvent& WXUNUSED(event) )
 
 void OSGCanvas::OnSize(wxSizeEvent& event)
 {
-    // this is also necessary to update the context on some platforms
-    wxGLCanvas::OnSize(event);
 
     // set GL viewport (not called by wxGLCanvas::OnSize on all platforms...)
     int width, height;
@@ -337,7 +341,7 @@ void GraphicsWindowWX::useCursor(bool cursorOn)
 
 bool GraphicsWindowWX::makeCurrentImplementation()
 {
-    _canvas->SetCurrent();
+    _canvas->SetContextCurrent();
     return true;
 }
 

--- a/examples/osgviewerWX/osgviewerWX.h
+++ b/examples/osgviewerWX/osgviewerWX.h
@@ -38,12 +38,14 @@ public:
 
     void UseCursor(bool value);
 
+	void SetContextCurrent();
 private:
     DECLARE_EVENT_TABLE()
 
     osg::ref_ptr<osgViewer::GraphicsWindow> _graphics_window;
 
     wxCursor _oldCursor;
+    wxGLContext _context;
 };
 
 class GraphicsWindowWX : public osgViewer::GraphicsWindow


### PR DESCRIPTION
Cherry-pick old PR of @Alexibu

Needed upgrade of WXWidgets. This PR make sample compatible with WXWidgets from version 3.0.1

I successfully tested it with wxWidgets 3.1

Pull request was closed

https://github.com/openscenegraph/OpenSceneGraph/pull/47

Thanks