### PR TITLE
Override default behavior for linear vector interpolations

### DIFF
--- a/include/osgParticle/LinearInterpolator
+++ b/include/osgParticle/LinearInterpolator
@@ -42,6 +42,21 @@ namespace osgParticle
             return y1 + (y2 - y1) * t;
         }
 
+        virtual osg::Vec2 interpolate(float t, const osg::Vec2& y1, const osg::Vec2& y2) const
+        {
+            return y1 + (y2 - y1) * t;
+        }
+
+        virtual osg::Vec3 interpolate(float t, const osg::Vec3& y1, const osg::Vec3& y2) const
+        {
+            return y1 + (y2 - y1) * t;
+        }
+
+        virtual osg::Vec4 interpolate(float t, const osg::Vec4& y1, const osg::Vec4& y2) const
+        {
+            return y1 + (y2 - y1) * t;
+        }
+
     protected:
         virtual ~LinearInterpolator() {}
     };


### PR DESCRIPTION
Since we already know what interpolate is going to do in a linear interpolator, it's really unnecessary to interpolate each component of a vector separately. They can simply be interpolated (surprise) linearly between each other directly for a slight performance improvement.