### PR TITLE
fix examples context creation for X11

### DIFF
--- a/applications/osgconv/osgconv.cpp
+++ b/applications/osgconv/osgconv.cpp
@@ -45,6 +45,8 @@ class MyGraphicsContext {
             traits->doubleBuffer = false;
             traits->sharedContext = 0;
             traits->pbuffer = true;
+            traits->readDISPLAY();
+            traits->setUndefinedScreenDetailsToDefaultScreen();
 
             _gc = osg::GraphicsContext::createGraphicsContext(traits.get());
 

--- a/examples/osgautocapture/osgautocapture.cpp
+++ b/examples/osgautocapture/osgautocapture.cpp
@@ -249,6 +249,8 @@ int main( int argc, char **argv )
             traits->width = 1 << 12;
             traits->height = 1 << 12;
             traits->pbuffer = true;
+            traits->readDISPLAY();
+            traits->setUndefinedScreenDetailsToDefaultScreen();
         }
         osg::ref_ptr<osg::GraphicsContext> pbuffer = osg::GraphicsContext::createGraphicsContext(traits.get());
         if (pbuffer.valid())

--- a/examples/osgautotransform/osgautotransform.cpp
+++ b/examples/osgautotransform/osgautotransform.cpp
@@ -209,6 +209,8 @@ osgViewer::View* createView(osg::ref_ptr<osg::Node> scenegraph, osg::ref_ptr<osg
         traits->windowDecoration = true;
         traits->doubleBuffer = true;
         traits->sharedContext = 0;
+        traits->readDISPLAY();
+        traits->setUndefinedScreenDetailsToDefaultScreen();
 
         gc = osg::GraphicsContext::createGraphicsContext(traits.get());
         if (!gc)
@@ -267,7 +269,11 @@ int main(int argc, char** argv)
         }
 
         unsigned int width, height;
-        wsi->getScreenResolution(osg::GraphicsContext::ScreenIdentifier(0), width, height);
+        osg::GraphicsContext::ScreenIdentifier main_screen_id;
+
+        main_screen_id.readDISPLAY();
+        main_screen_id.setUndefinedScreenDetailsToDefaultScreen();
+        wsi->getScreenResolution(main_screen_id, width, height);
 
         unsigned int x=0, y=0;
         while(arguments.read("--window", x, y, width, height)) {}
@@ -283,6 +289,8 @@ int main(int argc, char** argv)
             traits->windowDecoration = true;
             traits->doubleBuffer = true;
             traits->sharedContext = 0;
+            traits->readDISPLAY();
+            traits->setUndefinedScreenDetailsToDefaultScreen();
 
             gc = osg::GraphicsContext::createGraphicsContext(traits.get());
             if (!gc)

--- a/examples/osgcamera/osgcamera.cpp
+++ b/examples/osgcamera/osgcamera.cpp
@@ -83,7 +83,11 @@ void singleWindowMultipleCameras(osgViewer::Viewer& viewer)
     }
 
     unsigned int width, height;
-    wsi->getScreenResolution(osg::GraphicsContext::ScreenIdentifier(0), width, height);
+    osg::GraphicsContext::ScreenIdentifier main_screen_id;
+
+    main_screen_id.readDISPLAY();
+    main_screen_id.setUndefinedScreenDetailsToDefaultScreen();
+    wsi->getScreenResolution(main_screen_id, width, height);
 
     osg::ref_ptr<osg::GraphicsContext::Traits> traits = new osg::GraphicsContext::Traits;
     traits->x = 0;
@@ -93,6 +97,8 @@ void singleWindowMultipleCameras(osgViewer::Viewer& viewer)
     traits->windowDecoration = true;
     traits->doubleBuffer = true;
     traits->sharedContext = 0;
+    traits->readDISPLAY();
+    traits->setUndefinedScreenDetailsToDefaultScreen();
 
     osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
     if (gc.valid())
@@ -134,7 +140,11 @@ void multipleWindowMultipleCameras(osgViewer::Viewer& viewer, bool multipleScree
     }
 
     unsigned int width, height;
-    wsi->getScreenResolution(osg::GraphicsContext::ScreenIdentifier(0), width, height);
+    osg::GraphicsContext::ScreenIdentifier main_screen_id;
+
+    main_screen_id.readDISPLAY();
+    main_screen_id.setUndefinedScreenDetailsToDefaultScreen();
+    wsi->getScreenResolution(main_screen_id, width, height);
 
 
     unsigned int numCameras = 6;
@@ -151,6 +161,8 @@ void multipleWindowMultipleCameras(osgViewer::Viewer& viewer, bool multipleScree
         traits->windowDecoration = true;
         traits->doubleBuffer = true;
         traits->sharedContext = 0;
+        traits->readDISPLAY();
+        traits->setUndefinedScreenDetailsToDefaultScreen();
 
         osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
         if (gc.valid())

--- a/examples/osgcompositeviewer/osgcompositeviewer.cpp
+++ b/examples/osgcompositeviewer/osgcompositeviewer.cpp
@@ -289,7 +289,11 @@ int main( int argc, char **argv )
         }
 
         unsigned int width, height;
-        wsi->getScreenResolution(osg::GraphicsContext::ScreenIdentifier(0), width, height);
+        osg::GraphicsContext::ScreenIdentifier main_screen_id;
+
+        main_screen_id.readDISPLAY();
+        main_screen_id.setUndefinedScreenDetailsToDefaultScreen();
+        wsi->getScreenResolution(main_screen_id, width, height);
 
         osg::ref_ptr<osg::GraphicsContext::Traits> traits = new osg::GraphicsContext::Traits;
         traits->x = 100;
@@ -299,6 +303,8 @@ int main( int argc, char **argv )
         traits->windowDecoration = true;
         traits->doubleBuffer = true;
         traits->sharedContext = 0;
+        traits->readDISPLAY();
+        traits->setUndefinedScreenDetailsToDefaultScreen();
 
         osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
         if (gc.valid())

--- a/examples/osgdistortion/osgdistortion.cpp
+++ b/examples/osgdistortion/osgdistortion.cpp
@@ -79,7 +79,11 @@ struct CommandLineOptions
             return;
         }
 
-        wsi->getScreenResolution(osg::GraphicsContext::ScreenIdentifier(0), width, height);
+        osg::GraphicsContext::ScreenIdentifier main_screen_id;
+
+        main_screen_id.readDISPLAY();
+        main_screen_id.setUndefinedScreenDetailsToDefaultScreen();
+        wsi->getScreenResolution(main_screen_id, width, height);
         distance = sqrt(sphere_radius*sphere_radius - collar_radius*collar_radius);
     }
 
@@ -274,6 +278,8 @@ void setDomeFaces(osgViewer::Viewer& viewer, CommandLineOptions& options)
     traits->windowDecoration = true;
     traits->doubleBuffer = true;
     traits->sharedContext = 0;
+    traits->readDISPLAY();
+    traits->setUndefinedScreenDetailsToDefaultScreen();
 
     osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
     if (!gc)
@@ -502,6 +508,8 @@ void setDomeCorrection(osgViewer::Viewer& viewer, CommandLineOptions& options)
     traits->windowDecoration = false;
     traits->doubleBuffer = true;
     traits->sharedContext = 0;
+    traits->readDISPLAY();
+    traits->setUndefinedScreenDetailsToDefaultScreen();
 
     osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
     if (!gc)

--- a/examples/osgfpdepth/osgfpdepth.cpp
+++ b/examples/osgfpdepth/osgfpdepth.cpp
@@ -722,6 +722,8 @@ GraphicsContext* setupGC(osgViewer::Viewer& viewer, ArgumentParser& arguments)
     traits->windowDecoration = decoration;
     traits->doubleBuffer = true;
     traits->sharedContext = 0;
+    traits->readDISPLAY();
+    traits->setUndefinedScreenDetailsToDefaultScreen();
 
     ref_ptr<GraphicsContext> gc = GraphicsContext::createGraphicsContext(traits.get());
     osgViewer::GraphicsWindow* gw = dynamic_cast<osgViewer::GraphicsWindow*>(gc.get());

--- a/examples/osghangglide/osghangglide.cpp
+++ b/examples/osghangglide/osghangglide.cpp
@@ -48,7 +48,7 @@ class MoveEarthySkyWithEyePointTransform : public osg::Transform
 {
 public:
     /** Get the transformation matrix which moves from local coords to world coords.*/
-    virtual bool computeLocalToWorldMatrix(osg::Matrix& matrix,osg::NodeVisitor* nv) const 
+    virtual bool computeLocalToWorldMatrix(osg::Matrix& matrix,osg::NodeVisitor* nv) const
     {
         osgUtil::CullVisitor* cv = dynamic_cast<osgUtil::CullVisitor*>(nv);
         if (cv)
@@ -63,7 +63,7 @@ public:
     virtual bool computeWorldToLocalMatrix(osg::Matrix& matrix,osg::NodeVisitor* nv) const
     {
         std::cout<<"computing transform"<<std::endl;
-    
+
         osgUtil::CullVisitor* cv = dynamic_cast<osgUtil::CullVisitor*>(nv);
         if (cv)
         {
@@ -99,7 +99,7 @@ osg::Group* createModel()
 
     // add the sky and base layer.
     transform->addChild(makeSky());  // bin number -2 so drawn first.
-    transform->addChild(makeBase()); // bin number -1 so draw second.      
+    transform->addChild(makeBase()); // bin number -1 so draw second.
 
     // add the transform to the earth sky.
     clearNode->addChild(transform);
@@ -138,14 +138,14 @@ int main( int argc, char **argv )
         arguments.getApplicationUsage()->write(std::cout);
         return 1;
     }
-    
+
     bool customWindows = false;
     while(arguments.read("-2")) customWindows = true;
 
     if (customWindows)
     {
         osg::GraphicsContext::WindowingSystemInterface* wsi = osg::GraphicsContext::getWindowingSystemInterface();
-        if (!wsi) 
+        if (!wsi)
         {
             osg::notify(osg::NOTICE)<<"View::setUpViewAcrossAllScreens() : Error, no WindowSystemInterface available, cannot create windows."<<std::endl;
             return 0;
@@ -159,6 +159,8 @@ int main( int argc, char **argv )
         traits->windowDecoration = true;
         traits->doubleBuffer = true;
         traits->sharedContext = 0;
+        traits->readDISPLAY();
+        traits->setUndefinedScreenDetailsToDefaultScreen();
 
         osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
         if (gc.valid())
@@ -186,17 +188,17 @@ int main( int argc, char **argv )
 
             viewer.addSlave(camera.get(), osg::Matrixd(), osg::Matrixd::scale(aspectRatioScale,1.0,1.0));
         }
-    }    
+    }
     else
     {
         viewer.setUpViewAcrossAllScreens();
-    
+
     }
 
     // set up the camera manipulation with our custom manipultor
     viewer.setCameraManipulator(new GliderManipulator());
 
-    // pass the scene graph to the viewer    
+    // pass the scene graph to the viewer
     viewer.setSceneData( createModel() );
 
     return viewer.run();

--- a/examples/osgmovie/osgmovie.cpp
+++ b/examples/osgmovie/osgmovie.cpp
@@ -641,7 +641,11 @@ int main(int argc, char** argv)
         if (wsi)
         {
             unsigned int width, height;
-            wsi->getScreenResolution(osg::GraphicsContext::ScreenIdentifier(0), width, height);
+            osg::GraphicsContext::ScreenIdentifier main_screen_id;
+
+            main_screen_id.readDISPLAY();
+            main_screen_id.setUndefinedScreenDetailsToDefaultScreen();
+            wsi->getScreenResolution(main_screen_id, width, height);
 
             screenAspectRatio = float(width) / float(height);
         }

--- a/examples/osgmultiviewpaging/osgmultiviewpaging.cpp
+++ b/examples/osgmultiviewpaging/osgmultiviewpaging.cpp
@@ -91,7 +91,11 @@ int main( int argc, char **argv )
         }
 
         unsigned int width, height;
-        wsi->getScreenResolution(osg::GraphicsContext::ScreenIdentifier(0), width, height);
+        osg::GraphicsContext::ScreenIdentifier main_screen_id;
+
+        main_screen_id.readDISPLAY();
+        main_screen_id.setUndefinedScreenDetailsToDefaultScreen();
+        wsi->getScreenResolution(main_screen_id, width, height);
 
         osg::ref_ptr<osg::GraphicsContext::Traits> traits = new osg::GraphicsContext::Traits;
         traits->x = 100;
@@ -101,6 +105,8 @@ int main( int argc, char **argv )
         traits->windowDecoration = true;
         traits->doubleBuffer = true;
         traits->sharedContext = 0;
+        traits->readDISPLAY();
+        traits->setUndefinedScreenDetailsToDefaultScreen();
 
         osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
         if (gc.valid())

--- a/examples/osgoscdevice/osgoscdevice.cpp
+++ b/examples/osgoscdevice/osgoscdevice.cpp
@@ -443,6 +443,8 @@ int main( int argc, char **argv )
         traits->doubleBuffer = true;
         traits->sharedContext = 0;
         traits->windowName = "Receiver / view two";
+        traits->readDISPLAY();
+        traits->setUndefinedScreenDetailsToDefaultScreen();
 
         osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
 
@@ -509,6 +511,8 @@ int main( int argc, char **argv )
         traits->doubleBuffer = true;
         traits->sharedContext = 0;
         traits->windowName = "Sender / view one";
+        traits->readDISPLAY();
+        traits->setUndefinedScreenDetailsToDefaultScreen();
 
         osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
 

--- a/examples/osgscreencapture/osgscreencapture.cpp
+++ b/examples/osgscreencapture/osgscreencapture.cpp
@@ -712,6 +712,8 @@ int main(int argc, char** argv)
         traits->pbuffer = true;
         traits->doubleBuffer = true;
         traits->sharedContext = 0;
+        traits->readDISPLAY();
+        traits->setUndefinedScreenDetailsToDefaultScreen();
 
         pbuffer = osg::GraphicsContext::createGraphicsContext(traits.get());
         if (pbuffer.valid())

--- a/examples/osgsidebyside/osgsidebyside.cpp
+++ b/examples/osgsidebyside/osgsidebyside.cpp
@@ -182,7 +182,11 @@ void singleWindowSideBySideCameras(osgViewer::Viewer& viewer)
     }
 
     unsigned int width, height;
-    wsi->getScreenResolution(osg::GraphicsContext::ScreenIdentifier(0), width, height);
+    osg::GraphicsContext::ScreenIdentifier main_screen_id;
+
+    main_screen_id.readDISPLAY();
+    main_screen_id.setUndefinedScreenDetailsToDefaultScreen();
+    wsi->getScreenResolution(main_screen_id, width, height);
 
 
 
@@ -198,6 +202,8 @@ void singleWindowSideBySideCameras(osgViewer::Viewer& viewer)
     traits->windowDecoration = true;
     traits->doubleBuffer = true;
     traits->sharedContext = 0;
+    traits->readDISPLAY();
+    traits->setUndefinedScreenDetailsToDefaultScreen();
 
     osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
     if (gc.valid())

--- a/examples/osgsimplegl3/osgsimplegl3.cpp
+++ b/examples/osgsimplegl3/osgsimplegl3.cpp
@@ -87,6 +87,8 @@ int main( int argc, char** argv )
     traits->windowDecoration = true;
     traits->doubleBuffer = true;
     traits->glContextVersion = version;
+    traits->readDISPLAY();
+    traits->setUndefinedScreenDetailsToDefaultScreen();
     osg::ref_ptr< osg::GraphicsContext > gc = osg::GraphicsContext::createGraphicsContext( traits.get() );
     if( !gc.valid() )
     {

--- a/examples/osgslice/osgslice.cpp
+++ b/examples/osgslice/osgslice.cpp
@@ -142,6 +142,8 @@ int main( int argc, char **argv )
     traits->doubleBuffer = true;
     traits->sharedContext = 0;
     traits->pbuffer = false;
+    traits->readDISPLAY();
+    traits->setUndefinedScreenDetailsToDefaultScreen();
 
     osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
     if (!gc || !gc->valid())

--- a/examples/osgtexturecompression/osgtexturecompression.cpp
+++ b/examples/osgtexturecompression/osgtexturecompression.cpp
@@ -146,7 +146,11 @@ int main(int argc, char** argv)
 
 
     unsigned int width, height;
-    wsi->getScreenResolution(osg::GraphicsContext::ScreenIdentifier(0), width, height);
+    osg::GraphicsContext::ScreenIdentifier main_screen_id;
+
+    main_screen_id.readDISPLAY();
+    main_screen_id.setUndefinedScreenDetailsToDefaultScreen();
+    wsi->getScreenResolution(main_screen_id, width, height);
 
     osg::ref_ptr<osg::GraphicsContext::Traits> traits = new osg::GraphicsContext::Traits;
     traits->x = 0;
@@ -155,6 +159,8 @@ int main(int argc, char** argv)
     traits->height = height;
     traits->windowDecoration = false;
     traits->doubleBuffer = true;
+    traits->readDISPLAY();
+    traits->setUndefinedScreenDetailsToDefaultScreen();
 
     osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
     if (!gc)

--- a/examples/osgwindows/osgwindows.cpp
+++ b/examples/osgwindows/osgwindows.cpp
@@ -58,6 +58,8 @@ int main( int argc, char **argv )
         traits->windowDecoration = true;
         traits->doubleBuffer = true;
         traits->sharedContext = 0;
+        traits->readDISPLAY();
+        traits->setUndefinedScreenDetailsToDefaultScreen();
 
         osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
 
@@ -82,6 +84,8 @@ int main( int argc, char **argv )
         traits->windowDecoration = true;
         traits->doubleBuffer = true;
         traits->sharedContext = 0;
+        traits->readDISPLAY();
+        traits->setUndefinedScreenDetailsToDefaultScreen();
 
         osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
 


### PR DESCRIPTION
(when DISPLAY not :0.0)
It will avoid a lot of complains related to the new Ubuntu (gnome3) default policy (DISPLAY=:1) 
so merging it on release branch can be good idea too