### PR TITLE
remove ShadowVolume occluders feature in CullingSet

### DIFF
--- a/include/osg/CullingSet
+++ b/include/osg/CullingSet
@@ -23,7 +23,7 @@
 
 namespace osg {
 
-#define COMPILE_WITH_SHADOW_OCCLUSION_CULLING
+//#define COMPILE_WITH_SHADOW_OCCLUSION_CULLING
 
 /** A CullingSet class which contains a frustum and a list of occluders. */
 class OSG_EXPORT CullingSet : public Referenced


### PR DESCRIPTION
following removal of ShadowVolume feature
 https://github.com/openscenegraph/OpenSceneGraph/commit/b920d482c74d2bc75636b7c805c624c2c2d983dd
@openscenegraph 
_occluderList could be removed too from CullingSet (as well as osg/ShadowVolumeOccluder) as it may impact a lot perf even if empty (repeated loop of empty list +CullingSet copy constructor)

