### PR TITLE
Resolve OpenGL error caused by confusion between geometry shader implementations

### DIFF
--- a/src/osg/GLExtensions.cpp
+++ b/src/osg/GLExtensions.cpp
@@ -457,7 +457,7 @@ GLExtensions::GLExtensions(unsigned int in_contextID):
     isVertexShaderSupported = validContext && (shadersBuiltIn || osg::isGLExtensionSupported(contextID,"GL_ARB_vertex_shader"));
     isFragmentShaderSupported = validContext && (shadersBuiltIn || osg::isGLExtensionSupported(contextID,"GL_ARB_fragment_shader"));
     isLanguage100Supported = validContext && (shadersBuiltIn || osg::isGLExtensionSupported(contextID,"GL_ARB_shading_language_100"));
-    isGeometryShader4Supported = validContext && (osg::isGLExtensionSupported(contextID,"GL_EXT_geometry_shader4") || osg::isGLExtensionSupported(contextID,"GL_OES_geometry_shader") || osg::isGLExtensionOrVersionSupported(contextID,"GL_ARB_geometry_shader4", 3.2f));
+    isGeometryShader4Supported = validContext && (osg::isGLExtensionSupported(contextID,"GL_EXT_geometry_shader4") || osg::isGLExtensionSupported(contextID,"GL_ARB_geometry_shader4"));
     isGpuShader4Supported = validContext && osg::isGLExtensionOrVersionSupported(contextID,"GL_EXT_gpu_shader4", 3.0f);
     areTessellationShadersSupported = validContext && (osg::isGLExtensionOrVersionSupported(contextID, "GL_ARB_tessellation_shader", 4.0f) || osg::isGLExtensionSupported(contextID,"GL_OES_tessellation_shader"));
     isUniformBufferObjectSupported = validContext && osg::isGLExtensionOrVersionSupported(contextID,"GL_ARB_uniform_buffer_object", 3.1f);


### PR DESCRIPTION
There are two types of Geometry Shaders in OpenGL.

One is provided by `GL_EXT_geometry_shader4` and `GL_ARB_geometry_shader4` and requires that certain parameters are set with calls to `glProgramParameteri` before the program is linked. Without these extensions, the calls are erroneous.

The other is provided by OpenGL 3.2 as a core feature and by the GLES extensions `GL_EXT_geometry_shader` and `GL_OES_geometry_shader` and requires these parameters to be set in the GLSL source itself.

The value of `isGeometryShader4Supported` is being used [here](https://github.com/openscenegraph/OpenSceneGraph/blob/master/src/osg/Program.cpp#L709-L714) to determine if the `glProgramParameteri` calls should occur, so it should only be `true` when one of the extensions requiring them is present.

Resolves https://github.com/openscenegraph/OpenSceneGraph/issues/715