### PR TITLE
Replace REGISTER_WINDOWINGSYSTEMINTERFACE for X11 using OSGVIEWER_EXPORT

### DIFF
--- a/src/osgViewer/GraphicsWindowX11.cpp
+++ b/src/osgViewer/GraphicsWindowX11.cpp
@@ -2277,7 +2277,9 @@ public:
 
 };
 
-REGISTER_WINDOWINGSYSTEMINTERFACE(X11, X11WindowingSystemInterface)
+// Replaces REGISTER_WINDOWINGSYSTEMINTERFACE using OSGVIEWER_EXPORT
+extern "C" OSGVIEWER_EXPORT void graphicswindow_X11(void) {}
+static osg::WindowingSystemInterfaceProxy<X11WindowingSystemInterface> s_proxy_X11WindowingSystem("X11");
 
 void GraphicsWindowX11::raiseWindow()
 {


### PR DESCRIPTION
This fixes a linker error in example_osgslice on cygwin x64, Win10, gcc 7.3.0.

Problem: when compiling on cygwin for dynamic linking (using #586), osgslice can't link because `graphicswindow_X11()` is not found.

Solution: Use the same `REGISTER_WINDOWINGSYSTEMINTERFACE` replacement for X11 as for Win32 (0bca415d5af4647da868888c1588b9617dbe3eb8).

Explanation: On cygwin, X11 is the default windowing system.  Since `osgViewer` is compiling to a Win32 DLL, `X11WindowingSystem` needs `OSGVIEWER_EXPORT` just like `Win32WindowingSystem` does.  On non-Windows platforms, `OSGVIEWER_EXPORT` is a no-op, so this should not affect any other platform.