### PR TITLE
osgViewer: fix build with GCC < 6.x

### DIFF
--- a/src/osgViewer/GraphicsWindowWin32.cpp
+++ b/src/osgViewer/GraphicsWindowWin32.cpp
@@ -799,7 +799,7 @@ Win32WindowingSystem::Win32WindowingSystem()
 	if (hModuleShore) {
 		setProcessDpiAwareness = (SetProcessDpiAwarenessFunc *) GetProcAddress(hModuleShore, "SetProcessDpiAwareness");
 		if (setProcessDpiAwareness) {
-			(*setProcessDpiAwareness)(PROCESS_DPI_AWARENESS::PROCESS_PER_MONITOR_DPI_AWARE);
+			(*setProcessDpiAwareness)(PROCESS_PER_MONITOR_DPI_AWARE);
 		}
 	}
 // #endif


### PR DESCRIPTION
These patches are from [MXE project](https://mxe.cc/).

[Tested build](https://github.com/mxe/mxe/pull/2224) of `openscenegraph`, `osgearth` and `ossim` packages for targets:
```
MXE_TARGETS := i686-w64-mingw32.static i686-w64-mingw32.shared \
               x86_64-w64-mingw32.static x86_64-w64-mingw32.shared
```
