### PR TITLE
Use options when loading images in Collada loader

### DIFF
--- a/src/osgPlugins/dae/ReaderWriterDAE.cpp
+++ b/src/osgPlugins/dae/ReaderWriterDAE.cpp
@@ -144,7 +144,7 @@ ReaderWriterDAE::readNode(const std::string& fname,
     std::string fileName( osgDB::findDataFile( fname, options ) );
     if( fileName.empty() ) return ReadResult::FILE_NOT_FOUND;
     
-    pluginOptions.options = options ? static_cast<Options*>(options->clone(osg::CopyOp::SHALLOW_COPY)) : new Options;
+    pluginOptions.options = options ? osg::clone(options, osg::CopyOp::SHALLOW_COPY) : new Options;
     pluginOptions.options->getDatabasePathList().push_front(osgDB::getFilePath(fileName));
 
     OSG_INFO << "ReaderWriterDAE( \"" << fileName << "\" )" << std::endl;

--- a/src/osgPlugins/dae/ReaderWriterDAE.cpp
+++ b/src/osgPlugins/dae/ReaderWriterDAE.cpp
@@ -143,6 +143,9 @@ ReaderWriterDAE::readNode(const std::string& fname,
 
     std::string fileName( osgDB::findDataFile( fname, options ) );
     if( fileName.empty() ) return ReadResult::FILE_NOT_FOUND;
+    
+    pluginOptions.options = options ? static_cast<Options*>(options->clone(osg::CopyOp::SHALLOW_COPY)) : new Options;
+    pluginOptions.options->getDatabasePathList().push_front(osgDB::getFilePath(fileName));
 
     OSG_INFO << "ReaderWriterDAE( \"" << fileName << "\" )" << std::endl;
 

--- a/src/osgPlugins/dae/daeRMaterials.cpp
+++ b/src/osgPlugins/dae/daeRMaterials.cpp
@@ -1136,7 +1136,7 @@ osg::Texture2D* daeReader::processTexture(
     }
     else
     {
-        osg::ref_ptr<osg::Image> img = osgDB::readRefImageFile(parameters.filename);
+        osg::ref_ptr<osg::Image> img = osgDB::readRefImageFile(parameters.filename, _pluginOptions.options.get());
 
         if (!img.valid())
         {

--- a/src/osgPlugins/dae/daeReader.h
+++ b/src/osgPlugins/dae/daeReader.h
@@ -157,6 +157,7 @@ public:
         int precisionHint;              ///< Precision hint flags, as specified in osgDB::Options::PrecisionHint
         bool usePredefinedTextureUnits;
         TessellateMode tessellateMode;
+        osg::ref_ptr<osgDB::ReaderWriter::Options> options;
     };
 
     daeReader(DAE *dae_, const Options * pluginOptions);


### PR DESCRIPTION
The Collada loader uses the global registry options when loading images, instead of the options passed into the loader. This patch modifies the loader to use the specified options to load images.