### PR TITLE
fix compile error if OSGUTIL_RENDERBACKEND_USE_REF_PTR not defined in include/osgUtil/RenderLeaf

### DIFF
--- a/src/osgSim/LightPointNode.cpp
+++ b/src/osgSim/LightPointNode.cpp
@@ -205,7 +205,7 @@ void LightPointNode::traverse(osg::NodeVisitor& nv)
         // as this will be our special light point drawable.
         osgUtil::StateGraph::LeafList::iterator litr;
         for(litr = rg->_leaves.begin();
-            litr != rg->_leaves.end() && (*litr)->_drawable.get()!=drawable;
+            litr != rg->_leaves.end() && (*litr)->getDrawable()!=drawable;
             ++litr)
         {}
 


### PR DESCRIPTION
Ran into a compile error after removing the #define OSGUTIL_RENDERBACKEND_USE_REF_PTR (to see if that would render faster on windows; it does not).

Fix applies to master as well.
Laurens.