### PR TITLE
OcclusionQueryNode: reset the test result of the invalid geometry

### DIFF
--- a/src/osg/OcclusionQueryNode.cpp
+++ b/src/osg/OcclusionQueryNode.cpp
@@ -483,8 +483,15 @@ bool OcclusionQueryNode::getPassed( const Camera* camera, NodeVisitor& nv )
         return _passed;
     }
 
+    QueryGeometry* qg = static_cast< QueryGeometry* >( _queryGeode->getDrawable( 0 ) );
+
     if ( !_validQueryGeometry )
     {
+        // There're cases that the occlusion test result has been retrieved
+        // after the query geometry has been changed, it's the result of the
+        // geometry before the change.
+        qg->reset();
+
         // The box of the query geometry is invalid, return false to not traverse
         // the subgraphs.
         _passed = false;
@@ -513,7 +520,6 @@ bool OcclusionQueryNode::getPassed( const Camera* camera, NodeVisitor& nv )
         _passed = true;
         return _passed;
     }
-    QueryGeometry* qg = static_cast< QueryGeometry* >( _queryGeode->getDrawable( 0 ) );
 
     // Get the near plane for the upcoming distance calculation.
     osg::Matrix::value_type nearPlane;


### PR DESCRIPTION
There're cases that the occlusion test result has been retrieved
after the query geometry has been changed, it's the result of the
geometry before the change.