### PR TITLE
GL_RGBA16F and GL_RGBA32F not defined on Windows

### DIFF
--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -150,9 +150,13 @@ InternalPixelRelations sizedInternalFormats[] = {
     , { GL_RGB5_A1                             , GL_RGBA             , GL_UNSIGNED_INT_10_10_10_2                   }
     , { GL_RGB5_A1                             , GL_RGBA             , GL_UNSIGNED_INT_2_10_10_10_REV               }
  // , { GL_RGBA16F                             , GL_RGBA             , GL_HALF_FLOAT                                }
+#if defined(GL_RGBA16F) && defined(GL_RGBA32F) 
     , { GL_RGBA16F                             , GL_RGBA             , GL_FLOAT                                     }
     , { GL_RGBA32F                             , GL_RGBA             , GL_FLOAT                                     }
-
+#else
+	, { GL_RGBA16F_ARB                         , GL_RGBA             , GL_FLOAT                                     }
+	, { GL_RGBA32F_ARB                         , GL_RGBA             , GL_FLOAT                                     }
+#endif
     , { GL_SRGB8                               , GL_RGB              , GL_UNSIGNED_BYTE                             }
     , { GL_SRGB8_ALPHA8                        , GL_RGBA             , GL_UNSIGNED_BYTE                             }
 


### PR DESCRIPTION
GL_RGBA16F and GL_RGBA32F not defined on Windows so use _ARB versions.  I assume since Travis passed, this is a Windows issue