### PR TITLE
Drawable: Explicitly release VAO on destruction to avoid resource leak.

### DIFF
--- a/src/osg/Drawable.cpp
+++ b/src/osg/Drawable.cpp
@@ -257,6 +257,11 @@ Drawable::Drawable(const Drawable& drawable,const CopyOp& copyop):
 Drawable::~Drawable()
 {
     dirtyGLObjects();
+    for (unsigned int i = 0; i<_vertexArrayStateList.size(); ++i)
+    {
+        VertexArrayState* vas = _vertexArrayStateList[i].get();
+        if (vas) vas->release();
+    }
 }
 
 osg::MatrixList Drawable::getWorldMatrices(const osg::Node* haltTraversalAtNode) const


### PR DESCRIPTION
This appears to help the issue identified on the mailing list.  It may not be the correct fix but it seems like a step in the right direction.

The code reads like it was heavily influenced by Display Lists.  `~Drawable()` destroys associated display lists indirectly, by calling `dirtyGLObjects()`, which gets the call eventually to the contexts' `DisplayListManager`.  VAO was not making it to its `VertexArrayStateManager` class.  It looks like the hook is there with `VertexArrayState::release()`, but it wasn't being called when the drawable closed out.  Now it is called.

I tested on Core Profile with 3.6.2 and this modification.  Afterwards, I no longer see a leak.  Before, I was leaking up to 3 megs a minutes.

One note and why I think this might not be the right solution: I added a counter to the code to count the number of `glGenVertexArrays` to `glDeleteVertexArrays` calls.  I'm missing one on exit.  It seems like the VAO created in the very last frame doesn't get cleaned up.  I tried to track this down but failed to do so.  Since a resource leak of 1 VAO is better than 1 per frame, I thought this was worth at least posting for your consideration.  Thanks.