### PR TITLE
Add search location for textures in FBX plugin

### DIFF
--- a/src/osgPlugins/fbx/fbxMaterialToOsgStateSet.cpp
+++ b/src/osgPlugins/fbx/fbxMaterialToOsgStateSet.cpp
@@ -184,14 +184,18 @@ osg::ref_ptr<osg::Texture2D> FbxMaterialToOsgStateSet::fbxTextureToOsgTexture(co
 	{
 		filename = osgDB::concatPaths(_dir, fbx->GetFileName());
 	} 
-	else if (osgDB::fileExists(fbx->GetFileName())) // Then try  "name" (if absolute)
+	else if (osgDB::fileExists(fbx->GetFileName())) // Then try "name" (if absolute)
 	{
 		filename = fbx->GetFileName();
 	} 
-	else if (osgDB::fileExists(osgDB::concatPaths(_dir, fbx->GetRelativeFileName()))) // Else try  "current dir/name"
+	else if (osgDB::fileExists(osgDB::concatPaths(_dir, fbx->GetRelativeFileName()))) // Else try  "current dir + relative filename"
 	{
 		filename = osgDB::concatPaths(_dir, fbx->GetRelativeFileName());
 	} 
+	else if (osgDB::fileExists(osgDB::concatPaths(_dir, osgDB::getSimpleFileName(fbx->GetFileName())))) // Else try "current dir + simple filename"
+	{
+		filename = osgDB::concatPaths(_dir, osgDB::getSimpleFileName(fbx->GetFileName()));
+	}
 	else 
 	{
 		OSG_WARN << "Could not find valid file for " << fbx->GetFileName() << std::endl;


### PR DESCRIPTION
The FBX plugin may fail texture lookup even if the texture is located in the same folder as the model file. 
Currently the plugin checks the following locations:

1.  The absolute filename appended to the current directory _(Works well when the absolute filename is a pure filename, but fails when the absolute filename is a complete path)_

2. The absolute filename only. _(Works well assuming the texture can be found at exactly this complete path)._

3. The relative filename appended to the current directory _(requires that the texture is placed at exactly in the same relative location to the model as the file was saved in)._

This change adds a fourth option:

4. The pure filename part of the absolute filename (i.e. without any paths) appended to the current directory. This will look in the same folder as the model is stored in.

