### PR TITLE
1px error in GUIEventAdapter, View, Viewer and CompositeViewer major fix

### DIFF
--- a/src/osgGA/GUIEventAdapter.cpp
+++ b/src/osgGA/GUIEventAdapter.cpp
@@ -86,7 +86,7 @@ void GUIEventAdapter::setWindowRectangle(int x, int y, int width, int height, bo
 
     if (updateMouseRange)
     {
-        setInputRange(0, 0, width, height);
+        setInputRange(0, 0, width - 1, height - 1);
     }
 
 }

--- a/src/osgViewer/CompositeViewer.cpp
+++ b/src/osgViewer/CompositeViewer.cpp
@@ -753,7 +753,7 @@ void CompositeViewer::generateSlavePointerData(osg::Camera* camera, osgGA::GUIEv
         float y = event.getY();
 
         bool invert_y = event.getMouseYOrientation()==osgGA::GUIEventAdapter::Y_INCREASING_DOWNWARDS;
-        if (invert_y && gw->getTraits()) y = gw->getTraits()->height - y;
+        if (invert_y && gw->getTraits()) y = gw->getTraits()->height - 1 - y;
 
         double master_min_x = -1.0;
         double master_max_x = 1.0;
@@ -766,8 +766,8 @@ void CompositeViewer::generateSlavePointerData(osg::Camera* camera, osgGA::GUIEv
             osg::Viewport* viewport = view_masterCamera->getViewport();
             master_min_x = viewport->x();
             master_min_y = viewport->y();
-            master_max_x = viewport->x()+viewport->width();
-            master_max_y = viewport->y()+viewport->height();
+            master_max_x = viewport->x() + viewport->width() - 1;
+            master_max_y = viewport->y() + viewport->height() - 1;
             masterCameraVPW *= viewport->computeWindowMatrix();
         }
 
@@ -847,10 +847,10 @@ void CompositeViewer::generatePointerData(osgGA::GUIEventAdapter& event)
     float y = event.getY();
 
     bool invert_y = event.getMouseYOrientation()==osgGA::GUIEventAdapter::Y_INCREASING_DOWNWARDS;
-    if (invert_y && gw->getTraits()) y = gw->getTraits()->height - y;
+    if (invert_y && gw->getTraits()) y = gw->getTraits()->height - 1 - y;
 
-    event.addPointerData(new osgGA::PointerData(gw, x, 0, gw->getTraits()->width,
-                                                    y, 0, gw->getTraits()->height));
+    event.addPointerData(new osgGA::PointerData(gw, x, 0, gw->getTraits()->width - 1,
+                                                    y, 0, gw->getTraits()->height - 1));
 
     event.setMouseYOrientationAndUpdateCoords(osgGA::GUIEventAdapter::Y_INCREASING_UPWARDS);
 
@@ -869,7 +869,7 @@ void CompositeViewer::generatePointerData(osgGA::GUIEventAdapter& event)
             osg::Viewport* viewport = camera->getViewport();
             if (viewport &&
                 x >= viewport->x() && y >= viewport->y() &&
-                x <= (viewport->x()+viewport->width()) && y <= (viewport->y()+viewport->height()) )
+                x < (viewport->x()+viewport->width()) && y < (viewport->y()+viewport->height()) )
             {
                 activeCameras.push_back(camera);
             }
@@ -884,8 +884,8 @@ void CompositeViewer::generatePointerData(osgGA::GUIEventAdapter& event)
     {
         osg::Viewport* viewport = camera->getViewport();
 
-        event.addPointerData(new osgGA::PointerData(camera, (x-viewport->x())/viewport->width()*2.0f-1.0f, -1.0, 1.0,
-                                                            (y-viewport->y())/viewport->height()*2.0f-1.0f, -1.0, 1.0));
+        event.addPointerData(new osgGA::PointerData(camera, (x-viewport->x())/(viewport->width() - 1)*2.0f-1.0f, -1.0, 1.0,
+                                                            (y-viewport->y())/(viewport->height() - 1)*2.0f-1.0f, -1.0, 1.0));
 
         osgViewer::View* view = dynamic_cast<osgViewer::View*>(camera->getView());
         osg::Camera* view_masterCamera = view ? view->getCamera() : 0;
@@ -907,10 +907,10 @@ void CompositeViewer::reprojectPointerData(osgGA::GUIEventAdapter& source_event,
     float y = dest_event.getY();
 
     bool invert_y = dest_event.getMouseYOrientation()==osgGA::GUIEventAdapter::Y_INCREASING_DOWNWARDS;
-    if (invert_y && gw->getTraits()) y = gw->getTraits()->height - y;
+    if (invert_y && gw->getTraits()) y = gw->getTraits()->height - 1 - y;
 
-    dest_event.addPointerData(new osgGA::PointerData(gw, x, 0, gw->getTraits()->width,
-                                                         y, 0, gw->getTraits()->height));
+    dest_event.addPointerData(new osgGA::PointerData(gw, x, 0, gw->getTraits()->width - 1,
+                                                         y, 0, gw->getTraits()->height - 1));
 
     dest_event.setMouseYOrientationAndUpdateCoords(osgGA::GUIEventAdapter::Y_INCREASING_UPWARDS);
 
@@ -920,8 +920,8 @@ void CompositeViewer::reprojectPointerData(osgGA::GUIEventAdapter& source_event,
 
     if (!viewport) return;
 
-    dest_event.addPointerData(new osgGA::PointerData(camera, (x-viewport->x())/viewport->width()*2.0f-1.0f, -1.0, 1.0,
-                                                             (y-viewport->y())/viewport->height()*2.0f-1.0f, -1.0, 1.0));
+    dest_event.addPointerData(new osgGA::PointerData(camera, (x-viewport->x())/(viewport->width() - 1)*2.0f-1.0f, -1.0, 1.0,
+                                                             (y-viewport->y())/(viewport->height() - 1)*2.0f-1.0f, -1.0, 1.0));
 
     osgViewer::View* view = dynamic_cast<osgViewer::View*>(camera->getView());
     osg::Camera* view_masterCamera = view ? view->getCamera() : 0;

--- a/src/osgViewer/View.cpp
+++ b/src/osgViewer/View.cpp
@@ -857,7 +857,7 @@ void View::requestWarpPointer(float x,float y)
             getEventQueue()->mouseWarped(x,y);
             if (gw->getEventQueue()->getCurrentEventState()->getMouseYOrientation()==osgGA::GUIEventAdapter::Y_INCREASING_DOWNWARDS)
             {
-                local_y = gw->getTraits()->height - local_y;
+                local_y = gw->getTraits()->height - 1 - local_y;
             }
             const_cast<osgViewer::GraphicsWindow*>(gw)->getEventQueue()->mouseWarped(local_x,local_y);
             const_cast<osgViewer::GraphicsWindow*>(gw)->requestWarpPointer(local_x, local_y);
@@ -915,7 +915,7 @@ const osg::Camera* View::getCameraContainingPosition(float x, float y, float& lo
         new_y *= static_cast<double>(_camera->getGraphicsContext()->getTraits()->height);
 
         if (new_x >= (viewport->x()-epsilon) && new_y >= (viewport->y()-epsilon) &&
-            new_x < (viewport->x()+viewport->width()-1.0+epsilon) && new_y <= (viewport->y()+viewport->height()-1.0+epsilon) )
+            new_x < (viewport->x()+viewport->width()+epsilon) && new_y < (viewport->y()+viewport->height()+epsilon) )
         {
             local_x = new_x;
             local_y = new_y;
@@ -963,7 +963,7 @@ const osg::Camera* View::getCameraContainingPosition(float x, float y, float& lo
 
             if (viewport &&
                 new_coord.x() >= (viewport->x()-epsilon) && new_coord.y() >= (viewport->y()-epsilon) &&
-                new_coord.x() < (viewport->x()+viewport->width()-1.0+epsilon) && new_coord.y() <= (viewport->y()+viewport->height()-1.0+epsilon) )
+                new_coord.x() < (viewport->x()+viewport->width()+epsilon) && new_coord.y() < (viewport->y()+viewport->height()+epsilon) )
             {
                 // OSG_NOTICE<<"  in viewport "<<std::endl;;
 

--- a/src/osgViewer/Viewer.cpp
+++ b/src/osgViewer/Viewer.cpp
@@ -701,7 +701,7 @@ void Viewer::generateSlavePointerData(osg::Camera* camera, osgGA::GUIEventAdapte
         float y = event.getY();
 
         bool invert_y = event.getMouseYOrientation()==osgGA::GUIEventAdapter::Y_INCREASING_DOWNWARDS;
-        if (invert_y && gw->getTraits()) y = gw->getTraits()->height - y;
+        if (invert_y && gw->getTraits()) y = gw->getTraits()->height - 1 - y;
 
         double master_min_x = -1.0;
         double master_max_x = 1.0;
@@ -714,8 +714,8 @@ void Viewer::generateSlavePointerData(osg::Camera* camera, osgGA::GUIEventAdapte
             osg::Viewport* viewport = getCamera()->getViewport();
             master_min_x = viewport->x();
             master_min_y = viewport->y();
-            master_max_x = viewport->x()+viewport->width();
-            master_max_y = viewport->y()+viewport->height();
+            master_max_x = viewport->x() + viewport->width() - 1;
+            master_max_y = viewport->y() + viewport->height() - 1;
             masterCameraVPW *= viewport->computeWindowMatrix();
         }
 
@@ -788,7 +788,6 @@ void Viewer::generateSlavePointerData(osg::Camera* camera, osgGA::GUIEventAdapte
     }
 }
 
-
 void Viewer::generatePointerData(osgGA::GUIEventAdapter& event)
 {
     osgViewer::GraphicsWindow* gw = dynamic_cast<osgViewer::GraphicsWindow*>(event.getGraphicsContext());
@@ -798,10 +797,10 @@ void Viewer::generatePointerData(osgGA::GUIEventAdapter& event)
     float y = event.getY();
 
     bool invert_y = event.getMouseYOrientation()==osgGA::GUIEventAdapter::Y_INCREASING_DOWNWARDS;
-    if (invert_y && gw->getTraits()) y = gw->getTraits()->height - y;
+    if (invert_y && gw->getTraits()) y = gw->getTraits()->height - 1 - y;
 
-    event.addPointerData(new osgGA::PointerData(gw, x, 0, gw->getTraits()->width,
-                                                    y, 0, gw->getTraits()->height));
+    event.addPointerData(new osgGA::PointerData(gw, x, 0, gw->getTraits()->width - 1,
+                                                    y, 0, gw->getTraits()->height - 1));
 
     event.setMouseYOrientationAndUpdateCoords(osgGA::GUIEventAdapter::Y_INCREASING_UPWARDS);
 
@@ -822,7 +821,7 @@ void Viewer::generatePointerData(osgGA::GUIEventAdapter& event)
             osg::Viewport* viewport = camera->getViewport();
             if (viewport &&
                 x >= viewport->x() && y >= viewport->y() &&
-                x <= (viewport->x()+viewport->width()) && y <= (viewport->y()+viewport->height()) )
+                x < (viewport->x()+viewport->width()) && y < (viewport->y()+viewport->height()) )
             {
                 activeCameras.push_back(camera);
             }
@@ -837,8 +836,8 @@ void Viewer::generatePointerData(osgGA::GUIEventAdapter& event)
     {
         osg::Viewport* viewport = camera->getViewport();
 
-        event.addPointerData(new osgGA::PointerData(camera, (x-viewport->x())/viewport->width()*2.0f-1.0f, -1.0, 1.0,
-                                                            (y-viewport->y())/viewport->height()*2.0f-1.0f, -1.0, 1.0));
+        event.addPointerData(new osgGA::PointerData(camera, (x-viewport->x())/(viewport->width() - 1)*2.0f-1.0f, -1.0, 1.0,
+                                                            (y-viewport->y())/(viewport->height() - 1)*2.0f-1.0f, -1.0, 1.0));
 
         // if camera isn't the master it must be a slave and could need reprojecting.
         if (camera!=getCamera())
@@ -857,10 +856,10 @@ void Viewer::reprojectPointerData(osgGA::GUIEventAdapter& source_event, osgGA::G
     float y = dest_event.getY();
 
     bool invert_y = dest_event.getMouseYOrientation()==osgGA::GUIEventAdapter::Y_INCREASING_DOWNWARDS;
-    if (invert_y && gw->getTraits()) y = gw->getTraits()->height - y;
+    if (invert_y && gw->getTraits()) y = gw->getTraits()->height - 1 - y;
 
-    dest_event.addPointerData(new osgGA::PointerData(gw, x, 0, gw->getTraits()->width,
-                                                         y, 0, gw->getTraits()->height));
+    dest_event.addPointerData(new osgGA::PointerData(gw, x, 0, gw->getTraits()->width - 1,
+                                                         y, 0, gw->getTraits()->height - 1));
 
     dest_event.setMouseYOrientationAndUpdateCoords(osgGA::GUIEventAdapter::Y_INCREASING_UPWARDS);
 
@@ -870,8 +869,8 @@ void Viewer::reprojectPointerData(osgGA::GUIEventAdapter& source_event, osgGA::G
 
     if (!viewport) return;
 
-    dest_event.addPointerData(new osgGA::PointerData(camera, (x-viewport->x())/viewport->width()*2.0f-1.0f, -1.0, 1.0,
-                                                             (y-viewport->y())/viewport->height()*2.0f-1.0f, -1.0, 1.0));
+    dest_event.addPointerData(new osgGA::PointerData(camera, (x-viewport->x())/(viewport->width() - 1)*2.0f-1.0f, -1.0, 1.0,
+                                                             (y-viewport->y())/(viewport->height() - 1)*2.0f-1.0f, -1.0, 1.0));
 
     // if camera isn't the master it must be a slave and could need reprojecting.
     if (camera!=getCamera())

--- a/src/osgWidget/ViewerEventHandlers.cpp
+++ b/src/osgWidget/ViewerEventHandlers.cpp
@@ -24,7 +24,7 @@ bool MouseHandler::handle(
         // osgWidget assumes origin is bottom left of window so make sure mouse coordinate are increaseing y upwards and are scaled to window size.
         float x = (gea.getX()-gea.getXmin())/(gea.getXmax()-gea.getXmin())*static_cast<float>(gea.getWindowWidth());
         float y = (gea.getY()-gea.getYmin())/(gea.getYmax()-gea.getYmin())*static_cast<float>(gea.getWindowHeight());
-        if (gea.getMouseYOrientation()==osgGA::GUIEventAdapter::Y_INCREASING_DOWNWARDS) y = static_cast<float>(gea.getWindowHeight())-y;
+        if (gea.getMouseYOrientation()==osgGA::GUIEventAdapter::Y_INCREASING_DOWNWARDS) y = static_cast<float>(gea.getWindowHeight() - 1) - y;
 
         //OSG_NOTICE<<"MouseHandler(x="<<x<<", y="<<y<<")"<<std::endl;
 


### PR DESCRIPTION
1) InputRange in GUIEventAdapter is **segment** not  **half-open interval**
2) Wrong code example:
```
    bool invert_y = event.getMouseYOrientation()==osgGA::GUIEventAdapter::Y_INCREASING_DOWNWARDS;
    if (invert_y && gw->getTraits()) y = gw->getTraits()->height - y;
```
 
Let **gw->getTraits()->height = 1080** and **y = 0**
then y will be 1080, but it must be **1079**!

So `y = gw->getTraits()->height - 1 - y;` will be ok ;)

KOS
