### PR TITLE
fix bug with Fermi NV390.87 VAO name reutilization policy

### DIFF
--- a/include/osgParticle/ParticleSystem
+++ b/include/osgParticle/ParticleSystem
@@ -265,7 +265,7 @@ namespace osgParticle
           * for all graphics contexts. */
         virtual void releaseGLObjects(osg::State* state=0) const;
 
-        virtual osg::VertexArrayState* createVertexArrayStateImplemenation(osg::RenderInfo& renderInfo) const;
+        virtual osg::VertexArrayState* createVertexArrayStateImplementation(osg::RenderInfo& renderInfo) const;
 
         void adjustEstimatedMaxNumOfParticles(int delta) {  _estimatedMaxNumOfParticles += delta; }
 

--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -778,6 +778,7 @@ VertexArrayState* Geometry::createVertexArrayStateImplementation(RenderInfo& ren
         // OSG_NOTICE<<"  Setup VertexArrayState to use VAO "<<vas<<std::endl;
 
         vas->generateVertexArrayObject();
+        state.resetCurrentVertexArrayStateOnMatch(vas);
     }
     else
     {

--- a/src/osgParticle/ParticleSystem.cpp
+++ b/src/osgParticle/ParticleSystem.cpp
@@ -685,7 +685,7 @@ void osgParticle::ParticleSystem::releaseGLObjects(osg::State* state) const
     }
 }
 
-osg::VertexArrayState* osgParticle::ParticleSystem::createVertexArrayStateImplemenation(osg::RenderInfo& renderInfo) const
+osg::VertexArrayState* osgParticle::ParticleSystem::createVertexArrayStateImplementation(osg::RenderInfo& renderInfo) const
 {
     osg::State& state = *renderInfo.getState();
 

--- a/src/osgParticle/ParticleSystem.cpp
+++ b/src/osgParticle/ParticleSystem.cpp
@@ -699,6 +699,7 @@ osg::VertexArrayState* osgParticle::ParticleSystem::createVertexArrayStateImplem
     if (state.useVertexArrayObject(_useVertexArrayObject))
     {
         vas->generateVertexArrayObject();
+        state.resetCurrentVertexArrayStateOnMatch(vas);
     }
 
     return vas;

--- a/src/osgTerrain/GeometryPool.cpp
+++ b/src/osgTerrain/GeometryPool.cpp
@@ -814,6 +814,7 @@ osg::VertexArrayState* SharedGeometry::createVertexArrayStateImplementation(osg:
         // OSG_NOTICE<<"  Setup VertexArrayState to use VAO "<<vas<<std::endl;
 
         vas->generateVertexArrayObject();
+        state.resetCurrentVertexArrayStateOnMatch(vas);
     }
     else
     {

--- a/src/osgText/TextBase.cpp
+++ b/src/osgText/TextBase.cpp
@@ -128,6 +128,7 @@ osg::VertexArrayState* TextBase::createVertexArrayStateImplementation(osg::Rende
         OSG_INFO<<"TextBase::createVertexArrayState() Setup VertexArrayState to use VAO "<<vas<<std::endl;
 
         vas->generateVertexArrayObject();
+        state.resetCurrentVertexArrayStateOnMatch(vas);
     }
     else
     {


### PR DESCRIPTION
fix proposal for https://github.com/openscenegraph/OpenSceneGraph/issues/697
state.resetCurrentVertexArrayStateOnMatch(vas) can be added in different places:

-    in createVAS as in the pr
-    in Drawable::draw and compileGLObjects (after createVAS call)
    What solution would you find the more acceptable?
