### PR TITLE
replace unsized InternalFormat GL_RGBA to GL_RGBA16 for ImageLess Textures

### DIFF
--- a/examples/osgSSBO/osgSSBO.cpp
+++ b/examples/osgSSBO/osgSSBO.cpp
@@ -799,7 +799,8 @@ osg::Node* createPrerenderSubgraph(osg::Node* subgraph, const osg::Vec4& clearCo
 
     osg::Texture2D* texture = new osg::Texture2D;
     texture->setTextureSize(tex_width, tex_height);
-    texture->setInternalFormat(GL_RGBA);
+    texture->setInternalFormat(GL_RGBA16);
+    texture->setSourceFormat(GL_RGBA);
     texture->setFilter(osg::Texture2D::MIN_FILTER, osg::Texture2D::LINEAR);
     texture->setFilter(osg::Texture2D::MAG_FILTER, osg::Texture2D::LINEAR);
 

--- a/examples/osgoit/DepthPeeling.cpp
+++ b/examples/osgoit/DepthPeeling.cpp
@@ -307,7 +307,8 @@ void DepthPeeling::createPeeling()
         colorTexture->setFilter(osg::Texture::MAG_FILTER, osg::Texture::NEAREST);
         colorTexture->setWrap(osg::Texture::WRAP_S, osg::Texture::CLAMP_TO_BORDER);
         colorTexture->setWrap(osg::Texture::WRAP_T, osg::Texture::CLAMP_TO_BORDER);
-        colorTexture->setInternalFormat(GL_RGBA);
+        colorTexture->setInternalFormat(GL_RGBA16);
+        colorTexture->setSourceFormat(GL_RGBA);
 
         _colorTextures[i] = colorTexture;
     }

--- a/examples/osgprerender/osgprerender.cpp
+++ b/examples/osgprerender/osgprerender.cpp
@@ -218,7 +218,7 @@ osg::Node* createPreRenderSubGraph(osg::Node* subgraph,
     {
         osg::TextureRectangle* textureRect = new osg::TextureRectangle;
         textureRect->setTextureSize(tex_width, tex_height);
-        textureRect->setInternalFormat(GL_RGBA);
+        textureRect->setInternalFormat(GL_RGBA16);
         textureRect->setFilter(osg::Texture2D::MIN_FILTER,osg::Texture2D::LINEAR);
         textureRect->setFilter(osg::Texture2D::MAG_FILTER,osg::Texture2D::LINEAR);
 
@@ -228,17 +228,18 @@ osg::Node* createPreRenderSubGraph(osg::Node* subgraph,
     {
         osg::Texture2D* texture2D = new osg::Texture2D;
         texture2D->setTextureSize(tex_width, tex_height);
-        texture2D->setInternalFormat(GL_RGBA);
+        texture2D->setInternalFormat(GL_RGBA16);
         texture2D->setFilter(osg::Texture2D::MIN_FILTER,osg::Texture2D::LINEAR);
         texture2D->setFilter(osg::Texture2D::MAG_FILTER,osg::Texture2D::LINEAR);
 
         texture = texture2D;
     }
 
+    texture->setSourceFormat(GL_RGBA);
+
     if (useHDR)
     {
-        texture->setInternalFormat(GL_RGBA16F_ARB);
-        texture->setSourceFormat(GL_RGBA);
+        texture->setInternalFormat(GL_RGBA16F_ARB);        
         texture->setSourceType(GL_FLOAT);
     }
 


### PR DESCRIPTION
…and set sourceFormat to GL_RGBA
correct a bug introduced by the use of immutable texture storage
According to several users (http://forum.openscenegraph.org/viewtopic.php?t=17437)
the bug is involve in others examples
It may be GL_RGBA8 will mod it if required

