### PR TITLE
Fix hardware mipmap generation for cube maps

### DIFF
--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -2758,7 +2758,7 @@ Texture::GenerateMipmapMode Texture::mipmapBeforeTexImage(const State& state, bo
             if (useGenerateMipMap) return GENERATE_MIPMAP;
         }
 
-        glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP_SGIS, GL_TRUE);
+        glTexParameteri(getTextureTarget(), GL_GENERATE_MIPMAP_SGIS, GL_TRUE);
         return GENERATE_MIPMAP_TEX_PARAMETER;
 #endif
     }
@@ -2781,7 +2781,7 @@ void Texture::mipmapAfterTexImage(State& state, GenerateMipmapMode beforeResult)
             break;
         }
         case GENERATE_MIPMAP_TEX_PARAMETER:
-            glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP_SGIS, GL_FALSE);
+            glTexParameteri(getTextureTarget(), GL_GENERATE_MIPMAP_SGIS, GL_FALSE);
             break;
         case GENERATE_MIPMAP_NONE:
             break;


### PR DESCRIPTION
I was getting a black image when enabling hardware mipmap generation on cubemaps. I believe the problem is that the base Texture class is hard coding GL_TEXTURE_2D when enabling mipmap generation, instead of using the target type from the derived class.