### PR TITLE
On cygwin, don't use pthread functions that require _GNU_SOURCE in OpenThreads

### DIFF
--- a/src/OpenThreads/pthreads/CMakeLists.txt
+++ b/src/OpenThreads/pthreads/CMakeLists.txt
@@ -20,6 +20,11 @@ SET(TARGET_SRC
     ../common/Version.cpp
     ../common/Atomic.cpp
 )
+
+IF(CYGWIN)  # define for pthread_{yield,getconcurrency,setconcurrency}
+    ADD_DEFINITIONS(-D_GNU_SOURCE)
+ENDIF()
+
 IF(ANDROID)
       ADD_DEFINITIONS(-D_GNU_SOURCE)
       SET(CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS} -D_GNU_SOURCE")


### PR DESCRIPTION
This fixes a compilation failure in OpenThreads on cygwin x64 on Win8.1 and Win10 with gcc 7.3.0.  This is the smallest, most targeted fix I can think of, since I didn't want to unintentionally introduce any regressions.

Problem: `pthread_{yield,getconcurrency,setconcurrency}` are not declared in `pthread.h` on cygwin with gcc 7.3.0 (latest as of writing) unless `_GNU_SOURCE` is defined.  However, cmake's [`CheckFunctionExists`](https://cmake.org/cmake/help/latest/module/CheckFunctionExists.html) doesn't test for declarations, just for linkage.  Therefore, cmake detects those functions as existing, but then OpenThreads fails to compile because they are undeclared.

Solution implemented in this PR: on cygwin, just don't use the functions that are hidden when `_GNU_SOURCE` is not defined.  For example, without `pthread_yield`, the build falls back to `sched_yield`, which compiles just fine.

Alternative solution: define `_GNU_SOURCE` while compiling OpenThreads on cygwin (as is done now for Android).  However, this changes a number of other functions, and can possibly [change behaviour](https://stackoverflow.com/a/5583764/2877364) of some functions.  Therefore, I think the above approach is less likely to have unintended consequences.  However, if you prefer the `_GNU_SOURCE` approach, I am certainly happy to give it a try and let you know what I find.