### PR TITLE
Prevent culling of Drawables with culling disabled, but which have valid bounds

### DIFF
--- a/src/osgUtil/CullVisitor.cpp
+++ b/src/osgUtil/CullVisitor.cpp
@@ -924,7 +924,7 @@ void CullVisitor::apply(osg::Drawable& drawable)
 
     if (_computeNearFar && bb.valid())
     {
-        if (!updateCalculatedNearFar(matrix,drawable,false)) return;
+        if (!updateCalculatedNearFar(matrix,drawable,false) && drawable.isCullingActive()) return;
     }
 
     // need to track how push/pops there are, so we can unravel the stack correctly.


### PR DESCRIPTION
If the scene graph contains any Drawables with culling disabled, but which have valid bounds, and the CullVisitor is set to compute the near and far planes, it's possible for the Drawables to be culled.

Such a situation could occur if, for example, the drawable's vertices were to be repositioned by the vertex shader, but a programmer hadn't set the bounds to an invalid value as there was never any need when the application was initially written as it used fixed near and far planes.

I've spent the last six days trying to stop shadows making animated meshes disappear in OpenMW, and would rather no one else has to go through anything similar. This fix may not actually be necessary if there was big writing in lots of places warning that this could happen and saying how to avoid it, but I'm pretty sure it's a bug if a node with culling disabled still gets culled, so it's probably better off merged.