### PR TITLE
Remove duplication of REGISTER_WINDOWINGSYSTEMINTERFACE code in GraphicsWindowWin32

### DIFF
--- a/include/osg/GraphicsContext
+++ b/include/osg/GraphicsContext
@@ -597,10 +597,15 @@ struct WindowingSystemInterfaceProxy
     osg::ref_ptr<T> _wsi;
 };
 
-#define REGISTER_WINDOWINGSYSTEMINTERFACE(ext, classname) \
-    extern "C" void graphicswindow_##ext(void) {} \
+// Internal use only - compile on C90 compilers, which prohibit empty macro arguments.
+#define _OSG_GRAPHICSCONTEXT_NO_ATTRIBS
+
+#define REGISTER_WINDOWINGSYSTEMINTERFACE2(ext, classname, attribs) \
+    extern "C" attribs void graphicswindow_##ext(void) {} \
     static osg::WindowingSystemInterfaceProxy<classname> s_proxy_##classname(#ext);
 
+#define REGISTER_WINDOWINGSYSTEMINTERFACE(ext, classname) \
+    REGISTER_WINDOWINGSYSTEMINTERFACE2(ext, classname, _OSG_GRAPHICSCONTEXT_NO_ATTRIBS)
 }
 
 #endif

--- a/src/osgViewer/GraphicsWindowWin32.cpp
+++ b/src/osgViewer/GraphicsWindowWin32.cpp
@@ -3148,8 +3148,7 @@ static RegisterWindowingSystemInterfaceProxy createWindowingSystemInterfaceProxy
 } // namespace OsgViewer
 
 
-extern "C" OSGVIEWER_EXPORT void graphicswindow_Win32(void) {}
-static osg::WindowingSystemInterfaceProxy<Win32WindowingSystem> s_proxy_Win32WindowingSystem("Win32");
+REGISTER_WINDOWINGSYSTEMINTERFACE2(Win32,Win32WindowingSystem,OSGVIEWER_EXPORT)
 
 void GraphicsWindowWin32::raiseWindow()
 {

--- a/src/osgViewer/GraphicsWindowX11.cpp
+++ b/src/osgViewer/GraphicsWindowX11.cpp
@@ -2277,7 +2277,7 @@ public:
 
 };
 
-REGISTER_WINDOWINGSYSTEMINTERFACE(X11, X11WindowingSystemInterface)
+REGISTER_WINDOWINGSYSTEMINTERFACE2(X11, X11WindowingSystemInterface, OSGVIEWER_EXPORT)
 
 void GraphicsWindowX11::raiseWindow()
 {


### PR DESCRIPTION
Refactor so `src/osgViewer/GraphicsWindowWin32.cpp` doesn't duplicate code in `include/osg/GraphicsContext`.  New macro `REGISTER_WINDOWINGSYSTEMINTERFACE2` can accept `OSGVIEWER_EXPORT`, introduced into Win32 in May as part of 0bca415d5af4647da868888c1588b9617dbe3eb8.

Also fixes the Cygwin build problem identified in #588, and still present in master (e008784ab67be96e3e079aecfd2fc115b7b7885b).  Uses a neat and tidy macro, per Robert's feedback on #588.

Also tested and works with osgQt on my Cygwin setup (0bca415d5af4647da868888c1588b9617dbe3eb8 refers to osgQt, so I tried it out).