### PR TITLE
fix texture output bug of 3ds plugin

### DIFF
--- a/src/osgPlugins/3ds/WriterNodeVisitor.cpp
+++ b/src/osgPlugins/3ds/WriterNodeVisitor.cpp
@@ -528,7 +528,6 @@ void WriterNodeVisitor::writeMaterials()
                         path = osgDB::getPathRelative(_srcDirectory, mat.image->getFileName());
                     }
                     path = convertExt(path, _extendedFilePaths);
-                    path = getUniqueName(path, false, "");
 
                     // Write
                     const std::string fullPath( osgDB::concatPaths(_directory, path) );


### PR DESCRIPTION
I found i can't output a texture correct 3ds file when i have multiple node referenced same texture image. 
And found in this LOC, it used a unique file name instead of correct file name.
Is it should have unique file for every material in 3ds file ? 
I guess node name should use unique name but not sure about texture file name. So i deleted it and it works.
Now i have texture coorect 3ds file, verified with assimp_viewer.