### PR TITLE
force VAO to 0 at VAS::deleteVAO to avoid reuse of the same name

### DIFF
--- a/src/osg/VertexArrayState.cpp
+++ b/src/osg/VertexArrayState.cpp
@@ -540,7 +540,7 @@ void VertexArrayState::deleteVertexArrayObject()
     if (_vertexArrayObject)
     {
         VAS_NOTICE<<"  VertexArrayState::deleteVertexArrayObject() "<<_vertexArrayObject<<std::endl;
-
+        _state->setCurrentVertexArrayObject(0);
         _ext->glDeleteVertexArrays(1, &_vertexArrayObject);
         _vertexArrayObject = 0;
     }


### PR DESCRIPTION
**When a vao is deleted and a new one is regenerate, they may have the same name and so pass as the same for the active check in State::bindVertexArrayObject and crash**

To reproduce the bug use material provided in this issue https://github.com/openscenegraph/OpenSceneGraph/issues/694
