### PR TITLE
remove apply(Node&) overload on BoneMapVisitor

### DIFF
--- a/include/osgAnimation/BoneMapVisitor
+++ b/include/osgAnimation/BoneMapVisitor
@@ -30,7 +30,6 @@ namespace osgAnimation
         META_NodeVisitor(osgAnimation, BoneMapVisitor)
         BoneMapVisitor();
 
-        void apply(osg::Node&);
         void apply(osg::Transform& node);
         const BoneMap& getBoneMap() const;
 

--- a/src/osgAnimation/BoneMapVisitor.cpp
+++ b/src/osgAnimation/BoneMapVisitor.cpp
@@ -22,7 +22,6 @@ using namespace osgAnimation;
 
 BoneMapVisitor::BoneMapVisitor() : osg::NodeVisitor(osg::NodeVisitor::TRAVERSE_ALL_CHILDREN) {}
 
-void BoneMapVisitor::apply(osg::Node&) { return; }
 void BoneMapVisitor::apply(osg::Transform& node)
 {
     Bone* bone = dynamic_cast<Bone*>(&node);


### PR DESCRIPTION
to prevent visitor to exit before complete BoneMap has been collected