### PR TITLE
Changes to OcclusionQueryNode

### DIFF
--- a/include/osg/OcclusionQueryNode
+++ b/include/osg/OcclusionQueryNode
@@ -72,7 +72,9 @@ public:
 
     virtual void drawImplementation( osg::RenderInfo& renderInfo ) const;
 
-    unsigned int getNumPixels( const osg::Camera* cam );
+    // Returns the num visible pixels of the query geometry. The returned
+    // value is only correct if 'valid == true'.
+    unsigned int getNumPixels( const osg::Camera* cam, bool* valid=NULL );
 
     virtual void releaseGLObjects( osg::State* state = 0 ) const;
 

--- a/include/osg/OcclusionQueryNode
+++ b/include/osg/OcclusionQueryNode
@@ -125,6 +125,11 @@ public:
     void setQueryFrameCount( unsigned int frames ) { _queryFrameCount = frames; }
     unsigned int getQueryFrameCount() const { return _queryFrameCount; }
 
+    // Resets the queries. The next frame will issue a new query.
+    // This is useful for big view changes, if it shouldn't be waited for
+    // '_queryFrameCount' till the frame contents change.
+    void resetQueries();
+
     // Indicate whether or not the bounding box used in the occlusion query test
     //   should be rendered. Handy for debugging and development.
     // Should only be called outside of cull/draw. No thread issues.

--- a/src/osg/OcclusionQueryNode.cpp
+++ b/src/osg/OcclusionQueryNode.cpp
@@ -477,7 +477,8 @@ bool OcclusionQueryNode::getPassed( const Camera* camera, NodeVisitor& nv )
     if ( !_enabled )
         // Queries are not enabled. The caller should be osgUtil::CullVisitor,
         //   return true to traverse the subgraphs.
-        return true;
+        _passed = true;
+        return _passed;
 
     {
         // Two situations where we want to simply do a regular traversal:
@@ -487,15 +488,18 @@ bool OcclusionQueryNode::getPassed( const Camera* camera, NodeVisitor& nv )
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock( _frameCountMutex );
         const unsigned int& lastQueryFrame( _frameCountMap[ camera ] );
         if( ( lastQueryFrame == 0 ) ||
-            ( (nv.getTraversalNumber() - lastQueryFrame) >  (_queryFrameCount + 1) ) )
-            return true;
+            ( (nv.getTraversalNumber() - lastQueryFrame) >  (_queryFrameCount + 1) ) ) {
+            _passed = true;
+            return _passed;
+        }
     }
 
     if (_queryGeode->getDrawable( 0 ) == NULL)
     {
         OSG_FATAL << "osgOQ: OcclusionQueryNode: No QueryGeometry." << std::endl;
         // Something's broke. Return true so we at least render correctly.
-        return true;
+        _passed = true;
+        return _passed;
     }
     QueryGeometry* qg = static_cast< QueryGeometry* >( _queryGeode->getDrawable( 0 ) );
 
@@ -523,7 +527,8 @@ bool OcclusionQueryNode::getPassed( const Camera* camera, NodeVisitor& nv )
         {
            // The query hasn't finished yet and the result still
            // isn't available, return true to traverse the subgraphs.
-           return true;
+           _passed = true;
+           return _passed;
         }
 
         _passed = ( (unsigned int)(result) > _visThreshold );

--- a/src/osg/OcclusionQueryNode.cpp
+++ b/src/osg/OcclusionQueryNode.cpp
@@ -588,6 +588,12 @@ void OcclusionQueryNode::setQueriesEnabled( bool enable )
     _enabled = enable;
 }
 
+void OcclusionQueryNode::resetQueries()
+{
+   OpenThreads::ScopedLock<OpenThreads::Mutex> lock( _frameCountMutex );
+   _frameCountMap.clear();
+}
+
 // Should only be called outside of cull/draw. No thread issues.
 void OcclusionQueryNode::setDebugDisplay( bool debug )
 {


### PR DESCRIPTION
Hi Robert,

we had a few issues in our application with the OcclusionQueryNode which the first two commit fixed. The last one is more cosmetic one.

I'm not that happy with the API change of 'QueryGeometry::getNumPixels', but I didn't wanted
to create another method like 'QueryGeometry::isQueryValid', because it would mean
to take the same locks as in 'getNumPixels' once more, and on the other side user should
be more aware about the possible invalid return value of 'getNumPixels', and last, I didn't want to break the backward compatibility of the API.

Greetings,
Daniel