### PR TITLE
implement readObject for all relevant readerWriters

### DIFF
--- a/src/osgPlugins/3dc/ReaderWriter3DC.cpp
+++ b/src/osgPlugins/3dc/ReaderWriter3DC.cpp
@@ -92,6 +92,11 @@ class ReaderWriter3DC : public osgDB::ReaderWriter
 
         virtual const char* className() const { return "3DC point cloud reader"; }
 
+        virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readNode(fileName, options);
+        }
+
         virtual ReadResult readNode(const std::string& file, const osgDB::ReaderWriter::Options* options) const
         {
             std::string ext = osgDB::getLowerCaseFileExtension(file);

--- a/src/osgPlugins/3ds/ReaderWriter3DS.cpp
+++ b/src/osgPlugins/3ds/ReaderWriter3DS.cpp
@@ -171,7 +171,18 @@ public:
 
     virtual const char* className() const { return "3DS Auto Studio Reader/Writer"; }
 
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options);
+    }
+
     virtual ReadResult readNode(const std::string& file, const osgDB::ReaderWriter::Options* options) const;
+    virtual ReadResult readObject(std::istream& fin, const Options* options) const
+    {
+        return readNode(fin, options);
+    }
+
+
     virtual ReadResult readNode(std::istream& fin, const Options* options) const;
     virtual ReadResult doReadNode(std::istream& fin, const Options* options, const std::string & fileNamelib3ds) const;        ///< Subfunction of readNode()s functions.
 

--- a/src/osgPlugins/Inventor/ReaderWriterIV.h
+++ b/src/osgPlugins/Inventor/ReaderWriterIV.h
@@ -19,8 +19,19 @@ class ReaderWriterIV : public osgDB::ReaderWriter
             return osgDB::equalCaseInsensitive(extension, "iv") ? true : false;
         }
 
+        virtual ReadResult readObject(const std::string& filename, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readNode(filename, options);
+        }
+
         virtual ReadResult readNode(const std::string& filename,
                                     const osgDB::ReaderWriter::Options*) const;
+
+        virtual ReadResult readObject(std::istream& fin, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readNode(fin, options);
+        }
+
         virtual ReadResult readNode(std::istream& fin,
                                     const osgDB::ReaderWriter::Options* = NULL) const;
 

--- a/src/osgPlugins/ac/ac3d.cpp
+++ b/src/osgPlugins/ac/ac3d.cpp
@@ -78,7 +78,10 @@ class ReaderWriterAC : public osgDB::ReaderWriter
         }
 
         virtual const char* className() const { return "AC3D Database Reader"; }
-
+        virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readNode(fileName, options);
+        }
         virtual ReadResult readNode(const std::string& file,const Options* options) const
         {
             std::string ext = osgDB::getFileExtension(file);
@@ -109,6 +112,10 @@ class ReaderWriterAC : public osgDB::ReaderWriter
             if (result.validNode())
                 result.getNode()->setName(fileName);
             return result;
+        }
+        virtual ReadResult readObject(std::istream& fin, const Options* options) const
+        {
+            return readNode(fin, options);
         }
         virtual ReadResult readNode(std::istream& fin, const Options* options) const
         {

--- a/src/osgPlugins/bsp/ReaderWriterBSP.h
+++ b/src/osgPlugins/bsp/ReaderWriterBSP.h
@@ -18,6 +18,11 @@ public:
 
     virtual bool   acceptsExtension(const std::string& extension) const;
 
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options);
+    }
+
     virtual ReadResult   readNode(const std::string& file,
                                   const Options* options) const;
 };

--- a/src/osgPlugins/bvh/ReaderWriterBVH.cpp
+++ b/src/osgPlugins/bvh/ReaderWriterBVH.cpp
@@ -365,10 +365,20 @@ public:
     virtual const char* className() const
     { return "BVH Motion Reader"; }
 
+    virtual ReadResult readObject(std::istream& stream, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(stream, options);
+    }
+
     virtual ReadResult readNode(std::istream& stream, const osgDB::ReaderWriter::Options* options) const
     {
         ReadResult rr = BvhMotionBuilder::instance()->buildBVH( stream, options );
         return rr;
+    }
+
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options);
     }
 
     virtual ReadResult readNode(const std::string& file, const osgDB::ReaderWriter::Options* options) const

--- a/src/osgPlugins/dae/ReaderWriterDAE.h
+++ b/src/osgPlugins/dae/ReaderWriterDAE.h
@@ -40,7 +40,18 @@ public:
 
     const char* className() const { return "COLLADA 1.4.x DAE reader/writer"; }
 
+    virtual ReadResult readObject(std::istream& fin, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fin, options);
+    }
+
     ReadResult readNode(std::istream&, const Options* = NULL) const;
+
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options);
+    }
+
     ReadResult readNode(const std::string&, const Options* = NULL) const;
 
     WriteResult writeNode(const osg::Node&, const std::string&, const Options* = NULL) const;

--- a/src/osgPlugins/directshow/ReaderWriterDirectShow.cpp
+++ b/src/osgPlugins/directshow/ReaderWriterDirectShow.cpp
@@ -43,6 +43,11 @@ public:
     {
         return "ReaderWriterDirectShow";
     }
+    
+    virtual ReadResult readObject(const std::string& file, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readImage(file, options);
+    }
 
     virtual ReadResult readImage(const std::string & filename, const osgDB::ReaderWriter::Options * options) const
     {

--- a/src/osgPlugins/dxf/ReaderWriterDXF.cpp
+++ b/src/osgPlugins/dxf/ReaderWriterDXF.cpp
@@ -40,6 +40,11 @@ public:
 
     virtual const char* className() const { return "Autodesk DXF Reader/Writer"; }
 
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options);
+    }
+
     virtual ReadResult readNode(const std::string& fileName, const osgDB::ReaderWriter::Options*) const;
 
 

--- a/src/osgPlugins/ffmpeg/ReaderWriterFFmpeg.cpp
+++ b/src/osgPlugins/ffmpeg/ReaderWriterFFmpeg.cpp
@@ -132,6 +132,11 @@ public:
         return "ReaderWriterFFmpeg";
     }
 
+    virtual ReadResult readObject(const std::string& file, const osgDB::ReaderWriter::Options* options =NULL) const
+    {
+        return readImage(file, options);
+    }
+
     virtual ReadResult readImage(const std::string & filename, const osgDB::ReaderWriter::Options* options) const
     {
         const std::string ext = osgDB::getLowerCaseFileExtension(filename);

--- a/src/osgPlugins/gles/ReaderWriterGLES.cpp
+++ b/src/osgPlugins/gles/ReaderWriterGLES.cpp
@@ -129,6 +129,10 @@ public:
         return model.release();
     }
 
+    virtual ReadResult readObject(const std::string& filename, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(filename, options);
+    }
 
     virtual ReadResult readNode(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
     {

--- a/src/osgPlugins/gstreamer/ReaderWriterGStreamer.cpp
+++ b/src/osgPlugins/gstreamer/ReaderWriterGStreamer.cpp
@@ -52,6 +52,11 @@ public:
         return "ReaderWriterGStreamer";
     }
 
+    virtual ReadResult readObject(const std::string& file, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readImage(file, options);
+    }
+
     virtual ReadResult readImage(const std::string & filename, const osgDB::ReaderWriter::Options* options) const
     {
         const std::string ext = osgDB::getLowerCaseFileExtension(filename);

--- a/src/osgPlugins/hdr/ReaderWriterHDR.cpp
+++ b/src/osgPlugins/hdr/ReaderWriterHDR.cpp
@@ -69,6 +69,11 @@ public:
 
     virtual const char* className() const { return "HDR Image Reader"; }
 
+    virtual ReadResult readObject(const std::string& file, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readImage(file, options);
+    }
+
     virtual ReadResult readImage(const std::string &_file, const osgDB::ReaderWriter::Options *_opts) const
     {
         std::string filepath = osgDB::findDataFile(_file, _opts);

--- a/src/osgPlugins/ktx/ReaderWriterKTX.h
+++ b/src/osgPlugins/ktx/ReaderWriterKTX.h
@@ -43,7 +43,18 @@ public:
     ReaderWriterKTX();
 
     virtual const char* className() const;
+
+    virtual ReadResult readObject(std::istream& fin, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readImage(fin, options);
+    }
+    
     virtual ReadResult readImage(std::istream& fin,const osgDB::ReaderWriter::Options* =NULL) const;
+
+    virtual ReadResult readObject(const std::string& file, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readImage(file, options);
+    }
     virtual ReadResult readImage(const std::string& file, const osgDB::ReaderWriter::Options* options) const;
 
     virtual WriteResult writeObject(const osg::Object& object, const std::string& file, const osgDB::ReaderWriter::Options* options) const;

--- a/src/osgPlugins/las/ReaderWriterLAS.cpp
+++ b/src/osgPlugins/las/ReaderWriterLAS.cpp
@@ -34,6 +34,11 @@ class ReaderWriterLAS : public osgDB::ReaderWriter
 
         virtual const char* className() const { return "LAS point cloud reader"; }
 
+        virtual ReadResult readObject(const std::string& filename, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readNode(filename, options);
+        }
+
         virtual ReadResult readNode(const std::string& file, const osgDB::ReaderWriter::Options* options) const 
         {
             std::string ext = osgDB::getLowerCaseFileExtension(file);
@@ -51,7 +56,12 @@ class ReaderWriterLAS : public osgDB::ReaderWriter
             return readNode(ifs, options);
         }
 
-        virtual ReadResult readNode(std::istream& ifs, const Options* options) const {
+        virtual ReadResult readObject(std::istream& fin, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readNode(fin, options);
+        }
+
+       virtual ReadResult readNode(std::istream& ifs, const Options* options) const {
             // Reading options
             bool _verbose = false;
             bool _scale = true;

--- a/src/osgPlugins/logo/ReaderWriterLOGO.cpp
+++ b/src/osgPlugins/logo/ReaderWriterLOGO.cpp
@@ -231,6 +231,11 @@ class LOGOReaderWriter : public osgDB::ReaderWriter
 
         virtual const char* className() const { return "Logo Database Reader/Writer"; }
 
+        virtual ReadResult readObject(const std::string& filename, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readNode(filename, options);
+        }
+
         virtual ReadResult readNode(const std::string& file, const osgDB::ReaderWriter::Options* options) const
         {
             std::string ext = osgDB::getLowerCaseFileExtension(file);

--- a/src/osgPlugins/md2/ReaderWriterMD2.cpp
+++ b/src/osgPlugins/md2/ReaderWriterMD2.cpp
@@ -53,6 +53,11 @@ public:
         return "Quake MD2 Reader";
     }
 
+    virtual ReadResult readObject(const std::string& filename, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(filename, options);
+    }
+
     virtual ReadResult readNode (const std::string& filename, const osgDB::ReaderWriter::Options* options) const;
 };
 

--- a/src/osgPlugins/mdl/ReaderWriterMDL.h
+++ b/src/osgPlugins/mdl/ReaderWriterMDL.h
@@ -17,6 +17,11 @@ public:
 
     virtual bool   acceptsExtension(const std::string& extension) const;
 
+    virtual ReadResult readObject(const std::string& filename, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(filename, options);
+    }
+
     virtual ReadResult   readNode(const std::string& file,
                                   const Options* options) const;
 };

--- a/src/osgPlugins/osgjs/ReaderWriterJSON.cpp
+++ b/src/osgPlugins/osgjs/ReaderWriterJSON.cpp
@@ -76,6 +76,11 @@ public:
 
     virtual const char* className() const { return "OSGJS json Writer"; }
 
+    virtual ReadResult readObject(const std::string& filename, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(filename, options);
+    }
+
     virtual ReadResult readNode(const std::string& fileName, const Options* options) const;
 
     virtual WriteResult writeNode(const Node& node,

--- a/src/osgPlugins/osgtgz/ReaderWriterOSGTGZ.cpp
+++ b/src/osgPlugins/osgtgz/ReaderWriterOSGTGZ.cpp
@@ -34,6 +34,11 @@ class sgReaderWriterOSGTGZ : public osgDB::ReaderWriter
 
         virtual const char* className() const { return "OSGTGZ Database Reader/Writer"; }
 
+        virtual ReadResult readObject(const std::string& filename, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readNode(filename, options);
+        }
+
         virtual ReadResult readNode(const std::string& file, const osgDB::ReaderWriter::Options* options) const
         {
             std::string ext = osgDB::getFileExtension(file);

--- a/src/osgPlugins/p3d/ReaderWriterP3D.cpp
+++ b/src/osgPlugins/p3d/ReaderWriterP3D.cpp
@@ -163,8 +163,18 @@ public:
 
     osgDB::XmlNode::Properties::const_iterator findProperty(osgDB::XmlNode* cur, const char* token) const;
 
+    virtual ReadResult readObject(const std::string& filename, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(filename, options);
+    }
+
     virtual ReadResult readNode(const std::string& fileName,
                                 const osgDB::ReaderWriter::Options* options) const;
+
+    virtual ReadResult readObject(std::istream& fin, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fin, options);
+    }
 
     virtual ReadResult readNode(std::istream& fin, const Options* options) const;
 

--- a/src/osgPlugins/ply/ReaderWriterPLY.cpp
+++ b/src/osgPlugins/ply/ReaderWriterPLY.cpp
@@ -45,6 +45,12 @@ public:
     }
 
     virtual const char* className() const { return "ReaderWriterPLY"; }
+    
+    virtual ReadResult readObject(const std::string& filename, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(filename, options);
+    }
+
     virtual ReadResult readNode(const std::string& fileName, const osgDB::ReaderWriter::Options*) const;
 protected:
 };

--- a/src/osgPlugins/pnm/ReaderWriterPNM.cpp
+++ b/src/osgPlugins/pnm/ReaderWriterPNM.cpp
@@ -226,6 +226,11 @@ class ReaderWriterPNM : public osgDB::ReaderWriter
 
         virtual const char* className() const { return "PNM Image Reader/Writer"; }
 
+        virtual ReadResult readObject(std::istream& fin, const Options* options) const
+        {
+            return readImage(fin,options);
+        }
+
         virtual ReadResult readImage(std::istream& fin, const osgDB::ReaderWriter::Options* options=NULL) const
         {
             int ppmtype = 0;    /* P1, P2, etc. */
@@ -373,6 +378,11 @@ class ReaderWriterPNM : public osgDB::ReaderWriter
             }
 
             return pOsgImage;
+        }
+
+        virtual ReadResult readObject(const std::string& file, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readImage(file,options);
         }
 
         virtual ReadResult readImage(const std::string& file, const osgDB::ReaderWriter::Options* options) const

--- a/src/osgPlugins/quicktime/ReaderWriterQT.cpp
+++ b/src/osgPlugins/quicktime/ReaderWriterQT.cpp
@@ -209,6 +209,11 @@ public:
          acceptsLiveExtension(extension);
    }
 
+   virtual ReadResult readObject(const std::string& file, const osgDB::ReaderWriter::Options* options) const
+   {
+       return readImage(file,options);
+   }
+
    virtual ReadResult readImage(const std::string& file, const osgDB::ReaderWriter::Options* options) const
    {
       std::string ext = osgDB::getLowerCaseFileExtension(file);
@@ -362,6 +367,11 @@ public:
       _qtExitObserver.addMedia(image.get());
 
       return image.release();
+   }
+
+   virtual ReadResult readObject(std::istream& fin, const Options* options) const
+   {
+       return readImage(fin,options);
    }
 
     virtual ReadResult readImage (std::istream& is, const osgDB::ReaderWriter::Options* options=NULL) const

--- a/src/osgPlugins/rot/ReaderWriterROT.cpp
+++ b/src/osgPlugins/rot/ReaderWriterROT.cpp
@@ -100,6 +100,11 @@ public:
 
     virtual const char* className() const { return "rotation pseudo-loader"; }
 
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options); 
+    }
+
     virtual ReadResult readNode(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
     {
         std::string ext = osgDB::getLowerCaseFileExtension(fileName);

--- a/src/osgPlugins/scale/ReaderWriterSCALE.cpp
+++ b/src/osgPlugins/scale/ReaderWriterSCALE.cpp
@@ -108,6 +108,11 @@ public:
         return osgDB::equalCaseInsensitive( extension, EXTENSION_NAME );
     }
 
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options); 
+    }
+
     virtual ReadResult readNode(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
     {
         std::string ext = osgDB::getLowerCaseFileExtension(fileName);

--- a/src/osgPlugins/shadow/ReaderWriterOsgShadow.cpp
+++ b/src/osgPlugins/shadow/ReaderWriterOsgShadow.cpp
@@ -80,6 +80,11 @@ public:
 
     virtual const char* className() const { return "osgShadow pseudo-loader"; }
 
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options); 
+    }
+
     virtual ReadResult readNode(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
     {
         std::string ext = osgDB::getLowerCaseFileExtension(fileName);

--- a/src/osgPlugins/stl/ReaderWriterSTL.cpp
+++ b/src/osgPlugins/stl/ReaderWriterSTL.cpp
@@ -110,6 +110,11 @@ public:
         return "STL Reader";
     }
 
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options); 
+    }
+
     virtual ReadResult readNode(const std::string& fileName, const osgDB::ReaderWriter::Options*) const;
     virtual WriteResult writeNode(const osg::Node& node, const std::string& fileName, const Options* = NULL) const;
 

--- a/src/osgPlugins/terrain/ReaderWriterOsgTerrain.cpp
+++ b/src/osgPlugins/terrain/ReaderWriterOsgTerrain.cpp
@@ -25,6 +25,11 @@ class ReaderWriterTerrain : public osgDB::ReaderWriter
 
         virtual const char* className() const { return "Terrain ReaderWriter"; }
 
+        virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readNode(fileName, options); 
+        }
+
         virtual osgDB::ReaderWriter::ReadResult readNode(const std::string& file, const osgDB::ReaderWriter::Options* opt) const
         {
             std::string ext = osgDB::getLowerCaseFileExtension(file);

--- a/src/osgPlugins/tgz/ReaderWriterTGZ.cpp
+++ b/src/osgPlugins/tgz/ReaderWriterTGZ.cpp
@@ -33,6 +33,11 @@ class ReaderWriterTGZ : public osgDB::ReaderWriter
             supportsExtension("tgz","Tar gzip'd archive format");
         }
 
+        virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readNode(fileName, options); 
+        }
+
         virtual ReadResult readNode(const std::string& file, const osgDB::ReaderWriter::Options* options) const
         {
              std::string ext = osgDB::getLowerCaseFileExtension(file);

--- a/src/osgPlugins/trans/ReaderWriterTRANS.cpp
+++ b/src/osgPlugins/trans/ReaderWriterTRANS.cpp
@@ -101,6 +101,11 @@ public:
 
     virtual const char* className() const { return "translation pseudo-loader"; }
 
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options); 
+    }
+
     virtual ReadResult readNode(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
     {
         std::string ext = osgDB::getLowerCaseFileExtension(fileName);

--- a/src/osgPlugins/vrml/ReaderWriterVRML2.h
+++ b/src/osgPlugins/vrml/ReaderWriterVRML2.h
@@ -85,6 +85,10 @@ public:
 
     virtual const char* className() const { return "VRML2 Reader/Writer"; }
 
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options); 
+    }
 
     virtual ReadResult readNode(const std::string&, const osgDB::Options *options) const;
     // virtual ReadResult readNode(std::istream& fin, const osgDB::Options* options) const;

--- a/src/osgPlugins/x/ReaderWriterDirectX.cpp
+++ b/src/osgPlugins/x/ReaderWriterDirectX.cpp
@@ -61,7 +61,18 @@ public:
         return "DirectX Reader";
     }
 
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    {
+        return readNode(fileName, options); 
+    }
+
     virtual ReadResult readNode(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const;
+
+    virtual ReadResult readObject(std::istream& fin, const Options* options) const
+    {
+        return readNode(fin,options);
+    }
+
     virtual ReadResult readNode(std::istream& fin, const osgDB::ReaderWriter::Options* options) const;
 
 private:

--- a/src/osgPlugins/zip/ReaderWriterZIP.cpp
+++ b/src/osgPlugins/zip/ReaderWriterZIP.cpp
@@ -106,6 +106,10 @@ class ReaderWriterZIP : public osgDB::ReaderWriter
             return result;
         }
 
+        virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+        {
+            return readNode(fileName, options); 
+        }
 
         virtual osgDB::ReaderWriter::ReadResult readNode(const std::string& file, const osgDB::ReaderWriter::Options* options) const
         {
@@ -130,6 +134,11 @@ class ReaderWriterZIP : public osgDB::ReaderWriter
             local_options->setDatabasePath(file);
 
             return readNodeFromArchive(*archive, local_options.get());
+        }
+
+        virtual ReadResult readObject(std::istream& fin, const Options* options) const
+        {
+            return readNode(fin,options);
         }
 
         virtual ReadResult readNode(std::istream& fin,const osgDB::ReaderWriter::Options* options) const


### PR DESCRIPTION
As noted before in PR https://github.com/openscenegraph/OpenSceneGraph/pull/752
"osgconv cow.osg.0,180,0.rot" fails with osgconv build from current OpenSceneGraph-3.6
To resolve this problem I've added readObject functions to the relevant readerWriters.
Only the changes to the osga readerwriter are non-trivial.

After creating the branch for a PR for the master branch I found that the change in osgconv that triggers this problem in not in the master branch, I suppose that is not intentional so I'll submit that PR as well.

Laurens.