### PR TITLE
Allow Texture subclasses to override isSafeToUnrefImageData

### DIFF
--- a/include/osg/Texture
+++ b/include/osg/Texture
@@ -831,7 +831,7 @@ class OSG_EXPORT Texture : public osg::TextureAttribute
         bool isHardwareMipmapGenerationEnabled(const State& state) const;
 
         /** Returns true if the associated Image should be released and it's safe to do so. */
-        bool isSafeToUnrefImageData(const State& state) const {
+        virtual bool isSafeToUnrefImageData(const State& state) const {
             return (_unrefImageDataAfterApply && state.getMaxTexturePoolSize()==0 && areAllTextureObjectsLoaded());
         }
 


### PR DESCRIPTION
If a texture is not intended to be used in all the contexts, it should be possible to unref the image data.

As we don't know if the texture is intended to be shared between contexts or not, this seems the easiest way to allow applications to override the behaviour. For example, in our application we have a main view that contains large textures we wish to free the image data for, and a smaller auxiliary view that doesn't contain any textures. The auxiliary view is preventing the texture image data from being unref'ed.

I considered adding a Texture::_forceUnrefImageDataAfterApply or some other extra state, but this way seemed cleaner & more generally useful?