### PR TITLE
fix scale problem for osgText with characterSizeMode SCREEN_COORDS and _position set.

### DIFF
--- a/src/osgText/TextBase.cpp
+++ b/src/osgText/TextBase.cpp
@@ -513,7 +513,7 @@ bool TextBase::computeMatrix(osg::Matrix& matrix, osg::State* state) const
                 height = static_cast<value_type>(viewport->height());
             }
 
-            osg::Matrix mvpw = rotate_matrix * modelview * projection * osg::Matrix::scale(width/2.0, height/2.0, 1.0);
+            osg::Matrix mvpw = rotate_matrix * osg::Matrix::translate(_position) * modelview * projection * osg::Matrix::scale(width/2.0, height/2.0, 1.0);
 
             osg::Vec3d origin = osg::Vec3d(0.0, 0.0, 0.0) * mvpw;
             osg::Vec3d left = osg::Vec3d(1.0, 0.0, 0.0) * mvpw - origin;


### PR DESCRIPTION
Hi Robert,
Test size responds to rotation in 3.6 and master tree while it did not do that in previous osg versions.
Attached in zip a small file demonstrating the problem, when the scene is rotated the text size changes.

[testmeasure.zip](https://github.com/openscenegraph/OpenSceneGraph/files/2361146/testmeasure.zip)
Regards, Laurens.
