### PR TITLE
Various TGA improvements

### DIFF
--- a/src/osgPlugins/tga/ReaderWriterTGA.cpp
+++ b/src/osgPlugins/tga/ReaderWriterTGA.cpp
@@ -356,6 +356,11 @@ int *numComponents_ret)
         colormapLen = getInt16(&header[5]);
         colormapDepth = (header[7] + 7) >> 3;
         colormap.reinitialise(colormapLen*colormapDepth);
+        if (colormap == NULL)
+        {
+            tgaerror = ERR_MEM;
+            return NULL;
+        }
         fin.read((char*)colormap, colormapLen*colormapDepth);
 
         if (colormapDepth == 2)          /* 16 bits */
@@ -387,6 +392,12 @@ int *numComponents_ret)
     bpr = format * width;
     SafeArray<unsigned char> linebuf(width * depth);
 
+    if (buffer == NULL || linebuf == NULL)
+    {
+        tgaerror = ERR_MEM;
+        return NULL;
+    }
+
     //check the intended image orientation
     bool bLeftToRight = (flags&0x10)==0;
     bool bTopToBottom = (flags&0x20)!=0;
@@ -404,6 +415,11 @@ int *numComponents_ret)
                 return NULL;
             }
             SafeArray<unsigned char> formattedMap(colormapLen * format);
+            if (formattedMap == NULL)
+            {
+                tgaerror = ERR_MEM;
+                return NULL;
+            }
             for (int i = 0; i < colormapLen; i++)
             {
                 convert_data(colormap, formattedMap, i, colormapDepth, format);


### PR DESCRIPTION
This PR makes various improvements to the TGA loader, including adding support for type 3, 9 and 11 TGA images. While it's fairly large, each individual commit is intended to be easily reviewable on its own.

It's been tested with this suite of TGA files: https://github.com/ftrvxmtrx/tga/tree/master/testdata. This is comprised of Truevision's official TGA 2.0 Utilities Package plus some extras, and seems to be the same test suite that lots of other TGA loaders are using.