### PR TITLE
fix lazy reuse of vao with the same name

### DIFF
--- a/src/osg/VertexArrayState.cpp
+++ b/src/osg/VertexArrayState.cpp
@@ -541,6 +541,9 @@ void VertexArrayState::deleteVertexArrayObject()
     {
         VAS_NOTICE<<"  VertexArrayState::deleteVertexArrayObject() "<<_vertexArrayObject<<std::endl;
 
+        _state->setCurrentToGlobalVertexArrayState();
+        _state->setCurrentVertexArrayObject(_state->getCurrentVertexArrayState()->getVertexArrayObject());
+        
         _ext->glDeleteVertexArrays(1, &_vertexArrayObject);
         _vertexArrayObject = 0;
     }


### PR DESCRIPTION
https://github.com/openscenegraph/OpenSceneGraph/issues/694
I think i have a lead on that bug:
VA0 with name (says 1) is deleted then another is regenerated with the same  name (1)  but active check of vao in state.bindVAS  don't see they are different, don't do anything and crashes....
I fixed it by forcing state.setGlobalVAS and state.currentVAO on VAO deletion