### PR TITLE
Prevent geometry to release shared GLObject when destroyed

### DIFF
--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -83,7 +83,6 @@ Geometry::Geometry(const Geometry& geometry,const CopyOp& copyop):
 Geometry::~Geometry()
 {
     _stateset = 0;
-    Geometry::releaseGLObjects();
 }
 
 #define ARRAY_NOT_EMPTY(array) (array!=0 && array->getNumElements()!=0)


### PR DESCRIPTION
fix for https://github.com/openscenegraph/OpenSceneGraph/issues/674