### PR TITLE
 Add an interface of osg::Vec3d*

### DIFF
--- a/include/osg/TriangleFunctor
+++ b/include/osg/TriangleFunctor
@@ -46,14 +46,9 @@ public:
         _vertexArraySize=0;
         _vertexArrayPtr=0;
         _vertexArrayPtr_3d = nullptr;
-        _modeCache=0;
-        _treatVertexDataAsTemporary=false;
     }
 
     virtual ~TriangleFunctor() {}
-
-    void setTreatVertexDataAsTemporary(bool treatVertexDataAsTemporary) { _treatVertexDataAsTemporary=treatVertexDataAsTemporary; }
-    bool getTreatVertexDataAsTemporary() const { return _treatVertexDataAsTemporary; }
 
     virtual void setVertexArray(unsigned int,const Vec2*)
     {
@@ -573,36 +568,6 @@ public:
         }
     }
 
-
-
-    /** Note:
-      * begin(..),vertex(..) & end() are convenience methods for adapting
-      * non vertex array primitives to vertex array based primitives.
-      * This is done to simplify the implementation of primitive functor
-      * subclasses - users only need override drawArray and drawElements.
-    */
-    virtual void begin(GLenum mode)
-    {
-        _modeCache = mode;
-        _vertexCache.clear();
-    }
-
-    virtual void vertex(const Vec2& vert) { _vertexCache.push_back(osg::Vec3(vert[0],vert[1],0.0f)); }
-    virtual void vertex(const Vec3& vert) { _vertexCache.push_back(vert); }
-    virtual void vertex(const Vec4& vert) { _vertexCache.push_back(osg::Vec3(vert[0],vert[1],vert[2])/vert[3]); }
-    virtual void vertex(float x,float y) { _vertexCache.push_back(osg::Vec3(x,y,0.0f)); }
-    virtual void vertex(float x,float y,float z) { _vertexCache.push_back(osg::Vec3(x,y,z)); }
-    virtual void vertex(float x,float y,float z,float w) { _vertexCache.push_back(osg::Vec3(x,y,z)/w); }
-    virtual void end()
-    {
-        if (!_vertexCache.empty())
-        {
-            setVertexArray(_vertexCache.size(),&_vertexCache.front());
-            _treatVertexDataAsTemporary = true;
-            drawArrays(_modeCache,0,_vertexCache.size());
-        }
-    }
-
 protected:
 
 
@@ -610,8 +575,6 @@ protected:
     const Vec3*         _vertexArrayPtr;
 
     const Vec3d*       _vertexArrayPtr_3d;
-
-    GLenum              _modeCache;
 };
 
 

--- a/include/osg/TriangleFunctor
+++ b/include/osg/TriangleFunctor
@@ -106,14 +106,14 @@ public:
                 {
                     const Vec3* vlast = &_vertexArrayPtr[first+count];
                     for(const Vec3* vptr=&_vertexArrayPtr[first];vptr<vlast;vptr+=3)
-                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2));
                 }
 
                 if(isVec3d)
                 {
                     const Vec3d* vlast = &_vertexArrayPtr_3d[first+count];
                     for(const Vec3d* vptr=&_vertexArrayPtr_3d[first];vptr<vlast;vptr+=3)
-                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2));
                 }
 
                 break;
@@ -125,8 +125,8 @@ public:
                     const Vec3* vptr = &_vertexArrayPtr[first];
                     for(GLsizei i=2;i<count;++i,++vptr)
                     {
-                        if ((i%2)) this->operator()(*(vptr),*(vptr+2),*(vptr+1),_treatVertexDataAsTemporary);
-                        else       this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                        if ((i%2)) this->operator()(*(vptr),*(vptr+2),*(vptr+1));
+                        else       this->operator()(*(vptr),*(vptr+1),*(vptr+2));
                     }
                 }
 
@@ -135,8 +135,8 @@ public:
                     const Vec3d* vptr = &_vertexArrayPtr_3d[first];
                     for(GLsizei i=2;i<count;++i,++vptr)
                     {
-                        if ((i%2)) this->operator()(*(vptr),*(vptr+2),*(vptr+1),_treatVertexDataAsTemporary);
-                        else       this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                        if ((i%2)) this->operator()(*(vptr),*(vptr+2),*(vptr+1));
+                        else       this->operator()(*(vptr),*(vptr+1),*(vptr+2));
                     }
                 }
 
@@ -149,8 +149,8 @@ public:
                     const Vec3* vptr = &_vertexArrayPtr[first];
                     for(GLsizei i=3;i<count;i+=4,vptr+=4)
                     {
-                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
-                        this->operator()(*(vptr),*(vptr+2),*(vptr+3),_treatVertexDataAsTemporary);
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2));
+                        this->operator()(*(vptr),*(vptr+2),*(vptr+3));
                     }
                 }
 
@@ -159,8 +159,8 @@ public:
                     const Vec3d* vptr = &_vertexArrayPtr_3d[first];
                     for(GLsizei i=3;i<count;i+=4,vptr+=4)
                     {
-                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
-                        this->operator()(*(vptr),*(vptr+2),*(vptr+3),_treatVertexDataAsTemporary);
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2));
+                        this->operator()(*(vptr),*(vptr+2),*(vptr+3));
                     }
                 }
 
@@ -173,8 +173,8 @@ public:
                     const Vec3* vptr = &_vertexArrayPtr[first];
                     for(GLsizei i=3;i<count;i+=2,vptr+=2)
                     {
-                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
-                        this->operator()(*(vptr+1),*(vptr+3),*(vptr+2),_treatVertexDataAsTemporary);
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2));
+                        this->operator()(*(vptr+1),*(vptr+3),*(vptr+2));
                     }
                 }
 
@@ -183,8 +183,8 @@ public:
                     const Vec3d* vptr = &_vertexArrayPtr_3d[first];
                     for(GLsizei i=3;i<count;i+=2,vptr+=2)
                     {
-                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
-                        this->operator()(*(vptr+1),*(vptr+3),*(vptr+2),_treatVertexDataAsTemporary);
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2));
+                        this->operator()(*(vptr+1),*(vptr+3),*(vptr+2));
                     }
                 }
 
@@ -199,7 +199,7 @@ public:
                     const Vec3* vptr = vfirst+1;
                     for(GLsizei i=2;i<count;++i,++vptr)
                     {
-                        this->operator()(*(vfirst),*(vptr),*(vptr+1),_treatVertexDataAsTemporary);
+                        this->operator()(*(vfirst),*(vptr),*(vptr+1));
                     }
                 }
 
@@ -209,7 +209,7 @@ public:
                     const Vec3d* vptr = vfirst+1;
                     for(GLsizei i=2;i<count;++i,++vptr)
                     {
-                        this->operator()(*(vfirst),*(vptr),*(vptr+1),_treatVertexDataAsTemporary);
+                        this->operator()(*(vfirst),*(vptr),*(vptr+1));
                     }
                 }
 
@@ -247,10 +247,10 @@ public:
                 for(IndexPointer  iptr=indices;iptr<ilast;iptr+=3)
                 {
                     if(isVec3f)
-                        this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
 
                     if(isVec3d)
-                        this->operator()(_vertexArrayPtr_3d[*iptr],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*iptr],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
                 }
                 break;
             }
@@ -260,12 +260,12 @@ public:
                 for(GLsizei i=2;i<count;++i,++iptr)
                 {
                     if(isVec3f)
-                        if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
-                        else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)]);
+                        else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
                     
                     if(isVec3d)
-                        if ((i%2)) this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
-                        else       this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        if ((i%2)) this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+1)]);
+                        else       this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
                 }
                 break;
             }
@@ -276,14 +276,14 @@ public:
                 {
                     if(isVec3f)
                     {
-                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)]);
                     }
 
                     if(isVec3d)
                     {
-                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+3)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+3)]);
                     }      
                 }
                 break;
@@ -295,14 +295,14 @@ public:
                 {
                     if(isVec3f)
                     {
-                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)]);
                     }
 
                     if(isVec3f)
                     {
-                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+3)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+3)],_vertexArrayPtr_3d[*(iptr+2)]);
                     }                   
                 }
                 break;
@@ -316,7 +316,7 @@ public:
 					const Vec3& vfirst = _vertexArrayPtr[*iptr];
 					++iptr;
 					for(GLsizei i=2;i<count;++i,++iptr)
-						this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
+						this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)]);
 				}
 
                 if(isVec3d)
@@ -324,7 +324,7 @@ public:
 					const Vec3d& vfirst = _vertexArrayPtr_3d[*iptr];
 					++iptr;
 					for(GLsizei i=2;i<count;++i,++iptr)
-					this->operator()(vfirst,_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
+					this->operator()(vfirst,_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)]);
 				}
 
                 break;
@@ -361,10 +361,10 @@ public:
                 for(IndexPointer  iptr=indices;iptr<ilast;iptr+=3)
                 {
                     if(isVec3f)
-                        this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
 
                     if(isVec3d)
-                        this->operator()(_vertexArrayPtr_3d[*iptr],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*iptr],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
                 }
                 break;
             }
@@ -374,12 +374,12 @@ public:
                 for(GLsizei i=2;i<count;++i,++iptr)
                 {
                     if(isVec3f)
-                        if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
-                        else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)]);
+                        else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
                     
                     if(isVec3d)
-                        if ((i%2)) this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
-                        else       this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        if ((i%2)) this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+1)]);
+                        else       this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
                 }
                 break;
             }
@@ -390,14 +390,14 @@ public:
                 {
                     if(isVec3f)
                     {
-                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)]);
                     }
 
                     if(isVec3d)
                     {
-                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+3)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+3)]);
                     }    
                 }
                 break;
@@ -409,14 +409,14 @@ public:
                 {
                     if(isVec3f)
                     {
-                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)]);
                     }
 
                     if(isVec3d)
                     {
-                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+3)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+3)],_vertexArrayPtr_3d[*(iptr+2)]);
                     }                   
                 }
                 break;
@@ -430,7 +430,7 @@ public:
 					const Vec3& vfirst = _vertexArrayPtr[*iptr];
 					++iptr;
 					for(GLsizei i=2;i<count;++i,++iptr)
-						this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
+						this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)]);
 				}
 
                 if(isVec3d)
@@ -438,7 +438,7 @@ public:
 					const Vec3d& vfirst = _vertexArrayPtr_3d[*iptr];
 					++iptr;
 					for(GLsizei i=2;i<count;++i,++iptr)
-					this->operator()(vfirst,_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
+					this->operator()(vfirst,_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)]);
 				}
 
                 break;
@@ -475,10 +475,10 @@ public:
                 for(IndexPointer  iptr=indices;iptr<ilast;iptr+=3)
                 {
                     if(isVec3f)
-                        this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
 
                     if(isVec3d)
-                        this->operator()(_vertexArrayPtr_3d[*iptr],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*iptr],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
                 }
                 break;
             }
@@ -488,12 +488,12 @@ public:
                 for(GLsizei i=2;i<count;++i,++iptr)
                 {
                     if(isVec3f)
-                        if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
-                        else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)]);
+                        else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
                     
                     if(isVec3d)
-                        if ((i%2)) this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
-                        else       this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        if ((i%2)) this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+1)]);
+                        else       this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
                 }
                 break;
             }
@@ -504,14 +504,14 @@ public:
                 {
                     if(isVec3f)
                     {
-                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)]);
                     }
 
                     if(isVec3d)
                     {
-                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+3)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+3)]);
                     }    
                 }
                 break;
@@ -523,14 +523,14 @@ public:
                 {
                     if(isVec3f)
                     {
-                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)]);
                     }
 
                     if(isVec3d)
                     {
-                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
-                        this->operator()(_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+3)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)]);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+3)],_vertexArrayPtr_3d[*(iptr+2)]);
                     }                   
                 }
                 break;
@@ -545,7 +545,7 @@ public:
 					const Vec3& vfirst = _vertexArrayPtr[*iptr];
 					++iptr;
 					for(GLsizei i=2;i<count;++i,++iptr)
-						this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
+						this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)]);
 				}
                     
                 if(isVec3d)
@@ -553,7 +553,7 @@ public:
 					const Vec3d& vfirst = _vertexArrayPtr_3d[*iptr];
 					++iptr;
 					for(GLsizei i=2;i<count;++i,++iptr)
-						this->operator()(vfirst,_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
+						this->operator()(vfirst,_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)]);
 				}
                    
                 break;

--- a/include/osg/TriangleFunctor
+++ b/include/osg/TriangleFunctor
@@ -26,7 +26,9 @@ namespace osg {
  *  <p>Notice that \c TriangleFunctor is a class template, and that it inherits
  *  from its template parameter \c T. This template parameter must implement
  *  <tt>T::operator() (const osg::Vec3 v1, const osg::Vec3 v2, const osg::Vec3
- *  v3, bool treatVertexDataAsTemporary)</tt>, which will be called for every
+ *  v3, bool treatVertexDataAsTemporary)</tt>, or <tt>T::operator() (const 
+ *  osg::Vec3d v1, const osg::Vec3d v2, const osg::Vec3d v3, bool 
+ *  treatVertexDataAsTemporary)</tt>, which will be called for every
  *  triangle when the functor is applied to a \c Drawable. Parameters \c v1, \c
  *  v2, and \c v3 are the triangle vertices. The fourth parameter, \c
  *  treatVertexDataAsTemporary, indicates whether these vertices are coming from
@@ -43,9 +45,15 @@ public:
     {
         _vertexArraySize=0;
         _vertexArrayPtr=0;
+        _vertexArrayPtr_3d = nullptr;
+        _modeCache=0;
+        _treatVertexDataAsTemporary=false;
     }
 
     virtual ~TriangleFunctor() {}
+
+    void setTreatVertexDataAsTemporary(bool treatVertexDataAsTemporary) { _treatVertexDataAsTemporary=treatVertexDataAsTemporary; }
+    bool getTreatVertexDataAsTemporary() const { return _treatVertexDataAsTemporary; }
 
     virtual void setVertexArray(unsigned int,const Vec2*)
     {
@@ -56,6 +64,7 @@ public:
     {
         _vertexArraySize = count;
         _vertexArrayPtr = vertices;
+        _vertexArrayPtr_3d = 0;
     }
 
     virtual void setVertexArray(unsigned int,const Vec4* )
@@ -68,9 +77,13 @@ public:
         notify(WARN)<<"Triangle Functor does not support Vec2d* vertex arrays"<<std::endl;
     }
 
-    virtual void setVertexArray(unsigned int,const Vec3d*)
+    virtual void setVertexArray(unsigned int count,const Vec3d* vertices)
     {
-        notify(WARN)<<"Triangle Functor does not support Vec3d* vertex arrays"<<std::endl;
+        //notify(WARN)<<"Triangle Functor does not support Vec3d* vertex arrays"<<std::endl;
+        
+        _vertexArraySize = count;
+        _vertexArrayPtr_3d = vertices;
+        _vertexArrayPtr = 0;
     }
 
     virtual void setVertexArray(unsigned int,const Vec4d* )
@@ -80,56 +93,131 @@ public:
 
     virtual void drawArrays(GLenum mode,GLint first,GLsizei count)
     {
-        if (_vertexArrayPtr==0 || count==0) return;
+        if (_vertexArrayPtr==0 && _vertexArrayPtr_3d == 0 || count==0
+            || _vertexArrayPtr_3d != 0 && _vertexArrayPtr != 0) return;
+
+        bool isVec3d = false;
+        bool isVec3f = false;
+        if(_vertexArrayPtr)
+            isVec3f = true;
+        if(_vertexArrayPtr_3d)
+            isVec3d = true;
 
         switch(mode)
         {
             case(GL_TRIANGLES):
             {
-                const Vec3* vlast = &_vertexArrayPtr[first+count];
-                for(const Vec3* vptr=&_vertexArrayPtr[first];vptr<vlast;vptr+=3)
-                    this->operator()(*(vptr),*(vptr+1),*(vptr+2));
+                if(isVec3f)
+                {
+                    const Vec3* vlast = &_vertexArrayPtr[first+count];
+                    for(const Vec3* vptr=&_vertexArrayPtr[first];vptr<vlast;vptr+=3)
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                }
+
+                if(isVec3d)
+                {
+                    const Vec3d* vlast = &_vertexArrayPtr_3d[first+count];
+                    for(const Vec3d* vptr=&_vertexArrayPtr_3d[first];vptr<vlast;vptr+=3)
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                }
+
                 break;
             }
             case(GL_TRIANGLE_STRIP):
             {
-                const Vec3* vptr = &_vertexArrayPtr[first];
-                for(GLsizei i=2;i<count;++i,++vptr)
+                if(isVec3f)
                 {
-                    if ((i%2)) this->operator()(*(vptr),*(vptr+2),*(vptr+1));
-                    else       this->operator()(*(vptr),*(vptr+1),*(vptr+2));
+                    const Vec3* vptr = &_vertexArrayPtr[first];
+                    for(GLsizei i=2;i<count;++i,++vptr)
+                    {
+                        if ((i%2)) this->operator()(*(vptr),*(vptr+2),*(vptr+1),_treatVertexDataAsTemporary);
+                        else       this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                    }
                 }
+
+                if(isVec3d)
+                {
+                    const Vec3d* vptr = &_vertexArrayPtr_3d[first];
+                    for(GLsizei i=2;i<count;++i,++vptr)
+                    {
+                        if ((i%2)) this->operator()(*(vptr),*(vptr+2),*(vptr+1),_treatVertexDataAsTemporary);
+                        else       this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                    }
+                }
+
                 break;
             }
             case(GL_QUADS):
             {
-                const Vec3* vptr = &_vertexArrayPtr[first];
-                for(GLsizei i=3;i<count;i+=4,vptr+=4)
+                if(isVec3f)
                 {
-                    this->operator()(*(vptr),*(vptr+1),*(vptr+2));
-                    this->operator()(*(vptr),*(vptr+2),*(vptr+3));
+                    const Vec3* vptr = &_vertexArrayPtr[first];
+                    for(GLsizei i=3;i<count;i+=4,vptr+=4)
+                    {
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                        this->operator()(*(vptr),*(vptr+2),*(vptr+3),_treatVertexDataAsTemporary);
+                    }
                 }
+
+                if(isVec3d)
+                {
+                    const Vec3d* vptr = &_vertexArrayPtr_3d[first];
+                    for(GLsizei i=3;i<count;i+=4,vptr+=4)
+                    {
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                        this->operator()(*(vptr),*(vptr+2),*(vptr+3),_treatVertexDataAsTemporary);
+                    }
+                }
+
                 break;
             }
             case(GL_QUAD_STRIP):
             {
-                const Vec3* vptr = &_vertexArrayPtr[first];
-                for(GLsizei i=3;i<count;i+=2,vptr+=2)
+                if(isVec3f)
                 {
-                    this->operator()(*(vptr),*(vptr+1),*(vptr+2));
-                    this->operator()(*(vptr+1),*(vptr+3),*(vptr+2));
+                    const Vec3* vptr = &_vertexArrayPtr[first];
+                    for(GLsizei i=3;i<count;i+=2,vptr+=2)
+                    {
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                        this->operator()(*(vptr+1),*(vptr+3),*(vptr+2),_treatVertexDataAsTemporary);
+                    }
                 }
+
+                if(isVec3d)
+                {
+                    const Vec3d* vptr = &_vertexArrayPtr_3d[first];
+                    for(GLsizei i=3;i<count;i+=2,vptr+=2)
+                    {
+                        this->operator()(*(vptr),*(vptr+1),*(vptr+2),_treatVertexDataAsTemporary);
+                        this->operator()(*(vptr+1),*(vptr+3),*(vptr+2),_treatVertexDataAsTemporary);
+                    }
+                }
+
                 break;
             }
             case(GL_POLYGON): // treat polygons as GL_TRIANGLE_FAN
             case(GL_TRIANGLE_FAN):
             {
-                const Vec3* vfirst = &_vertexArrayPtr[first];
-                const Vec3* vptr = vfirst+1;
-                for(GLsizei i=2;i<count;++i,++vptr)
+                if (isVec3f)
                 {
-                    this->operator()(*(vfirst),*(vptr),*(vptr+1));
+                    const Vec3* vfirst = &_vertexArrayPtr[first];
+                    const Vec3* vptr = vfirst+1;
+                    for(GLsizei i=2;i<count;++i,++vptr)
+                    {
+                        this->operator()(*(vfirst),*(vptr),*(vptr+1),_treatVertexDataAsTemporary);
+                    }
                 }
+
+                if (isVec3d)
+                {
+                    const Vec3d* vfirst = &_vertexArrayPtr_3d[first];
+                    const Vec3d* vptr = vfirst+1;
+                    for(GLsizei i=2;i<count;++i,++vptr)
+                    {
+                        this->operator()(*(vfirst),*(vptr),*(vptr+1),_treatVertexDataAsTemporary);
+                    }
+                }
+
                 break;
             }
             case(GL_POINTS):
@@ -144,9 +232,17 @@ public:
 
     virtual void drawElements(GLenum mode,GLsizei count,const GLubyte* indices)
     {
-        if (indices==0 || count==0) return;
+        if (indices==0 || count==0 
+            || _vertexArrayPtr != 0 && _vertexArrayPtr_3d != 0) return;
 
         typedef const GLubyte* IndexPointer;
+
+        bool isVec3f = false;
+        bool isVec3d = false;
+        if (_vertexArrayPtr)
+            isVec3f = true;
+        if (_vertexArrayPtr_3d)
+            isVec3d = true;
 
         switch(mode)
         {
@@ -154,7 +250,13 @@ public:
             {
                 IndexPointer ilast = &indices[count];
                 for(IndexPointer  iptr=indices;iptr<ilast;iptr+=3)
-                    this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                {
+                    if(isVec3f)
+                        this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+
+                    if(isVec3d)
+                        this->operator()(_vertexArrayPtr_3d[*iptr],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                }
                 break;
             }
             case(GL_TRIANGLE_STRIP):
@@ -162,8 +264,13 @@ public:
                 IndexPointer iptr = indices;
                 for(GLsizei i=2;i<count;++i,++iptr)
                 {
-                    if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)]);
-                    else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                    if(isVec3f)
+                        if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
+                        else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                    
+                    if(isVec3d)
+                        if ((i%2)) this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
+                        else       this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
                 }
                 break;
             }
@@ -172,8 +279,17 @@ public:
                 IndexPointer iptr = indices;
                 for(GLsizei i=3;i<count;i+=4,iptr+=4)
                 {
-                    this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
-                    this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)]);
+                    if(isVec3f)
+                    {
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)],_treatVertexDataAsTemporary);
+                    }
+
+                    if(isVec3d)
+                    {
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+3)],_treatVertexDataAsTemporary);
+                    }      
                 }
                 break;
             }
@@ -182,21 +298,40 @@ public:
                 IndexPointer iptr = indices;
                 for(GLsizei i=3;i<count;i+=2,iptr+=2)
                 {
-                    this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
-                    this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)]);
+                    if(isVec3f)
+                    {
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                    }
+
+                    if(isVec3f)
+                    {
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+3)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                    }                   
                 }
                 break;
             }
             case(GL_POLYGON): // treat polygons as GL_TRIANGLE_FAN
             case(GL_TRIANGLE_FAN):
             {
-                IndexPointer iptr = indices;
-                const Vec3& vfirst = _vertexArrayPtr[*iptr];
-                ++iptr;
-                for(GLsizei i=2;i<count;++i,++iptr)
-                {
-                    this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)]);
-                }
+				IndexPointer iptr = indices;
+                if(isVec3f)
+				{
+					const Vec3& vfirst = _vertexArrayPtr[*iptr];
+					++iptr;
+					for(GLsizei i=2;i<count;++i,++iptr)
+						this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
+				}
+
+                if(isVec3d)
+				{
+					const Vec3d& vfirst = _vertexArrayPtr_3d[*iptr];
+					++iptr;
+					for(GLsizei i=2;i<count;++i,++iptr)
+					this->operator()(vfirst,_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
+				}
+
                 break;
             }
             case(GL_POINTS):
@@ -211,9 +346,17 @@ public:
 
     virtual void drawElements(GLenum mode,GLsizei count,const GLushort* indices)
     {
-        if (indices==0 || count==0) return;
+        if (indices==0 || count==0 
+            || _vertexArrayPtr_3d != 0 && _vertexArrayPtr != 0) return;
 
         typedef const GLushort* IndexPointer;
+
+        bool isVec3f = false;
+        bool isVec3d = false;
+        if (_vertexArrayPtr)
+            isVec3f = true;
+        if (_vertexArrayPtr_3d)
+            isVec3d = true;
 
         switch(mode)
         {
@@ -222,7 +365,11 @@ public:
                 IndexPointer ilast = &indices[count];
                 for(IndexPointer  iptr=indices;iptr<ilast;iptr+=3)
                 {
-                    this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                    if(isVec3f)
+                        this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+
+                    if(isVec3d)
+                        this->operator()(_vertexArrayPtr_3d[*iptr],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
                 }
                 break;
             }
@@ -231,8 +378,13 @@ public:
                 IndexPointer iptr = indices;
                 for(GLsizei i=2;i<count;++i,++iptr)
                 {
-                    if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)]);
-                    else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                    if(isVec3f)
+                        if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
+                        else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                    
+                    if(isVec3d)
+                        if ((i%2)) this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
+                        else       this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
                 }
                 break;
             }
@@ -241,8 +393,17 @@ public:
                 IndexPointer iptr = indices;
                 for(GLsizei i=3;i<count;i+=4,iptr+=4)
                 {
-                    this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
-                    this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)]);
+                    if(isVec3f)
+                    {
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)],_treatVertexDataAsTemporary);
+                    }
+
+                    if(isVec3d)
+                    {
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+3)],_treatVertexDataAsTemporary);
+                    }    
                 }
                 break;
             }
@@ -251,8 +412,17 @@ public:
                 IndexPointer iptr = indices;
                 for(GLsizei i=3;i<count;i+=2,iptr+=2)
                 {
-                    this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
-                    this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)]);
+                    if(isVec3f)
+                    {
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                    }
+
+                    if(isVec3d)
+                    {
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+3)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                    }                   
                 }
                 break;
             }
@@ -260,12 +430,22 @@ public:
             case(GL_TRIANGLE_FAN):
             {
                 IndexPointer iptr = indices;
-                const Vec3& vfirst = _vertexArrayPtr[*iptr];
-                ++iptr;
-                for(GLsizei i=2;i<count;++i,++iptr)
-                {
-                    this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)]);
-                }
+                if(isVec3f)
+				{
+					const Vec3& vfirst = _vertexArrayPtr[*iptr];
+					++iptr;
+					for(GLsizei i=2;i<count;++i,++iptr)
+						this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
+				}
+
+                if(isVec3d)
+				{
+					const Vec3d& vfirst = _vertexArrayPtr_3d[*iptr];
+					++iptr;
+					for(GLsizei i=2;i<count;++i,++iptr)
+					this->operator()(vfirst,_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
+				}
+
                 break;
             }
             case(GL_POINTS):
@@ -280,9 +460,17 @@ public:
 
     virtual void drawElements(GLenum mode,GLsizei count,const GLuint* indices)
     {
-        if (indices==0 || count==0) return;
+        if (indices==0 || count==0 
+            || _vertexArrayPtr_3d != 0 && _vertexArrayPtr != 0) return;
 
         typedef const GLuint* IndexPointer;
+
+        bool isVec3f = false;
+        bool isVec3d = false;
+        if (_vertexArrayPtr)
+            isVec3f = true;
+        if (_vertexArrayPtr_3d)
+            isVec3d = true;
 
         switch(mode)
         {
@@ -290,7 +478,13 @@ public:
             {
                 IndexPointer ilast = &indices[count];
                 for(IndexPointer  iptr=indices;iptr<ilast;iptr+=3)
-                    this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                {
+                    if(isVec3f)
+                        this->operator()(_vertexArrayPtr[*iptr],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+
+                    if(isVec3d)
+                        this->operator()(_vertexArrayPtr_3d[*iptr],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                }
                 break;
             }
             case(GL_TRIANGLE_STRIP):
@@ -298,8 +492,13 @@ public:
                 IndexPointer iptr = indices;
                 for(GLsizei i=2;i<count;++i,++iptr)
                 {
-                    if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)]);
-                    else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
+                    if(isVec3f)
+                        if ((i%2)) this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
+                        else       this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                    
+                    if(isVec3d)
+                        if ((i%2)) this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
+                        else       this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
                 }
                 break;
             }
@@ -308,8 +507,17 @@ public:
                 IndexPointer iptr = indices;
                 for(GLsizei i=3;i<count;i+=4,iptr+=4)
                 {
-                    this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
-                    this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)]);
+                    if(isVec3f)
+                    {
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+2)],_vertexArrayPtr[*(iptr+3)],_treatVertexDataAsTemporary);
+                    }
+
+                    if(isVec3d)
+                    {
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+2)],_vertexArrayPtr_3d[*(iptr+3)],_treatVertexDataAsTemporary);
+                    }    
                 }
                 break;
             }
@@ -318,8 +526,17 @@ public:
                 IndexPointer iptr = indices;
                 for(GLsizei i=3;i<count;i+=2,iptr+=2)
                 {
-                    this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)]);
-                    this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)]);
+                    if(isVec3f)
+                    {
+                        this->operator()(_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr[*(iptr+1)],_vertexArrayPtr[*(iptr+3)],_vertexArrayPtr[*(iptr+2)],_treatVertexDataAsTemporary);
+                    }
+
+                    if(isVec3d)
+                    {
+                        this->operator()(_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                        this->operator()(_vertexArrayPtr_3d[*(iptr+1)],_vertexArrayPtr_3d[*(iptr+3)],_vertexArrayPtr_3d[*(iptr+2)],_treatVertexDataAsTemporary);
+                    }                   
                 }
                 break;
             }
@@ -327,12 +544,23 @@ public:
             case(GL_TRIANGLE_FAN):
             {
                 IndexPointer iptr = indices;
-                const Vec3& vfirst = _vertexArrayPtr[*iptr];
-                ++iptr;
-                for(GLsizei i=2;i<count;++i,++iptr)
-                {
-                    this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)]);
-                }
+
+                if(isVec3f)
+				{
+					const Vec3& vfirst = _vertexArrayPtr[*iptr];
+					++iptr;
+					for(GLsizei i=2;i<count;++i,++iptr)
+						this->operator()(vfirst,_vertexArrayPtr[*(iptr)],_vertexArrayPtr[*(iptr+1)],_treatVertexDataAsTemporary);
+				}
+                    
+                if(isVec3d)
+				{
+					const Vec3d& vfirst = _vertexArrayPtr_3d[*iptr];
+					++iptr;
+					for(GLsizei i=2;i<count;++i,++iptr)
+						this->operator()(vfirst,_vertexArrayPtr_3d[*(iptr)],_vertexArrayPtr_3d[*(iptr+1)],_treatVertexDataAsTemporary);
+				}
+                   
                 break;
             }
             case(GL_POINTS):
@@ -345,12 +573,47 @@ public:
         }
     }
 
+
+
+    /** Note:
+      * begin(..),vertex(..) & end() are convenience methods for adapting
+      * non vertex array primitives to vertex array based primitives.
+      * This is done to simplify the implementation of primitive functor
+      * subclasses - users only need override drawArray and drawElements.
+    */
+    virtual void begin(GLenum mode)
+    {
+        _modeCache = mode;
+        _vertexCache.clear();
+    }
+
+    virtual void vertex(const Vec2& vert) { _vertexCache.push_back(osg::Vec3(vert[0],vert[1],0.0f)); }
+    virtual void vertex(const Vec3& vert) { _vertexCache.push_back(vert); }
+    virtual void vertex(const Vec4& vert) { _vertexCache.push_back(osg::Vec3(vert[0],vert[1],vert[2])/vert[3]); }
+    virtual void vertex(float x,float y) { _vertexCache.push_back(osg::Vec3(x,y,0.0f)); }
+    virtual void vertex(float x,float y,float z) { _vertexCache.push_back(osg::Vec3(x,y,z)); }
+    virtual void vertex(float x,float y,float z,float w) { _vertexCache.push_back(osg::Vec3(x,y,z)/w); }
+    virtual void end()
+    {
+        if (!_vertexCache.empty())
+        {
+            setVertexArray(_vertexCache.size(),&_vertexCache.front());
+            _treatVertexDataAsTemporary = true;
+            drawArrays(_modeCache,0,_vertexCache.size());
+        }
+    }
+
 protected:
 
 
     unsigned int        _vertexArraySize;
     const Vec3*         _vertexArrayPtr;
+
+    const Vec3d*       _vertexArrayPtr_3d;
+
+    GLenum              _modeCache;
 };
+
 
 }
 

--- a/include/osg/TriangleFunctor
+++ b/include/osg/TriangleFunctor
@@ -45,7 +45,7 @@ public:
     {
         _vertexArraySize=0;
         _vertexArrayPtr=0;
-        _vertexArrayPtr_3d = nullptr;
+        _vertexArrayPtr_3d = 0;
     }
 
     virtual ~TriangleFunctor() {}

--- a/src/osgPlugins/stl/ReaderWriterSTL.cpp
+++ b/src/osgPlugins/stl/ReaderWriterSTL.cpp
@@ -373,7 +373,7 @@ private:
 
             //add vec3d data output, Solve the problem of 
             //program crash caused by STL of output osg::Vev3d type,by Dyuzz Yu
-            inline void operator () (const osg::Vec3d& _v1, const osg::Vec3d& _v2, const osg::Vec3d& _v3, bool treatVertexDataAsTemporary)
+            inline void operator () (const osg::Vec3d& _v1, const osg::Vec3d& _v2, const osg::Vec3d& _v3)
             {
                 osg::Vec3d v1 = _v1 * m_mat;
                 osg::Vec3d v2 = _v2 * m_mat;

--- a/src/osgPlugins/stl/ReaderWriterSTL.cpp
+++ b/src/osgPlugins/stl/ReaderWriterSTL.cpp
@@ -372,7 +372,7 @@ private:
             }
 
             //add vec3d data output, Solve the problem of 
-            //program crash caused by STL of output osg::Vev3d type,by Dyuzz Yu
+            //program crash caused by STL of output osg::Vev3d type
             inline void operator () (const osg::Vec3d& _v1, const osg::Vec3d& _v2, const osg::Vec3d& _v3)
             {
                 osg::Vec3d v1 = _v1 * m_mat;

--- a/src/osgPlugins/stl/ReaderWriterSTL.cpp
+++ b/src/osgPlugins/stl/ReaderWriterSTL.cpp
@@ -370,6 +370,29 @@ private:
                 *m_stream << "endloop" << std::endl;
                 *m_stream << "endfacet" << std::endl;
             }
+
+            //add vec3d data output, Solve the problem of 
+            //program crash caused by STL of output osg::Vev3d type,by Dyuzz Yu
+            inline void operator () (const osg::Vec3d& _v1, const osg::Vec3d& _v2, const osg::Vec3d& _v3, bool treatVertexDataAsTemporary)
+            {
+                osg::Vec3d v1 = _v1 * m_mat;
+                osg::Vec3d v2 = _v2 * m_mat;
+                osg::Vec3d v3 = _v3 * m_mat;
+                osg::Vec3d vV1V2 = v2 - v1;
+                osg::Vec3d vV1V3 = v3 - v1;
+                osg::Vec3d vNormal = vV1V2.operator ^(vV1V3);
+                if (m_dontSaveNormals)
+                    *m_stream << "facet normal 0 0 0" << std::endl;
+                else
+                    *m_stream << "facet normal " << vNormal[0] << " " << vNormal[1] << " " << vNormal[2] << std::endl;
+                *m_stream << "outer loop" << std::endl;
+                m_stream->precision(10);
+                *m_stream << "vertex " << v1[0] << " " << v1[1] << " " << v1[2] << std::endl;
+                *m_stream << "vertex " << v2[0] << " " << v2[1] << " " << v2[2] << std::endl;
+                *m_stream << "vertex " << v3[0] << " " << v3[1] << " " << v3[2] << std::endl;
+                *m_stream << "endloop" << std::endl;
+                *m_stream << "endfacet" << std::endl;
+            }
         };
     };
 };


### PR DESCRIPTION
In some cases, vertex coordinates will exceed 6-digit valid digits, such as UTM coordinate system, need to use double type,so I add osg:: vec3d* interface, and use requiring overload operator() (vec3d x, vec3d y, vec3d z, bool raw). 
And it solves a bug: when STL is generated, the system crashes if vec3d type data is output