### PR TITLE
Avoid unnecessary matrix type conversion in osgParticle

### DIFF
--- a/src/osgParticle/ParticleSystem.cpp
+++ b/src/osgParticle/ParticleSystem.cpp
@@ -174,7 +174,7 @@ void osgParticle::ParticleSystem::update(double dt, osg::NodeVisitor& nv)
         osgUtil::CullVisitor* cv = nv.asCullVisitor();
         if (cv)
         {
-            osg::Matrixd modelview = *(cv->getModelViewMatrix());
+            osg::Matrix modelview = *(cv->getModelViewMatrix());
             double scale = (_sortMode==SORT_FRONT_TO_BACK ? -1.0 : 1.0);
             double deadDistance = DBL_MAX;
             for (unsigned int i=0; i<_particles.size(); ++i)


### PR DESCRIPTION
If OSG is compiled with OSG_USE_FLOAT_MATRIX=ON, using Matrixd here leads to rather wasteful Matrixd<=>Matrixf conversions when particles are updated. osg::Matrix, however, is always typedef'd to the correct type, so the minor overhead will no longer be present.