### PR TITLE
fix typo in ReaderWriterFBX: writObject -> writeObject

### DIFF
--- a/src/osgPlugins/fbx/ReaderWriterFBX.h
+++ b/src/osgPlugins/fbx/ReaderWriterFBX.h
@@ -33,7 +33,7 @@ public:
         return readNode(filename, options);
     }
 
-    virtual WriteResult writObject(const osg::Node& node, const std::string& filename, const Options* options) const
+    virtual WriteResult writeObject(const osg::Node& node, const std::string& filename, const Options* options) const
     {
         return writeNode(node, filename, options);
     }


### PR DESCRIPTION
Hi Robert,
I noticed a type in the function name for fbx writeObject, and while I'm not sure if there is any code path that might call this function I suppose it's better to fix this anyway.
Laurens.