### PR TITLE
Fix osgAnimation transform not updating in some cases

### DIFF
--- a/src/osgAnimation/StackedTransform.cpp
+++ b/src/osgAnimation/StackedTransform.cpp
@@ -41,9 +41,7 @@ void StackedTransform::update(float t)
             continue;
         // update and check if there are changes
         element->update(t);
-        if (!dirty && !element->isIdentity()){
-            dirty = true;
-        }
+        dirty = true;
     }
 
     if (!dirty)


### PR DESCRIPTION
The osgAnimation::StackedTransform class will not update the matrix if the state is going from a non-identity to identity value. For example, if you have a stepped animation that is cycling the scale of an object between (1,1,1) and (2,2,2), the object will scale to (2,2,2) and remain at that value, since (1,1,1) is considered identity and will not dirty the matrix.

I've modified the StackedTransform::update class so that it will update the matrix, regardless of the element identity state. It will still check if the element is identity when apply the value to the new matrix.