### PR TITLE
osgText: fixed thread-safety issues in Glyph and Font

### DIFF
--- a/include/osgText/Glyph
+++ b/include/osgText/Glyph
@@ -126,6 +126,8 @@ protected:
 
     typedef std::vector< osg::ref_ptr<TextureInfo> > TextureInfoList;
     TextureInfoList             _textureInfoList;
+
+    mutable OpenThreads::Mutex  _textureInfoListMutex;
 };
 
 class OSGTEXT_EXPORT GlyphGeometry : public osg::Referenced

--- a/src/osgText/Font.cpp
+++ b/src/osgText/Font.cpp
@@ -337,15 +337,16 @@ Glyph* Font::getGlyph(const FontResolution& fontRes, unsigned int charcode)
             GlyphMap::iterator gitr = glyphmap.find(charcode);
             if (gitr!=glyphmap.end()) return gitr->second.get();
         }
-    }
 
-    Glyph* glyph = _implementation->getGlyph(fontResUsed, charcode);
-    if (glyph)
-    {
-        addGlyph(fontResUsed, charcode, glyph);
-        return glyph;
+        Glyph* glyph = _implementation->getGlyph(fontResUsed, charcode);
+        if (glyph)
+        {
+            //addGlyph(fontResUsed, charcode, glyph);
+            _sizeGlyphMap[fontResUsed][charcode] = glyph;
+            return glyph;
+        }
+        else return 0;
     }
-    else return 0;
 }
 
 Glyph3D* Font::getGlyph3D(const FontResolution &fontRes, unsigned int charcode)
@@ -364,16 +365,15 @@ Glyph3D* Font::getGlyph3D(const FontResolution &fontRes, unsigned int charcode)
             Glyph3DMap::iterator gitr = glyphmap.find(charcode);
             if (gitr!=glyphmap.end()) return gitr->second.get();
         }
-    }
 
-    Glyph3D* glyph = _implementation->getGlyph3D(fontResUsed, charcode);
-    if (glyph)
-    {
-        OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_glyphMapMutex);
-        _sizeGlyph3DMap[fontResUsed][charcode] = glyph;
-        return glyph;
+        Glyph3D* glyph = _implementation->getGlyph3D(fontResUsed, charcode);
+        if (glyph)
+        {
+            _sizeGlyph3DMap[fontResUsed][charcode] = glyph;
+            return glyph;
+        }
+        else return 0;
     }
-    else return 0;
 }
 
 void Font::setThreadSafeRefUnref(bool threadSafe)

--- a/src/osgText/Glyph.cpp
+++ b/src/osgText/Glyph.cpp
@@ -464,6 +464,8 @@ float Glyph::getVerticalAdvance() const { return _verticalAdvance; }
 
 void Glyph::setTextureInfo(ShaderTechnique technique, TextureInfo* info)
 {
+    OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_textureInfoListMutex);
+
     if (technique>=_textureInfoList.size())
     {
         _textureInfoList.resize(technique+1);
@@ -473,11 +475,15 @@ void Glyph::setTextureInfo(ShaderTechnique technique, TextureInfo* info)
 
 const Glyph::TextureInfo* Glyph::getTextureInfo(ShaderTechnique technique) const
 {
+    OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_textureInfoListMutex);
+
     return  (technique<_textureInfoList.size()) ? _textureInfoList[technique].get() : 0;
 }
 
 Glyph::TextureInfo* Glyph::getOrCreateTextureInfo(ShaderTechnique technique)
 {
+    OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_textureInfoListMutex);
+
     if (technique>=_textureInfoList.size())
     {
         _textureInfoList.resize(technique+1);


### PR DESCRIPTION
Patch to address a thread-safety issue when creating osgText objects from multiple threads simultaneously.