### PR TITLE
Get rid of some type conversions

### DIFF
--- a/include/osg/Node
+++ b/include/osg/Node
@@ -42,6 +42,7 @@ class Node;
 class Switch;
 class Geode;
 class Camera;
+class OccluderNode;
 
 /** A vector of Nodes pointers which is used to describe the path from a root node to a descendant.*/
 typedef std::vector< Node* > NodePath;
@@ -132,6 +133,12 @@ class OSG_EXPORT Node : public Object
           * Equivalent to dynamic_cast<const Transform*>(this).*/
         virtual const Transform* asTransform() const { return 0; }
 
+        /** Convert 'this' into an OccluderNode pointer if Node is an OccluderNode, otherwise return 0.
+          * Equivalent to dynamic_cast<OccluderNode*>(this).*/
+        virtual OccluderNode* asOccluderNode() { return 0; }
+        /** Convert 'const this' into a const OccluderNode pointer if Node is an OccluderNode, otherwise return 0.
+          * Equivalent to dynamic_cast<const OccluderNode*>(this).*/
+        virtual const OccluderNode* asOccluderNode() const { return 0; }
 
 
         /** Convert 'this' into a Switch pointer if Node is a Switch, otherwise return 0.

--- a/include/osg/OccluderNode
+++ b/include/osg/OccluderNode
@@ -34,6 +34,12 @@ class OSG_EXPORT OccluderNode : public Group
 
         META_Node(osg, OccluderNode);
 
+        /** Convert 'this' into an OccluderNode pointer if Node is an OccluderNode, otherwise return 0.
+          * Equivalent to dynamic_cast<OccluderNode*>(this).*/
+        virtual OccluderNode* asOccluderNode() { return this; }
+        /** Convert 'const this' into a const OccluderNode pointer if Node is an OccluderNode, otherwise return 0.
+          * Equivalent to dynamic_cast<const OccluderNode*>(this).*/
+        virtual const OccluderNode* asOccluderNode() const { return this; }
 
         /** Attach a ConvexPlanarOccluder to an OccluderNode.*/
         void setOccluder(ConvexPlanarOccluder* occluder) { _occluder = occluder; }

--- a/src/osg/Group.cpp
+++ b/src/osg/Group.cpp
@@ -137,7 +137,7 @@ bool Group::insertChild( unsigned int index, Node *child )
     }
 
     if (child->getNumChildrenWithOccluderNodes()>0 ||
-        dynamic_cast<osg::OccluderNode*>(child))
+        child->asOccluderNode())
     {
         setNumChildrenWithOccluderNodes(
             getNumChildrenWithOccluderNodes()+1
@@ -190,7 +190,7 @@ bool Group::removeChildren(unsigned int pos,unsigned int numChildrenToRemove)
 
             if (child->getNumChildrenWithCullingDisabled()>0 || !child->getCullingActive()) ++numChildrenWithCullingDisabledRemoved;
 
-            if (child->getNumChildrenWithOccluderNodes()>0 || dynamic_cast<osg::OccluderNode*>(child)) ++numChildrenWithOccludersRemoved;
+            if (child->getNumChildrenWithOccluderNodes()>0 || child->asOccluderNode()) ++numChildrenWithOccludersRemoved;
 
         }
 
@@ -326,12 +326,12 @@ bool Group::setChild( unsigned  int i, Node* newNode )
         // so need to check and update if required.
         int delta_numChildrenWithOccluderNodes = 0;
         if (origNode->getNumChildrenWithOccluderNodes()>0 ||
-            dynamic_cast<osg::OccluderNode*>(origNode.get()))
+            origNode.get()->asOccluderNode())
         {
             --delta_numChildrenWithOccluderNodes;
         }
         if (newNode->getNumChildrenWithOccluderNodes()>0 ||
-            dynamic_cast<osg::OccluderNode*>(newNode))
+            newNode->asOccluderNode())
         {
             ++delta_numChildrenWithOccluderNodes;
         }

--- a/src/osgParticle/ParticleProcessor.cpp
+++ b/src/osgParticle/ParticleProcessor.cpp
@@ -59,12 +59,8 @@ void osgParticle::ParticleProcessor::setParticleSystem(ParticleSystem* ps)
 
 void osgParticle::ParticleProcessor::traverse(osg::NodeVisitor& nv)
 {
-    // typecast the NodeVisitor to CullVisitor
-    osgUtil::CullVisitor* cv = nv.asCullVisitor();
-
     // continue only if the visitor actually is a cull visitor
-    if (cv) {
-
+    if (nv.getVisitorType() == osg::NodeVisitor::CULL_VISITOR) {
         // continue only if the particle system is valid
         if (_ps.valid())
         {

--- a/src/osgParticle/ParticleSystemUpdater.cpp
+++ b/src/osgParticle/ParticleSystemUpdater.cpp
@@ -22,8 +22,7 @@ osgParticle::ParticleSystemUpdater::ParticleSystemUpdater(const ParticleSystemUp
 
 void osgParticle::ParticleSystemUpdater::traverse(osg::NodeVisitor& nv)
 {
-    osgUtil::CullVisitor* cv = nv.asCullVisitor();
-    if (cv)
+    if (nv.getVisitorType() == osg::NodeVisitor::CULL_VISITOR)
     {
         if (nv.getFrameStamp())
         {


### PR DESCRIPTION
1. asOccluderNode virtual method was added to avoid costly dynamic casts in Group child insertion and removal.
2. Unnecessary asCullVisitor usage in osgParticle was replaced with a type check, since that's what is usually done for the purpose and it makes the code intention more clear - the resulting pointer to a cull visitor isn't actually used beyond an existence check.

A project I'm contributing to has plans to move to upstream OSG from a barely maintained forked 3.4.1 and I'm aiming to get some of the used changes to upstream, so it'd be nice if these could also get into 3.6 branch if possible but if not, well, I won't complain.