### PR TITLE
fix fbx redundant node issue

### DIFF
--- a/src/osgPlugins/fbx/WriterNodeVisitor.cpp
+++ b/src/osgPlugins/fbx/WriterNodeVisitor.cpp
@@ -652,10 +652,10 @@ void WriterNodeVisitor::apply(osg::Geometry& geometry)
     // retrieved from the geometry.
 
     // create fbx node to contain the single geometry
-    FbxNode* parent = _curFbxNode;
-    FbxNode* nodeFBX = FbxNode::Create(_pSdkManager, geometry.getName().empty() ? "Geometry" : geometry.getName().c_str());
-    _curFbxNode->AddChild(nodeFBX);
-    _curFbxNode = nodeFBX;
+    //FbxNode* parent = _curFbxNode;
+    //FbxNode* nodeFBX = FbxNode::Create(_pSdkManager, geometry.getName().empty() ? "Geometry" : geometry.getName().c_str());
+    //_curFbxNode->AddChild(nodeFBX);
+    //_curFbxNode = nodeFBX;
 
     _geometryList.push_back(&geometry);
 
@@ -669,23 +669,33 @@ void WriterNodeVisitor::apply(osg::Geometry& geometry)
         buildFaces(geometry.getName(), _geometryList, _listTriangles, _texcoords);
 
     // return to parent fbx node
-    _curFbxNode = parent;
+    //_curFbxNode = parent;
 }
 
 void WriterNodeVisitor::apply(osg::Group& node)
 {
-    FbxNode* parent = _curFbxNode;
+	if (_firstNodeProcessed)
+	{
+		FbxNode* parent = _curFbxNode;
 
-    FbxNode* nodeFBX = FbxNode::Create(_pSdkManager, node.getName().empty() ? "DefaultName" : node.getName().c_str());
-    _curFbxNode->AddChild(nodeFBX);
-    _curFbxNode = nodeFBX;
+		FbxNode* nodeFBX = FbxNode::Create(_pSdkManager, node.getName().empty() ? "DefaultName" : node.getName().c_str());
+		_curFbxNode->AddChild(nodeFBX);
+		_curFbxNode = nodeFBX;
 
-    traverse(node);
+		traverse(node);
 
-    if (_listTriangles.size() > 0)
-        buildFaces(node.getName(), _geometryList, _listTriangles, _texcoords);
+		if (_listTriangles.size() > 0)
+			buildFaces(node.getName(), _geometryList, _listTriangles, _texcoords);
 
-    _curFbxNode = parent;
+		_curFbxNode = parent;
+	}
+	else
+	{
+		_firstNodeProcessed = true;
+		traverse(node);
+
+		
+	}
 }
 
 void WriterNodeVisitor::apply(osg::MatrixTransform& node)

--- a/src/osgPlugins/fbx/WriterNodeVisitor.cpp
+++ b/src/osgPlugins/fbx/WriterNodeVisitor.cpp
@@ -648,15 +648,7 @@ void WriterNodeVisitor::createListTriangle(const osg::Geometry* geo,
 
 void WriterNodeVisitor::apply(osg::Geometry& geometry)
 {
-    // here we simply create a single fbx node to assign it the mesh
     // retrieved from the geometry.
-
-    // create fbx node to contain the single geometry
-    //FbxNode* parent = _curFbxNode;
-    //FbxNode* nodeFBX = FbxNode::Create(_pSdkManager, geometry.getName().empty() ? "Geometry" : geometry.getName().c_str());
-    //_curFbxNode->AddChild(nodeFBX);
-    //_curFbxNode = nodeFBX;
-
     _geometryList.push_back(&geometry);
 
     pushStateSet(geometry.getStateSet());
@@ -668,8 +660,6 @@ void WriterNodeVisitor::apply(osg::Geometry& geometry)
     if (getNodePath().size() == 1)
         buildFaces(geometry.getName(), _geometryList, _listTriangles, _texcoords);
 
-    // return to parent fbx node
-    //_curFbxNode = parent;
 }
 
 void WriterNodeVisitor::apply(osg::Group& node)
@@ -691,10 +681,9 @@ void WriterNodeVisitor::apply(osg::Group& node)
 	}
 	else
 	{
+		//ignore the root node to maintain same hierarchy
 		_firstNodeProcessed = true;
-		traverse(node);
-
-		
+		traverse(node);		
 	}
 }
 

--- a/src/osgPlugins/fbx/WriterNodeVisitor.cpp
+++ b/src/osgPlugins/fbx/WriterNodeVisitor.cpp
@@ -664,26 +664,26 @@ void WriterNodeVisitor::apply(osg::Geometry& geometry)
 
 void WriterNodeVisitor::apply(osg::Group& node)
 {
-	if (_firstNodeProcessed)
-	{
-		FbxNode* parent = _curFbxNode;
+    if (_firstNodeProcessed)
+    {
+        FbxNode* parent = _curFbxNode;
 
-		FbxNode* nodeFBX = FbxNode::Create(_pSdkManager, node.getName().empty() ? "DefaultName" : node.getName().c_str());
-		_curFbxNode->AddChild(nodeFBX);
-		_curFbxNode = nodeFBX;
+        FbxNode* nodeFBX = FbxNode::Create(_pSdkManager, node.getName().empty() ? "DefaultName" : node.getName().c_str());
+        _curFbxNode->AddChild(nodeFBX);
+        _curFbxNode = nodeFBX;
 
-		traverse(node);
+        traverse(node);
 
-		if (_listTriangles.size() > 0)
-			buildFaces(node.getName(), _geometryList, _listTriangles, _texcoords);
+        if (_listTriangles.size() > 0)
+            buildFaces(node.getName(), _geometryList, _listTriangles, _texcoords);
 
-		_curFbxNode = parent;
-	}
-	else
-	{
-		//ignore the root node to maintain same hierarchy
-		_firstNodeProcessed = true;
-		traverse(node);		
+        _curFbxNode = parent;
+    }
+    else
+    {
+        //ignore the root node to maintain same hierarchy
+        _firstNodeProcessed = true;
+        traverse(node);		
 	}
 }
 

--- a/src/osgPlugins/fbx/WriterNodeVisitor.h
+++ b/src/osgPlugins/fbx/WriterNodeVisitor.h
@@ -87,7 +87,7 @@ class WriterNodeVisitor: public osg::NodeVisitor
             _externalWriter(srcDirectory, osgDB::getFilePath(fileName), true, 0),
             _texcoords(false),
             _drawableNum(0),
-			_firstNodeProcessed(false)
+            _firstNodeProcessed(false)
         {}
 
         virtual void apply(osg::Geometry& node);
@@ -235,8 +235,8 @@ class WriterNodeVisitor: public osg::NodeVisitor
         ///Tell us if the last apply succeed, useful to stop going through the graph.
         bool _succeedLastApply;
 
-		///Marks if the first node is processed.
-		bool _firstNodeProcessed;
+        ///Marks if the first node is processed.
+        bool _firstNodeProcessed;
 		
         ///The current directory.
         std::string _directory;

--- a/src/osgPlugins/fbx/WriterNodeVisitor.h
+++ b/src/osgPlugins/fbx/WriterNodeVisitor.h
@@ -86,7 +86,8 @@ class WriterNodeVisitor: public osg::NodeVisitor
             _options(options),
             _externalWriter(srcDirectory, osgDB::getFilePath(fileName), true, 0),
             _texcoords(false),
-            _drawableNum(0)
+            _drawableNum(0),
+			_firstNodeProcessed(false)
         {}
 
         virtual void apply(osg::Geometry& node);
@@ -234,6 +235,9 @@ class WriterNodeVisitor: public osg::NodeVisitor
         ///Tell us if the last apply succeed, useful to stop going through the graph.
         bool _succeedLastApply;
 
+		///Marks if the first node is processed.
+		bool _firstNodeProcessed;
+		
         ///The current directory.
         std::string _directory;
 


### PR DESCRIPTION
Saving fbx function creates redundant fbx nodes, including one empty parent node for the whole scene and one empty node for each Geometry. Every time you load the model and save to file, these redundant nodes would accumulate, so after repeating load&save for some times the hierarchy become a mess. This commit fixes the problem and ensures fbx file remains the same after each load&save operation.