### PR TITLE
replace unsized pixel format GL_RGBA to GL_RGBA8

### DIFF
--- a/examples/osgprerender/osgprerender.cpp
+++ b/examples/osgprerender/osgprerender.cpp
@@ -218,7 +218,7 @@ osg::Node* createPreRenderSubGraph(osg::Node* subgraph,
     {
         osg::TextureRectangle* textureRect = new osg::TextureRectangle;
         textureRect->setTextureSize(tex_width, tex_height);
-        textureRect->setInternalFormat(GL_RGBA);
+        textureRect->setInternalFormat(GL_RGBA8);
         textureRect->setFilter(osg::Texture2D::MIN_FILTER,osg::Texture2D::LINEAR);
         textureRect->setFilter(osg::Texture2D::MAG_FILTER,osg::Texture2D::LINEAR);
 
@@ -228,7 +228,7 @@ osg::Node* createPreRenderSubGraph(osg::Node* subgraph,
     {
         osg::Texture2D* texture2D = new osg::Texture2D;
         texture2D->setTextureSize(tex_width, tex_height);
-        texture2D->setInternalFormat(GL_RGBA);
+        texture2D->setInternalFormat(GL_RGBA8);
         texture2D->setFilter(osg::Texture2D::MIN_FILTER,osg::Texture2D::LINEAR);
         texture2D->setFilter(osg::Texture2D::MAG_FILTER,osg::Texture2D::LINEAR);
 


### PR DESCRIPTION
correct a bug introduced by the use of immutable texture storage
According to several users (http://forum.openscenegraph.org/viewtopic.php?t=17437)
the bug is involve in others examples
