### PR TITLE
Ensure valid occlusion query geometry

### DIFF
--- a/include/osg/OcclusionQueryNode
+++ b/include/osg/OcclusionQueryNode
@@ -198,6 +198,9 @@ protected:
 
     bool _enabled;
 
+    // If the box of the query geometry is valid.
+    mutable bool _validQueryGeometry;
+
     // Tracks the last frame number that we performed a query.
     // User can set how many times  (See setQueryFrameCount).
     typedef std::map< const osg::Camera*, unsigned int > FrameCountMap;

--- a/src/osg/OcclusionQueryNode.cpp
+++ b/src/osg/OcclusionQueryNode.cpp
@@ -442,6 +442,7 @@ QueryGeometry::discardDeletedQueryObjects( unsigned int contextID )
 
 OcclusionQueryNode::OcclusionQueryNode()
   : _enabled( true ),
+    _validQueryGeometry( false ),
     _passed(false),
     _visThreshold( 500 ),
     _queryFrameCount( 5 ),
@@ -459,6 +460,7 @@ OcclusionQueryNode::~OcclusionQueryNode()
 
 OcclusionQueryNode::OcclusionQueryNode( const OcclusionQueryNode& oqn, const CopyOp& copyop )
   : Group( oqn, copyop ),
+    _validQueryGeometry( false ),
     _passed( false )
 {
     _enabled = oqn._enabled;
@@ -478,6 +480,14 @@ bool OcclusionQueryNode::getPassed( const Camera* camera, NodeVisitor& nv )
         // Queries are not enabled. The caller should be osgUtil::CullVisitor,
         //   return true to traverse the subgraphs.
         _passed = true;
+        return _passed;
+    }
+
+    if ( !_validQueryGeometry )
+    {
+        // The box of the query geometry is invalid, return false to not traverse
+        // the subgraphs.
+        _passed = false;
         return _passed;
     }
 
@@ -540,6 +550,9 @@ bool OcclusionQueryNode::getPassed( const Camera* camera, NodeVisitor& nv )
 
 void OcclusionQueryNode::traverseQuery( const Camera* camera, NodeVisitor& nv )
 {
+    if (!_validQueryGeometry)
+        return;
+
     bool issueQuery;
     {
         const int curFrame = nv.getTraversalNumber();
@@ -577,17 +590,28 @@ BoundingSphere OcclusionQueryNode::computeBound() const
         ComputeBoundsVisitor cbv;
         nonConstThis->accept( cbv );
         BoundingBox bb = cbv.getBoundingBox();
+        const bool bbValid = bb.valid();
+        _validQueryGeometry = bbValid;
 
         osg::ref_ptr<Vec3Array> v = new Vec3Array;
         v->resize( 8 );
-        (*v)[0] = Vec3( bb._min.x(), bb._min.y(), bb._min.z() );
-        (*v)[1] = Vec3( bb._max.x(), bb._min.y(), bb._min.z() );
-        (*v)[2] = Vec3( bb._max.x(), bb._min.y(), bb._max.z() );
-        (*v)[3] = Vec3( bb._min.x(), bb._min.y(), bb._max.z() );
-        (*v)[4] = Vec3( bb._max.x(), bb._max.y(), bb._min.z() );
-        (*v)[5] = Vec3( bb._min.x(), bb._max.y(), bb._min.z() );
-        (*v)[6] = Vec3( bb._min.x(), bb._max.y(), bb._max.z() );
-        (*v)[7] = Vec3( bb._max.x(), bb._max.y(), bb._max.z() );
+
+        // Having (0,0,0) as vertices for the case of the invalid query geometry
+        // still isn't quite the right thing. But the query geometry is public
+        // accessible and therefore a user might expect eight vertices, so
+        // it seems safer to keep eight vertices in the geometry.
+
+        if (bbValid)
+        {
+            (*v)[0] = Vec3( bb._min.x(), bb._min.y(), bb._min.z() );
+            (*v)[1] = Vec3( bb._max.x(), bb._min.y(), bb._min.z() );
+            (*v)[2] = Vec3( bb._max.x(), bb._min.y(), bb._max.z() );
+            (*v)[3] = Vec3( bb._min.x(), bb._min.y(), bb._max.z() );
+            (*v)[4] = Vec3( bb._max.x(), bb._max.y(), bb._min.z() );
+            (*v)[5] = Vec3( bb._min.x(), bb._max.y(), bb._min.z() );
+            (*v)[6] = Vec3( bb._min.x(), bb._max.y(), bb._max.z() );
+            (*v)[7] = Vec3( bb._max.x(), bb._max.y(), bb._max.z() );
+        }
 
         Geometry* geom = static_cast< Geometry* >( nonConstThis->_queryGeode->getDrawable( 0 ) );
         geom->setVertexArray( v.get() );


### PR DESCRIPTION
Regarding a race condition setting _validQueryGeometry, it's already protected by the _computeBoundMutex, which is already used for updating the query geometry.

The _computeBoundMutex isn't locked when the query geometry is accessed in the rest of the code, so I suspect that accessing _validQueryGeometry should also be fine, otherwise there currently already is a race condition.

About the validity of the query geometry, what I found in our application is, that the
box has to be at least >=0.01 in all three dimensions, otherwise the occlusion query
doesn't yield correct results.

If you like I could also add such a test to OcclusionQueryNode.
