### PR TITLE
ObjectCache expiry/DatabasePage locking when busy to prevent deletion of referenced object.

### DIFF
--- a/include/OpenThreads/ReadWriteMutex
+++ b/include/OpenThreads/ReadWriteMutex
@@ -61,6 +61,11 @@ class ReadWriteMutex
             return _readWriteMutex.lock();
         }
 
+        virtual int writeTryLock()
+        {
+            return _readWriteMutex.trylock();
+        }
+
         virtual int writeUnlock()
         {
             return _readWriteMutex.unlock();

--- a/include/osgDB/Registry
+++ b/include/osgDB/Registry
@@ -15,6 +15,7 @@
 #define OSGDB_REGISTRY 1
 
 #include <OpenThreads/ReentrantMutex>
+#include <OpenThreads/ReadWriteMutex>
 
 #include <osg/ref_ptr>
 #include <osg/ArgumentParser>
@@ -119,6 +120,7 @@ class OSGDB_EXPORT Registry : public osg::Referenced
 
         /** get a reader writer which handles specified extension.*/
         ReaderWriter* getReaderWriterForExtension(const std::string& ext);
+        OpenThreads::ReadWriteMutex *getObjectCacheExpiryMutex(){return &_objectCacheExpiryMutex;}
 
         /** gets a reader/writer that handles the extension mapped to by one of
           * the registered mime-types. */
@@ -610,6 +612,7 @@ class OSGDB_EXPORT Registry : public osg::Referenced
         osg::ref_ptr<WriteFileCallback>     _writeFileCallback;
         osg::ref_ptr<FileLocationCallback>  _fileLocationCallback;
 
+        mutable OpenThreads::ReadWriteMutex _objectCacheExpiryMutex;
         OpenThreads::ReentrantMutex _pluginMutex;
         ReaderWriterList            _rwList;
         ImageProcessorList          _ipList;

--- a/src/osgDB/DatabasePager.cpp
+++ b/src/osgDB/DatabasePager.cpp
@@ -847,6 +847,7 @@ void DatabasePager::DatabaseThread::run()
 
         if (databaseRequest.valid())
         {
+            Registry::instance()->getObjectCacheExpiryMutex()->readLock();
 
             // load the data, note safe to write to the databaseRequest since once
             // it is created this thread is the only one to write to the _loadedModel pointer.
@@ -941,7 +942,7 @@ void DatabasePager::DatabaseThread::run()
                 }
 
             }
-
+            Registry::instance()->getObjectCacheExpiryMutex()->readUnlock();
             // _pager->_dataToCompileList->pruneOldRequestsAndCheckIfEmpty();
         }
         else


### PR DESCRIPTION
This fixes a problem when the ObjectCache is in the process of expiring an object that is simultaneously has been newly referenced from the DatabasePager thread resulting in a "Deleting still referenced object".

Problem diagnosis; when the DatabasePager has loaded from the object cache after releasing the objectCacheMutex a reference is taken (ref_ptr); as the mutex is released the object cache then expires the object at the same time as the ref_ptr is incremented in the database pager thread. This happens because the object meets the expiry time condition based on the start of the frame. So there exists a condition where the object may be deleted from the cache when it has just been referenced and this will often lead ref_ptr detecting this, warning with "Deleting still referenced object" and ultimately probably a segfault.

------------
This fix uses a ReadWriteMutex (with a new method writeTryLock) to control the expiry process. The database pager is considered to be a reader, of which there can be many (tested with 1 and 20), the ObjectCache expiry method is considered to be a writer. Only when there are no readers will the object cache expiry be able to remove items from the cache. As the expiry uses a writeTryLock expiry will be locked when there are ongoing DatabasePager loads. This will defer the expiry of objects to a later frame when the DatabasePager has finished its work.

Testing this is tricky because of the small window of opportunity; however by adding some debug print statements it has been verified that the locking is working as expected and a 60.5h test (previous failed after 40h) exhibited no problems.

NOTES:

1. Possible side effects of this fix could be an unusually large number of items being expired when the mutex is released if held for an extended period (probably never going to be a problem).

2. Lockout causes no noticeable difference to frame rate, and no frame pauses.

2. In a 3 hour test the longest expiry lockout was 549 frames, average lockout 23.4 frames. mean 24, median 10.

(cherry picked from commit b596d59410cbc7e176751f14ee77634e0de9dc1a)