### PR TITLE
fix bug with NV390.87 VAO name reutilization policy

### DIFF
--- a/src/osg/VertexArrayState.cpp
+++ b/src/osg/VertexArrayState.cpp
@@ -551,7 +551,6 @@ void VertexArrayState::deleteVertexArrayObject()
         VAS_NOTICE<<"  VertexArrayState::deleteVertexArrayObject() "<<_vertexArrayObject<<" "<<_stateObserverSet->getObserverdObject()<<std::endl;
 
         _ext->glDeleteVertexArrays(1, &_vertexArrayObject);
-        _vertexArrayObject = 0;
     }
 }
 


### PR DESCRIPTION

citing @openscenegraph 
> If the VAS is always destructed after the call to deleteVertexArrayObject() then it will be safe to just remove this _vertexArrayObject = 0;
