### PR TITLE
Fix for inconsistent FBX bone hierarchy

### DIFF
--- a/src/osgPlugins/fbx/fbxRMesh.cpp
+++ b/src/osgPlugins/fbx/fbxRMesh.cpp
@@ -419,8 +419,7 @@ void addBindMatrix(
     const osg::Matrix& bindMatrix,
     osgAnimation::RigGeometry* pRigGeometry)
 {
-    boneBindMatrices.insert(BindMatrixMap::value_type(
-        BindMatrixMap::key_type(pBone, pRigGeometry), bindMatrix));
+    boneBindMatrices[pBone][bindMatrix].insert(pRigGeometry);
 }
 
 void addVec2ArrayElement(osg::Array& a, const FbxVector2& v)

--- a/src/osgPlugins/fbx/fbxReader.h
+++ b/src/osgPlugins/fbx/fbxReader.h
@@ -13,7 +13,8 @@ namespace osgAnimation
     class Skeleton;
 }
 
-typedef std::map<std::pair<FbxNode*, osgAnimation::RigGeometry*>, osg::Matrix> BindMatrixMap;
+typedef std::map< osg::Matrix, std::set<osgAnimation::RigGeometry*> > BindMatrixGeometryMap;
+typedef std::map< FbxNode* , BindMatrixGeometryMap > BindMatrixMap;
 
 class OsgFbxReader
 {


### PR DESCRIPTION
Loading an fbx model multiple times or across separate runs can result in different skeleton bone hierarchies. The problem is with how the "resolveBindMatrices" function resolves new bones. The iteration order is dependent on osgAnimation::RigGeometry pointer values, which can differ across runs. I've refactored the BindMatrixMap so that it maps bones to a map of bind matrices and set of geometry. This ensures a consistent and minimum number of bones are created for each unique bind matrix.