### PR TITLE
Protect the _programSet in Shader with a mutex.

### DIFF
--- a/include/osg/Shader
+++ b/include/osg/Shader
@@ -347,6 +347,7 @@ class OSG_EXPORT Shader : public osg::Object
         /** osg::Programs that this osg::Shader is attached to */
         typedef std::set< osg::Program* > ProgramSet;
         ProgramSet                      _programSet;
+        OpenThreads::Mutex _programSetMutex;
         mutable osg::buffered_value< osg::ref_ptr<ShaderObjects> > _pcsList;
 
     private:

--- a/src/osg/Shader.cpp
+++ b/src/osg/Shader.cpp
@@ -484,6 +484,7 @@ Shader::PerContextShader* Shader::getPCS(osg::State& state) const
 
 bool Shader::addProgramRef( Program* program )
 {
+    OpenThreads::ScopedLock<OpenThreads::Mutex> lk(_programSetMutex);
     ProgramSet::iterator itr = _programSet.find(program);
     if( itr != _programSet.end() ) return false;
 
@@ -493,6 +494,7 @@ bool Shader::addProgramRef( Program* program )
 
 bool Shader::removeProgramRef( Program* program )
 {
+    OpenThreads::ScopedLock<OpenThreads::Mutex> lk(_programSetMutex);
     ProgramSet::iterator itr = _programSet.find(program);
     if( itr == _programSet.end() ) return false;
 
@@ -508,6 +510,7 @@ void Shader::dirtyShader()
         if( _pcsList[cxt].valid() ) _pcsList[cxt]->requestCompile();
     }
 
+    OpenThreads::ScopedLock<OpenThreads::Mutex> lk(_programSetMutex);
     // Also mark Programs that depend on us as needing relink.
     for( ProgramSet::iterator itr = _programSet.begin();
         itr != _programSet.end(); ++itr )


### PR DESCRIPTION
Hi Robert!

Here is a change to Shader that protects the _programSet with a mutex.  Crashes can occur if you reuse Shader objects between multiple Programs b/c the addProgramRef and removeProgramRef functions aren't thread safe.  The VirtualProgram framework in osgEarth can generate Programs as needed using shared Shader objects, so we would see crashes when running with multiple windows using CullThreadPerCameraDrawThreadPerContext mode.

I've attached a simple example that shows the issue, it just creates and destroys programs in background threads that share a global Shader object.

Thanks!

Jason
[sharedshader.txt](https://github.com/openscenegraph/OpenSceneGraph/files/2349377/sharedshader.txt)

