### PR TITLE
Repair VAS design in 3.6 [please review]

### DIFF
--- a/include/osg/DispatchCompute
+++ b/include/osg/DispatchCompute
@@ -39,7 +39,7 @@ class OSG_EXPORT DispatchCompute : public osg::Drawable
 
         virtual void compileGLObjects(RenderInfo&) const {}
 
-        virtual VertexArrayState* createVertexArrayStateImplememtation(RenderInfo&) const { return 0; }
+        virtual VertexArrayState* createVertexArrayStateImplememtation(State*) const { return 0; }
 
         virtual void drawImplementation(RenderInfo& renderInfo) const;
 

--- a/include/osg/Drawable
+++ b/include/osg/Drawable
@@ -283,43 +283,51 @@ class OSG_EXPORT Drawable : public Node
         virtual void compileGLObjects(RenderInfo& renderInfo) const;
 
 
-        /** Callback class for overriding the default Drawable::createCreateVertexArrayStateImplementation().*/
-        struct CreateVertexArrayStateCallback : public virtual osg::Object
+        /** Callback class for overriding the default Drawable::Create/DestroyVertexArrayStateImplementation().*/
+        struct VertexArrayStateCallback : public virtual osg::Object
         {
-            CreateVertexArrayStateCallback() {}
+            VertexArrayStateCallback() {}
 
-            CreateVertexArrayStateCallback(const CreateVertexArrayStateCallback& rhs,const CopyOp& copyop):
+            VertexArrayStateCallback(const VertexArrayStateCallback& rhs,const CopyOp& copyop):
                 Object(rhs, copyop) {}
 
-            META_Object(osg, CreateVertexArrayStateCallback);
+            META_Object(osg, VertexArrayStateCallback);
 
-            /** do customized createVertexArrayState .*/
-            virtual osg::VertexArrayState* createVertexArrayStateImplementation(osg::RenderInfo& renderInfo, const osg::Drawable* drawable) const
-            {
-                return drawable->createVertexArrayStateImplementation(renderInfo);
-            }
+            /** do customize VertexArrayState lifecycle.*/
+            virtual osg::VertexArrayState* operator () (osg::State*, const osg::Drawable*) const { return 0; }
         };
 
 
         /** Set the callback to override the default Drawable::createCreateVertexArrayStateImplementation().*/
-        void setCreateVertexArrayStateCallback(CreateVertexArrayStateCallback* cb) { _createVertexArrayStateCallback = cb; }
+        void setCreateVertexArrayStateCallback(VertexArrayStateCallback* cb) { _createVertexArrayStateCallback = cb; }
+        /** Set the callback to override the default Drawable::destroyCreateVertexArrayStateImplementation().*/
+        void setDestroyVertexArrayStateCallback(VertexArrayStateCallback* cb) { _destroyVertexArrayStateCallback = cb; }
 
         /** Get the callback that overrides the default Drawable::createCreateVertexArrayStateImplementation().*/
-        CreateVertexArrayStateCallback* getCreateVertexArrayStateCallback() { return _createVertexArrayStateCallback.get(); }
+        VertexArrayStateCallback* getCreateVertexArrayStateCallback() { return _createVertexArrayStateCallback.get(); }
+        VertexArrayStateCallback* getDestroyVertexArrayStateCallback() { return _destroyVertexArrayStateCallback.get(); }
 
         /** Get the const callback that overrides the default Drawable::createCreateVertexArrayStateImplementation().*/
-        const CreateVertexArrayStateCallback* getCreateVertexArrayStateCallback() const { return _createVertexArrayStateCallback.get(); }
+        const VertexArrayStateCallback* getCreateVertexArrayStateCallback() const { return _createVertexArrayStateCallback.get(); }
+        const VertexArrayStateCallback* getDestroyVertexArrayStateCallback() const { return _destroyVertexArrayStateCallback.get(); }
 
 
         /** Create the VertexArrayState object used to track vertex array and vertex array object state. This method will be called automatically during rendering setup so users should not call this themselves.*/
-        inline VertexArrayState* createVertexArrayState(RenderInfo& renderInfo) const
+        inline VertexArrayState* createVertexArrayState(State* state) const
         {
-            if (_createVertexArrayStateCallback.valid()) return _createVertexArrayStateCallback->createVertexArrayStateImplementation(renderInfo, this);
-            else return createVertexArrayStateImplementation(renderInfo);
+            if (_createVertexArrayStateCallback.valid()) return _createVertexArrayStateCallback->operator()(state, this);
+            else return createVertexArrayStateImplementation(state);
+        }
+        inline VertexArrayState* destroyVertexArrayState(State* state=0) const
+        {
+            if (_destroyVertexArrayStateCallback.valid()) return _destroyVertexArrayStateCallback->operator()(state, this);
+            else return destroyVertexArrayStateImplementation(state);
         }
 
         /** Implementation of Create the VertexArrayState object.*/
-        virtual VertexArrayState* createVertexArrayStateImplementation(RenderInfo& renderInfo) const;
+        virtual VertexArrayState* createVertexArrayStateImplementation(State* state) const;
+        /** Implementation of Destroy the VertexArrayState object.*/
+        virtual VertexArrayState* destroyVertexArrayStateImplementation(State* state) const;
 
         void setVertexArrayStateList(VertexArrayStateList& vasl) { _vertexArrayStateList = vasl; }
 
@@ -542,7 +550,7 @@ class OSG_EXPORT Drawable : public Node
         mutable VertexArrayStateList    _vertexArrayStateList;
 
         ref_ptr<DrawCallback>   _drawCallback;
-        ref_ptr<CreateVertexArrayStateCallback> _createVertexArrayStateCallback;
+        ref_ptr<VertexArrayStateCallback> _createVertexArrayStateCallback, _destroyVertexArrayStateCallback;
 };
 
 #ifdef INLINE_DRAWABLE_DRAW

--- a/include/osg/Drawable
+++ b/include/osg/Drawable
@@ -294,7 +294,7 @@ class OSG_EXPORT Drawable : public Node
             META_Object(osg, VertexArrayStateCallback);
 
             /** do customize VertexArrayState lifecycle.*/
-            virtual osg::VertexArrayState* operator () (osg::State*, const osg::Drawable*) const { return 0; }
+            virtual osg::VertexArrayState* operator () (osg::State*, const osg::Drawable*) { return 0; }
         };
 
 

--- a/include/osg/Geometry
+++ b/include/osg/Geometry
@@ -233,7 +233,7 @@ class OSG_EXPORT Geometry : public Drawable
 
         bool                            _containsDeprecatedData;
 
-        virtual VertexArrayState* createVertexArrayStateImplementation(RenderInfo& renderInfo) const;
+        virtual VertexArrayState* createVertexArrayStateImplementation(State* state) const;
 
     public:
 

--- a/include/osg/VertexArrayState
+++ b/include/osg/VertexArrayState
@@ -24,8 +24,8 @@ namespace osg {
 class OSG_EXPORT VertexArrayState : public osg::Referenced
 {
     public:
+        static VertexArrayState *createVertexArrayState(osg::State* state, bool useVAO=false);
 
-        VertexArrayState(osg::State* state);
 
         struct ArrayDispatch : public osg::Referenced
         {
@@ -180,8 +180,7 @@ class OSG_EXPORT VertexArrayState : public osg::Referenced
 
         void release();
 
-    public:
-
+        VertexArrayState(osg::State* state);
 
         // osg::GLBufferObject* getGLBufferObject(osg::Array* array);
 
@@ -209,6 +208,8 @@ class OSG_EXPORT VertexArrayState : public osg::Referenced
         GLBufferObject*                 _currentEBO;
 
         bool                            _requiresSetArrays;
+        typedef std::list< osg::ref_ptr<VertexArrayState> > VASList;
+        VASList::iterator _iteratormanager;
 };
 
 

--- a/include/osgParticle/ParticleSystem
+++ b/include/osgParticle/ParticleSystem
@@ -265,7 +265,7 @@ namespace osgParticle
           * for all graphics contexts. */
         virtual void releaseGLObjects(osg::State* state=0) const;
 
-        virtual osg::VertexArrayState* createVertexArrayStateImplemenation(osg::RenderInfo& renderInfo) const;
+        virtual osg::VertexArrayState* createVertexArrayStateImplemenation(osg::State* state) const;
 
         void adjustEstimatedMaxNumOfParticles(int delta) {  _estimatedMaxNumOfParticles += delta; }
 

--- a/include/osgTerrain/GeometryPool
+++ b/include/osgTerrain/GeometryPool
@@ -65,8 +65,7 @@ class OSGTERRAIN_EXPORT SharedGeometry : public osg::Drawable
         VertexToHeightFieldMapping& getVertexToHeightFieldMapping() { return _vertexToHeightFieldMapping; }
         const VertexToHeightFieldMapping& getVertexToHeightFieldMapping() const { return _vertexToHeightFieldMapping; }
 
-
-        osg::VertexArrayState* createVertexArrayStateImplementation(osg::RenderInfo& renderInfo) const;
+        virtual osg::VertexArrayState* createVertexArrayStateImplementation(osg::State* state) const;
 
         void compileGLObjects(osg::RenderInfo& renderInfo) const;
 

--- a/include/osgText/TextBase
+++ b/include/osgText/TextBase
@@ -295,7 +295,7 @@ protected:
 
     void initArraysAndBuffers();
 
-    osg::VertexArrayState* createVertexArrayStateImplementation(osg::RenderInfo& renderInfo) const;
+    osg::VertexArrayState* createVertexArrayStateImplementation(osg::State* state) const;
 
     void positionCursor(const osg::Vec2 & endOfLine_coords, osg::Vec2 & cursor, unsigned int linelength);
     String::iterator computeLastCharacterOnLine(osg::Vec2& cursor, String::iterator first,String::iterator last);

--- a/src/osg/Drawable.cpp
+++ b/src/osg/Drawable.cpp
@@ -259,7 +259,6 @@ Drawable::~Drawable()
 {
     _stateset = 0;
     dirtyGLObjects();
-    Drawable::destroyVertexArrayState();
 }
 
 osg::MatrixList Drawable::getWorldMatrices(const osg::Node* haltTraversalAtNode) const
@@ -337,7 +336,7 @@ void Drawable::releaseGLObjects(State* state) const
         VertexArrayState* vas = contextID <_vertexArrayStateList.size() ? _vertexArrayStateList[contextID].get() : 0;
         if (vas)
         {
-            vas->release();
+            destroyVertexArrayState(state);
             _vertexArrayStateList[contextID] = 0;
         }
     }
@@ -449,11 +448,7 @@ void Drawable::dirtyGLObjects()
     }
 #endif
 
-    for(i=0; i<_vertexArrayStateList.size(); ++i)
-    {
-        VertexArrayState* vas = _vertexArrayStateList[i].get();
-        if (vas) vas->dirty();
-    }
+    destroyVertexArrayState();
 }
 
 
@@ -697,14 +692,14 @@ void Drawable::draw(RenderInfo& renderInfo) const
 VertexArrayState* Drawable::createVertexArrayStateImplementation(State* state ) const
 {
     OSG_INFO<<"VertexArrayState* Drawable::createVertexArrayStateImplementation(RenderInfo& renderInfo) const "<<this<<std::endl;
-    VertexArrayState* vos = new osg::VertexArrayState(state);
+    VertexArrayState* vos = osg::VertexArrayState::createVertexArrayState(state);
     vos->assignAllDispatchers();
     return vos;
 }
 
 VertexArrayState* Drawable::destroyVertexArrayStateImplementation(State* state ) const
 {
-    OSG_INFO<<"VertexArrayState* Drawable::createVertexArrayStateImplementation(RenderInfo& renderInfo) const "<<this<<std::endl;
+    OSG_INFO<<"VertexArrayState* Drawable::destroyVertexArrayStateImplementation(RenderInfo& renderInfo) const "<<this<<std::endl;
     if(state)
     {
         _vertexArrayStateList[state->getContextID()]->release();

--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -715,16 +715,6 @@ void Geometry::releaseGLObjects(State* state) const
 {
     Drawable::releaseGLObjects(state);
 
-    if (state)
-    {
-        if (_vertexArrayStateList[state->getContextID()].valid())
-        {
-            _vertexArrayStateList[state->getContextID()]->release();
-            _vertexArrayStateList[state->getContextID()] = 0;
-        }
-    }
-    else _vertexArrayStateList.clear();
-
     ArrayList arrays;
     if (getArrayList(arrays))
     {
@@ -752,7 +742,7 @@ void Geometry::releaseGLObjects(State* state) const
 VertexArrayState* Geometry::createVertexArrayStateImplementation(State* state) const
 {
 
-    VertexArrayState* vas = new osg::VertexArrayState(state);
+    VertexArrayState* vas = osg::VertexArrayState::createVertexArrayState(state,state->useVertexArrayObject(_useVertexArrayObject));
 
     // OSG_NOTICE<<"Creating new osg::VertexArrayState "<< vas<<std::endl;
 
@@ -764,17 +754,6 @@ VertexArrayState* Geometry::createVertexArrayStateImplementation(State* state) c
 
     if (!_texCoordList.empty()) vas->assignTexCoordArrayDispatcher(_texCoordList.size());
     if (!_vertexAttribList.empty()) vas->assignVertexAttribArrayDispatcher(_vertexAttribList.size());
-
-    if (state->useVertexArrayObject(_useVertexArrayObject))
-    {
-        // OSG_NOTICE<<"  Setup VertexArrayState to use VAO "<<vas<<std::endl;
-
-        vas->generateVertexArrayObject();
-    }
-    else
-    {
-        // OSG_NOTICE<<"  Setup VertexArrayState to without using VAO "<<vas<<std::endl;
-    }
 
     return vas;
 }

--- a/src/osg/State.cpp
+++ b/src/osg/State.cpp
@@ -217,7 +217,7 @@ void State::initializeExtensionProcs()
 
 
     // Set up up global VertexArrayState object
-    _globalVertexArrayState = new VertexArrayState(this);
+    _globalVertexArrayState = VertexArrayState::createVertexArrayState(this);
     _globalVertexArrayState->assignAllDispatchers();
     // if (_useVertexArrayObject) _globalVertexArrayState->generateVertexArrayObject();
 

--- a/src/osgParticle/ParticleSystem.cpp
+++ b/src/osgParticle/ParticleSystem.cpp
@@ -681,18 +681,16 @@ void osgParticle::ParticleSystem::releaseGLObjects(osg::State* state) const
     }
 }
 
-osg::VertexArrayState* osgParticle::ParticleSystem::createVertexArrayStateImplemenation(osg::RenderInfo& renderInfo) const
+osg::VertexArrayState* osgParticle::ParticleSystem::createVertexArrayStateImplemenation(osg::State* state) const
 {
-    osg::State& state = *renderInfo.getState();
-
-    osg::VertexArrayState* vas = new osg::VertexArrayState(&state);
+    osg::VertexArrayState* vas = new osg::VertexArrayState(state);
 
     vas->assignVertexArrayDispatcher();
     vas->assignNormalArrayDispatcher();
     vas->assignColorArrayDispatcher();
     vas->assignTexCoordArrayDispatcher(1);
 
-    if (state.useVertexArrayObject(_useVertexArrayObject))
+    if (state->useVertexArrayObject(_useVertexArrayObject))
     {
         vas->generateVertexArrayObject();
     }

--- a/src/osgParticle/ParticleSystem.cpp
+++ b/src/osgParticle/ParticleSystem.cpp
@@ -664,6 +664,8 @@ void osgParticle::ParticleSystem::resizeGLObjectBuffers(unsigned int maxSize)
     {
         _bufferedArrayData[i].resizeGLObjectBuffers(maxSize);
     }
+
+    dirtyGLObjects();
 }
 
 void osgParticle::ParticleSystem::releaseGLObjects(osg::State* state) const
@@ -679,21 +681,16 @@ void osgParticle::ParticleSystem::releaseGLObjects(osg::State* state) const
             _bufferedArrayData[i].releaseGLObjects(0);
         }
     }
+    Drawable::releaseGLObjects(state);
 }
 
 osg::VertexArrayState* osgParticle::ParticleSystem::createVertexArrayStateImplemenation(osg::State* state) const
 {
-    osg::VertexArrayState* vas = new osg::VertexArrayState(state);
-
+    osg::VertexArrayState* vas = osg::VertexArrayState::createVertexArrayState(state, _useVertexArrayObject);
     vas->assignVertexArrayDispatcher();
     vas->assignNormalArrayDispatcher();
     vas->assignColorArrayDispatcher();
     vas->assignTexCoordArrayDispatcher(1);
-
-    if (state->useVertexArrayObject(_useVertexArrayObject))
-    {
-        vas->generateVertexArrayObject();
-    }
 
     return vas;
 }

--- a/src/osgTerrain/GeometryPool.cpp
+++ b/src/osgTerrain/GeometryPool.cpp
@@ -798,7 +798,7 @@ SharedGeometry::~SharedGeometry()
 
 osg::VertexArrayState* SharedGeometry::createVertexArrayStateImplementation(osg::State* state) const
 {
-    osg::VertexArrayState* vas = new osg::VertexArrayState(state);
+    osg::VertexArrayState* vas = osg::VertexArrayState::createVertexArrayState(state, _useVertexArrayObject);
 
     // OSG_NOTICE<<"Creating new osg::VertexArrayState "<< vas<<std::endl;
 
@@ -806,17 +806,6 @@ osg::VertexArrayState* SharedGeometry::createVertexArrayStateImplementation(osg:
     if (_colorArray.valid()) vas->assignColorArrayDispatcher();
     if (_normalArray.valid()) vas->assignNormalArrayDispatcher();
     if (_texcoordArray.valid()) vas->assignTexCoordArrayDispatcher(1);
-
-    if (state->useVertexArrayObject(_useVertexArrayObject))
-    {
-        // OSG_NOTICE<<"  Setup VertexArrayState to use VAO "<<vas<<std::endl;
-
-        vas->generateVertexArrayObject();
-    }
-    else
-    {
-        // OSG_NOTICE<<"  Setup VertexArrayState to without using VAO "<<vas<<std::endl;
-    }
 
     return vas;
 }
@@ -886,6 +875,7 @@ void SharedGeometry::resizeGLObjectBuffers(unsigned int maxSize)
 
     osg::BufferObject* ebo = _drawElements->getElementBufferObject();
     if (ebo) ebo->resizeGLObjectBuffers(maxSize);
+    dirtyGLObjects();
 }
 
 void SharedGeometry::releaseGLObjects(osg::State* state) const
@@ -897,6 +887,7 @@ void SharedGeometry::releaseGLObjects(osg::State* state) const
 
     osg::BufferObject* ebo = _drawElements->getElementBufferObject();
     if (ebo) ebo->releaseGLObjects(state);
+    Drawable::releaseGLObjects(state);
 }
 
 void SharedGeometry::drawImplementation(osg::RenderInfo& renderInfo) const

--- a/src/osgTerrain/GeometryPool.cpp
+++ b/src/osgTerrain/GeometryPool.cpp
@@ -796,11 +796,9 @@ SharedGeometry::~SharedGeometry()
 {
 }
 
-osg::VertexArrayState* SharedGeometry::createVertexArrayStateImplementation(osg::RenderInfo& renderInfo) const
+osg::VertexArrayState* SharedGeometry::createVertexArrayStateImplementation(osg::State* state) const
 {
-    osg::State& state = *renderInfo.getState();
-
-    osg::VertexArrayState* vas = new osg::VertexArrayState(&state);
+    osg::VertexArrayState* vas = new osg::VertexArrayState(state);
 
     // OSG_NOTICE<<"Creating new osg::VertexArrayState "<< vas<<std::endl;
 
@@ -809,7 +807,7 @@ osg::VertexArrayState* SharedGeometry::createVertexArrayStateImplementation(osg:
     if (_normalArray.valid()) vas->assignNormalArrayDispatcher();
     if (_texcoordArray.valid()) vas->assignTexCoordArrayDispatcher(1);
 
-    if (state.useVertexArrayObject(_useVertexArrayObject))
+    if (state->useVertexArrayObject(_useVertexArrayObject))
     {
         // OSG_NOTICE<<"  Setup VertexArrayState to use VAO "<<vas<<std::endl;
 
@@ -858,7 +856,7 @@ void SharedGeometry::compileGLObjects(osg::RenderInfo& renderInfo) const
 
             osg::VertexArrayState* vas = 0;
 
-            _vertexArrayStateList[contextID] = vas = createVertexArrayState(renderInfo);
+            _vertexArrayStateList[contextID] = vas = createVertexArrayState(renderInfo.getState());
 
             // OSG_NOTICE<<"  setting up VertexArrayObject "<<vas<<std::endl;
 

--- a/src/osgText/TextBase.cpp
+++ b/src/osgText/TextBase.cpp
@@ -109,11 +109,9 @@ void TextBase::initArraysAndBuffers()
     _texcoords->setBufferObject(_vbo.get());
 }
 
-osg::VertexArrayState* TextBase::createVertexArrayStateImplementation(osg::RenderInfo& renderInfo) const
+osg::VertexArrayState* TextBase::createVertexArrayStateImplementation(osg::State* state) const
 {
-    State& state = *renderInfo.getState();
-
-    VertexArrayState* vas = new osg::VertexArrayState(&state);
+    VertexArrayState* vas = new osg::VertexArrayState(state);
 
     // OSG_NOTICE<<"Creating new osg::VertexArrayState "<< vas<<std::endl;
 
@@ -123,7 +121,7 @@ osg::VertexArrayState* TextBase::createVertexArrayStateImplementation(osg::Rende
 
     if (_texcoords.valid()) vas->assignTexCoordArrayDispatcher(1);
 
-    if (state.useVertexArrayObject(_useVertexArrayObject))
+    if (state->useVertexArrayObject(_useVertexArrayObject))
     {
         OSG_INFO<<"TextBase::createVertexArrayState() Setup VertexArrayState to use VAO "<<vas<<std::endl;
 

--- a/src/osgText/TextBase.cpp
+++ b/src/osgText/TextBase.cpp
@@ -111,26 +111,14 @@ void TextBase::initArraysAndBuffers()
 
 osg::VertexArrayState* TextBase::createVertexArrayStateImplementation(osg::State* state) const
 {
-    VertexArrayState* vas = new osg::VertexArrayState(state);
+    osg::VertexArrayState* vas = osg::VertexArrayState::createVertexArrayState(state, _useVertexArrayObject);
 
     // OSG_NOTICE<<"Creating new osg::VertexArrayState "<< vas<<std::endl;
 
     if (_coords.valid()) vas->assignVertexArrayDispatcher();
     if (_colorCoords.valid()) vas->assignColorArrayDispatcher();
     if (_normals.valid()) vas->assignNormalArrayDispatcher();
-
     if (_texcoords.valid()) vas->assignTexCoordArrayDispatcher(1);
-
-    if (state->useVertexArrayObject(_useVertexArrayObject))
-    {
-        OSG_INFO<<"TextBase::createVertexArrayState() Setup VertexArrayState to use VAO "<<vas<<std::endl;
-
-        vas->generateVertexArrayObject();
-    }
-    else
-    {
-        OSG_INFO<<"TextBase::createVertexArrayState() Setup VertexArrayState to without using VAO "<<vas<<std::endl;
-    }
 
     return vas;
 }


### PR DESCRIPTION

 fix propal for #674

Some of the original discussion is on #587
The original discussion on the leak was covered in the thread https://www.mail-archive.com/osg-users@lists.openscenegraph.org/msg77211.html "VAO Resource Leak in OSG 3.6.2" starting 2 Aug 2018.

commit engaged eee5d54
@robertosfield edited:
problems adressed in this pr are:
   - bufferobject "overfree" bug (releaseGLObject at Drawable destruction cf issue #674) (fix: revert eee5d54 to previous design using dirtyGLObject in ~geometry -vas leak at end of program prevented with following fix-)
   - threading issue with VAO (vao released after context destruction cf issue #674) (fix:record each created vas in VASmanager and delete them on context destruction..vas can be released a second time after context destruction so i added a guard in VASmanager::flushAll)
   - vas life cycle (no way to override vas destruction)(fix add a callback and mod callback interface)
   - and several dirtyGLObject releasGLObject misses in Drawable based (crash at prog end  with vao path using  geometrypool and particlesystem)
