### PR TITLE
fix Texture2DArray mipmapping with textureStorageEnabled

### DIFF
--- a/src/osg/Texture2DArray.cpp
+++ b/src/osg/Texture2DArray.cpp
@@ -355,7 +355,7 @@ void Texture2DArray::apply(State& state) const
         // First we need to allocate the texture memory
         if(texStorageSizedInternalFormat!=0)
         {
-            extensions->glTexStorage3D(GL_TEXTURE_2D_ARRAY, 1, texStorageSizedInternalFormat, _textureWidth, _textureHeight, textureDepth);
+            extensions->glTexStorage3D(GL_TEXTURE_2D_ARRAY, _numMipmapLevels, texStorageSizedInternalFormat, _textureWidth, _textureHeight, textureDepth);
         }
         else
         {


### PR DESCRIPTION
fix the broken mipmapping reported by Glenn Waldron here [http://forum.openscenegraph.org/viewtopic.php?p=74713#74713](url)
For the 3.7 tree the same change seems appropriate, but the files are not identical anymore.
I did not read into the textureStorage stuff, so I did not check if the call to glTexStorage3D makes sense if you have a valid image, (texture2D seems to avoid that call). I just made sure the space for the mipmaps is added.
Regards, Laurens.