### PR TITLE
fix osgconv for readerWriters that don't implement readObject

### DIFF
--- a/applications/osgconv/osgconv.cpp
+++ b/applications/osgconv/osgconv.cpp
@@ -792,12 +792,18 @@ int main( int argc, char **argv )
         itr != fileNames.end();
         ++itr)
     {
-        osg::ref_ptr<osg::Object> object = osgDB::readObjectFile(*itr);
-        if (object.valid())
-        {
-            if (object->asNode()) nodes.push_back(object->asNode());
-            else if (object->asImage()) images.push_back(object->asImage());
-            else objects.push_back(object);
+        // a few plugins don't implement readObjectFile
+        osg::ref_ptr<osg::Node> node = osgDB::readRefNodeFile(*itr);
+        if (node.valid()) {
+            nodes.push_back(node);
+        } else {
+            osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile(*itr);
+            if (object.valid())
+            {
+                if (object->asNode()) nodes.push_back(object->asNode());
+                else if (object->asImage()) images.push_back(object->asImage());
+                else objects.push_back(object);
+            }
         }
     }
 


### PR DESCRIPTION
Hi Robert,

I was surprised by
  C:\Users\laurens>osgconv cow.osg.0,180,0.rot
  Error reading file cow.osg.0,180,0.rot: not implemented

Tracing back the problem I found it was caused by your commit on 20/11/2018
* Added support for reading and writing images

this caused all plugins that don't implement readObject to fail with osgconv.
I implemented this fix by trying readRefNodeFile if readRefObjectFile fails 
(changed readObjectFile to readRefObjectFile to keep things working if OSG_PROVIDE_READFILE is not defined)
Flipped the logic to try readRefNodeFile first to avoid 
  Error reading file cow.osg.0,180,0.rot: not implemented
for nearly all 3d models, but now the waring is given for all images (both versions work fine, despite the warning).

I guess this could be fixed by changing the default impementation of readObject (ReaderWriter:239) to call readNode, 
or implementing readObject in all readerWriters. I'm not totaly sure this will have no side effects, so for now I propose this fix.

Regards, Laurens. 