### PR TITLE
Added saving of inline Images without having the physical image file.

### DIFF
--- a/src/osgDB/OutputStream.cpp
+++ b/src/osgDB/OutputStream.cpp
@@ -17,6 +17,7 @@
 #include <osgDB/ConvertBase64>
 #include <osgDB/FileUtils>
 #include <osgDB/WriteFile>
+#include <osgDB/FileNameUtils>
 #include <osgDB/ObjectWrapper>
 #include <osgDB/fstream>
 #include <sstream>
@@ -581,35 +582,61 @@ void OutputStream::writeImage( const osg::Image* img )
             if ( isBinary() )
             {
                 std::string fullPath = osgDB::findDataFile( img->getFileName(), _options.get() );
-                osgDB::ifstream infile( fullPath.c_str(), std::ios::in|std::ios::binary );
-                if ( infile )
+                if (fullPath.empty()==false)
                 {
-                    infile.seekg( 0, std::ios::end );
-                    unsigned int size = infile.tellg();
-                    writeSize(size);
-
-                    if ( size>0 )
+                    osgDB::ifstream infile( fullPath.c_str(), std::ios::in|std::ios::binary );
+                
+                    if ( infile )
                     {
-                        char* data = new char[size];
-                        if ( !data )
-                        {
-                            throwException( "OutputStream::writeImage(): Out of memory." );
-                            if ( getException() ) return;
-                        }
+                        infile.seekg( 0, std::ios::end );
+                        unsigned int size = infile.tellg();
+                        writeSize(size);
 
-                        infile.seekg( 0, std::ios::beg );
-                        infile.read( data, size );
-                        writeCharArray( data, size );
-                        delete[] data;
+                        if ( size>0 )
+                        {
+                            char* data = new char[size];
+                            if ( !data )
+                            {
+                                throwException( "OutputStream::writeImage(): Out of memory." );
+                                if ( getException() ) return;
+                            }
+
+                            infile.seekg( 0, std::ios::beg );
+                            infile.read( data, size );
+                            writeCharArray( data, size );
+                            delete[] data;
+                        }
+                        infile.close();
                     }
-                    infile.close();
+                    else
+                    {
+                        OSG_WARN << "OutputStream::writeImage(): Failed to open image file "
+                                            << img->getFileName() << std::endl;
+                        *this << (unsigned int)0;
+                    }
                 }
                 else
                 {
-                    OSG_WARN << "OutputStream::writeImage(): Failed to open image file "
-                                        << img->getFileName() << std::endl;
-                    *this << (unsigned int)0;
+                    std::string ext = osgDB::getFileExtension( img->getFileName() );
+                    osgDB::ReaderWriter* writer =
+                        osgDB::Registry::instance()->getReaderWriterForExtension( ext );
+                    if ( writer )
+                    {
+                        std::stringstream outputStream;
+                        writer->writeImage(*img, outputStream, getOptions());
+                        std::string data (outputStream.str()); 
+                        unsigned int size = data.size();
+                        writeSize(size);
+                        writeCharArray( data.c_str(), size );
+                    }
+                    else
+                    {
+                        OSG_WARN << "OutputStream::writeImage(): Failed to find a plugin to write the image file "
+                                            << img->getFileName() << std::endl;
+                        *this << (unsigned int)0;
+                    }
                 }
+
             }
             break;
         case IMAGE_EXTERNAL:


### PR DESCRIPTION
This corrects the use-case of converting osg binary files( to and from) that have inlined image files. 
The OutputStream assumed that the file is physically available from the disk. This correction mimics the reader of inlined image files to select a writer and write the osg::Image into a buffer that will then be inlined into the stream.

