### PR TITLE
fix compilation with OSG_USE_FLOAT_PLANE

### DIFF
--- a/include/osg/GLExtensions
+++ b/include/osg/GLExtensions
@@ -841,8 +841,11 @@ class OSG_EXPORT GLExtensions : public osg::Referenced
         inline void glUniform(GLint location, const osg::Vec3d& value) const { glUniform3dv(location, 1, value.ptr()); }
         inline void glUniform(GLint location, const osg::Vec4d& value) const { glUniform4dv(location, 1, value.ptr()); }
 
+#ifdef OSG_USE_FLOAT_PLANE
+        inline void glUniform(GLint location, const osg::Plane& value) const { glUniform4fv(location, 1, value.ptr()); }
+#else
         inline void glUniform(GLint location, const osg::Plane& value) const { glUniform4dv(location, 1, value.ptr()); }
-
+#endif
         inline void glUniform(GLint location, const osg::Matrix2& value) const { glUniformMatrix2fv(location, 1, GL_FALSE, value.ptr()); }
         inline void glUniform(GLint location, const osg::Matrix2x3& value) const { glUniformMatrix2x3fv(location, 1, GL_FALSE, value.ptr()); }
         inline void glUniform(GLint location, const osg::Matrix2x4& value) const { glUniformMatrix2x4fv(location, 1, GL_FALSE, value.ptr()); }


### PR DESCRIPTION
Hi Robert,
master branch compilation fails with OSG_USE_FLOAT_PLANE defined. Not sure if there is still a valid case for doing this, I did not see a speedup on x64 at all. 

Regards, Laurens.