### PR TITLE
Add missing files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,9 @@ PlatformSpecifics/Windows/*.rc
 *.sdf
 *.opensdf
 
+# Visual Studio - Cache/Options Directory
+.vs/
+
 #osx xcode
 DerivedData/
 *.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ doc/openthreads.doxyfile
 
 doc/OpenSceneGraphReferenceDocs/
 doc/OpenThreadsReferenceDocs/
+doc/*.chm
+
+CMakeDoxyfile.in
+CMakeDoxygenDefaults.cmake
 
 cmake_uninstall.cmake
 


### PR DESCRIPTION
The `.gitignore` was missing some files from an in-source build. Some of these were from the documentation build process, while another was the `.vs` folder Visual Studio 2015 and later use to store machine-specific files.

I've tried to put them in what seemed like the most sensible places as the `.gitignore` file is nicely sorted and I didn't want to mess that up.