### PR TITLE
Renamed USE_DEPRECATED_API to OSG_USE_DEPRECATED_API

### DIFF
--- a/include/osg/Matrixd
+++ b/include/osg/Matrixd
@@ -327,7 +327,7 @@ class OSG_EXPORT Matrixd
         inline Vec4f operator* ( const Vec4f& v ) const;
         inline Vec4d operator* ( const Vec4d& v ) const;
 
-#ifdef USE_DEPRECATED_API
+#ifdef OSG_USE_DEPRECATED_API
         inline void set(const Quat& q) { makeRotate(q); }   /// deprecated, replace with makeRotate(q)
         inline void get(Quat& q) const { q = getRotate(); } /// deprecated, replace with getRotate()
 #endif

--- a/include/osg/Matrixf
+++ b/include/osg/Matrixf
@@ -328,7 +328,7 @@ class OSG_EXPORT Matrixf
         inline Vec4f operator* ( const Vec4f& v ) const;
         inline Vec4d operator* ( const Vec4d& v ) const;
 
-#ifdef USE_DEPRECATED_API
+#ifdef OSG_USE_DEPRECATED_API
         inline void set(const Quat& q) { makeRotate(q); }
         inline void get(Quat& q) const { q = getRotate(); }
 #endif


### PR DESCRIPTION
Using USE_DEPRECATED_API, you can not disable Matrix's get/set methods with cmake.