### PR TITLE
fix MSVC warning C4250: inherits 'X' via dominance (94x)

### DIFF
--- a/include/osgViewer/Viewer
+++ b/include/osgViewer/Viewer
@@ -114,8 +114,8 @@ class OSGVIEWER_EXPORT Viewer : public ViewerBase, public osgViewer::View
         virtual void getUsage(osg::ApplicationUsage& usage) const;
 
         // ensure that osg::View provides the reiszerGLObjects and releaseGLObjects methods
-        using osg::View::resizeGLObjectBuffers;
-        using osg::View::releaseGLObjects;
+        virtual void resizeGLObjectBuffers(unsigned int maxSize) { osg::View::resizeGLObjectBuffers(maxSize); }
+        virtual void releaseGLObjects(osg::State* state = 0) const { osg::View::releaseGLObjects(state); }
 
     protected:
 


### PR DESCRIPTION
Hi Robert,
I get quite a few warnings in visual studio 15.9.5.
The "using" statements you added doesn't solve this (I assume it solved something else, I did not try to remove them). An explicit call to the base class removes the warnings, and if I remember properly that's the solution we used last time as well.
I checked this on the OpenScengraph-3.6 tree, but the master tree seems to have the same code.
Regards, Laurens.

e:\osg\36\laurens\openscenegraph\include\osgviewer\viewer(130): warning C4250: 'osgViewer::Viewer': inherits 'osg::View::osg::View::resizeGLObjectBuffers' via dominance (compiling source file E:\osg\36\laurens\OpenSceneGraph\src\osgViewer\HelpHandler.cpp)
e:\osg\36\laurens\openscenegraph\include\osg\view(164): note: see declaration of 'osg::View::resizeGLObjectBuffers' (compiling source file E:\osg\36\laurens\OpenSceneGraph\src\osgViewer\HelpHandler.cpp)
e:\osg\36\laurens\openscenegraph\include\osgviewer\viewer(130): warning C4250: 'osgViewer::Viewer': inherits 'osg::View::osg::View::releaseGLObjects' via dominance (compiling source file E:\osg\36\laurens\OpenSceneGraph\src\osgViewer\HelpHandler.cpp)
e:\osg\36\laurens\openscenegraph\include\osg\view(165): note: see declaration of 'osg::View::releaseGLObjects' 
