### PR TITLE
macOS support for glVertexAttribDivisor with legacy GL

### DIFF
--- a/src/osg/GLExtensions.cpp
+++ b/src/osg/GLExtensions.cpp
@@ -603,7 +603,7 @@ GLExtensions::GLExtensions(unsigned int in_contextID):
     setGLExtensionFuncPtr(glVertexAttribPointer, "glVertexAttribPointer","glVertexAttribPointerARB", validContext);
     setGLExtensionFuncPtr(glVertexAttribIPointer, "glVertexAttribIPointer","glVertexAttribIPointerARB", validContext);
     setGLExtensionFuncPtr(glVertexAttribLPointer, "glVertexAttribLPointer","glVertexAttribLPointerARB", validContext);
-    setGLExtensionFuncPtr(glVertexAttribDivisor, "glVertexAttribDivisor", validContext);
+    setGLExtensionFuncPtr(glVertexAttribDivisor, "glVertexAttribDivisor", "glVertexAttribDivisorARB", validContext);
 
     // v1.5-only ARB entry points, in case they're needed for fallback
     setGLExtensionFuncPtr(glGetInfoLogARB, "glGetInfoLogARB", validContext);


### PR DESCRIPTION
In compatibility mode (OpenGL 2.1), glVertexAttribDivisor is available
via glVertexAttribDivisorARB on macOS.