### PR TITLE
clear temp objectCache in databaseRequest

### DIFF
--- a/src/osgDB/DatabasePager.cpp
+++ b/src/osgDB/DatabasePager.cpp
@@ -1663,12 +1663,6 @@ void DatabasePager::addLoadedDataToSceneGraph(const osg::FrameStamp &frameStamp)
                 registerPagedLODs(databaseRequest->_loadedModel.get(), frameNumber);
             }
 
-            if (databaseRequest->_objectCache.valid() && osgDB::Registry::instance()->getObjectCache())
-            {
-                // insert loaded model into Registry ObjectCache
-                osgDB::Registry::instance()->getObjectCache()->addObjectCache( databaseRequest->_objectCache.get());
-            }
-
             // OSG_NOTICE<<"merged subgraph"<<databaseRequest->_fileName<<" after "<<databaseRequest->_numOfRequests<<" requests and time="<<(timeStamp-databaseRequest->_timestampFirstRequest)*1000.0<<std::endl;
 
             double timeToMerge = timeStamp-databaseRequest->_timestampFirstRequest;
@@ -1684,6 +1678,13 @@ void DatabasePager::addLoadedDataToSceneGraph(const osg::FrameStamp &frameStamp)
             OSG_INFO<<"DatabasePager::addLoadedDataToSceneGraph() node in parental chain deleted, discarding subgaph."<<std::endl;
         }
 
+
+        if (databaseRequest->_objectCache.valid() && osgDB::Registry::instance()->getObjectCache())
+        {
+            // insert loaded model into Registry ObjectCache
+            osgDB::Registry::instance()->getObjectCache()->addObjectCache( databaseRequest->_objectCache.get());
+            databaseRequest->_objectCache->clear();
+        }
         // reset the loadedModel pointer
         databaseRequest->_loadedModel = 0;
 


### PR DESCRIPTION
Hi Robert,
I found some models that did not unload from memory after opening a different model in our viewer, and this pr allows them to properly unload. The problematic nodes are children of a pagedLOD node, I'm not sure if the problem is only the databaseRequest holding a ref_ptr in the temp object cache or that child nodes (nested pagedLODs) make a copy of the options.
Regards, Laurens.