### PR TITLE
Check for empty DrawElements to avoid undefined behaviour.

### DIFF
--- a/src/osg/PrimitiveSet.cpp
+++ b/src/osg/PrimitiveSet.cpp
@@ -187,6 +187,9 @@ DrawElementsUByte::~DrawElementsUByte()
 
 void DrawElementsUByte::draw(State& state, bool useVertexBufferObjects) const
 {
+    if (empty())
+        return;
+    
     GLenum mode = _mode;
     #if defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE) || defined(OSG_GLES3_AVAILABLE)
         if (mode==GL_POLYGON) mode = GL_TRIANGLE_FAN;
@@ -249,6 +252,9 @@ DrawElementsUShort::~DrawElementsUShort()
 
 void DrawElementsUShort::draw(State& state, bool useVertexBufferObjects) const
 {
+    if (empty())
+        return;
+
     GLenum mode = _mode;
     #if defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE) || defined(OSG_GLES3_AVAILABLE)
         if (mode==GL_POLYGON) mode = GL_TRIANGLE_FAN;
@@ -310,6 +316,9 @@ DrawElementsUInt::~DrawElementsUInt()
 
 void DrawElementsUInt::draw(State& state, bool useVertexBufferObjects) const
 {
+    if (empty())
+        return;
+
     GLenum mode = _mode;
     #if defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE) || defined(OSG_GLES3_AVAILABLE)
         if (mode==GL_POLYGON) mode = GL_TRIANGLE_FAN;


### PR DESCRIPTION
In `DrawElementsUByte/Short/Int`, if the vector is empty when `draw` is called, `glDrawElements` is still called with `&front()` as one of the arguments. Calling `front()` on an empty vector is undefined behaviour, which is bad (and also throws an exception on Debug builds on Windows).

This avoids the issue by returning from `draw` early when the vector is empty.