### PR TITLE
Fix typo in the initial check of Image::scaleImage().

### DIFF
--- a/src/osg/Image.cpp
+++ b/src/osg/Image.cpp
@@ -1518,7 +1518,7 @@ void Image::swap(osg::Image& rhs)
 
 void Image::scaleImage(int s,int t,int r, GLenum newDataType)
 {
-    if (_s==s && _t==t && _r==r && _dataType==_dataType) return;
+    if (_s==s && _t==t && _r==r && _dataType==newDataType) return;
 
     if (_data==NULL)
     {


### PR DESCRIPTION
I think there is a typo in the initial check for not doing anything if the data provided matches the ones already present.