### PR TITLE
VertexArrayState's lazy disabling of vertex attributes mechanism major fix

### DIFF
--- a/src/osg/VertexArrayState.cpp
+++ b/src/osg/VertexArrayState.cpp
@@ -553,7 +553,19 @@ bool VertexArrayState::correctArrayDispatchAssigned(const ArrayDispatch* ad)
 #else
     return ad!=0;
 #endif
- }
+}
+
+namespace {
+    VertexArrayState::ArrayDispatch* getOrCreateVertexAttributeDispatch(VertexArrayState::ArrayDispatchList& list, int slot)
+    {
+        list.resize(slot + 1);
+        osg::ref_ptr<VertexArrayState::ArrayDispatch>& ad = list[slot];
+        if (!ad.valid())
+            ad = new VertexAttribArrayDispatch(slot);
+
+        return ad.get();
+    }
+}// anonumous namespace
 
 void VertexArrayState::assignVertexArrayDispatcher()
 {
@@ -567,9 +579,9 @@ void VertexArrayState::assignVertexArrayDispatcher()
     else
 #endif
     {
-        if (_vertexArray.valid()) return;
-        VAS_NOTICE<<"VertexArrayState::assignVertexArrayDispatcher() _state->getVertexAlias()._location="<<_state->getVertexAlias()._location<<std::endl;
-        _vertexArray = new VertexAttribArrayDispatch(_state->getVertexAlias()._location);
+        int slot = _state->getVertexAlias()._location;
+        VAS_NOTICE << "VertexArrayState::assignVertexArrayDispatcher() _state->getVertexAlias()._location = " << slot << std::endl;
+        _vertexArray = getOrCreateVertexAttributeDispatch(_vertexAttribArrays, slot);
     }
 }
 
@@ -585,8 +597,9 @@ void VertexArrayState::assignNormalArrayDispatcher()
     else
 #endif
     {
-        VAS_NOTICE<<"VertexArrayState::assignNormalArrayDispatcher() _state->getNormalAlias()._location="<<_state->getNormalAlias()._location<<std::endl;
-        _normalArray = new VertexAttribArrayDispatch(_state->getNormalAlias()._location);
+        int slot = _state->getNormalAlias()._location;
+        VAS_NOTICE << "VertexArrayState::assignNormalArrayDispatcher() _state->getNormalAlias()._location = " << slot << std::endl;
+        _normalArray = getOrCreateVertexAttributeDispatch(_vertexAttribArrays, slot);
     }
 }
 
@@ -602,8 +615,9 @@ void VertexArrayState::assignColorArrayDispatcher()
     else
 #endif
     {
-        VAS_NOTICE<<"VertexArrayState::assignColorArrayDispatcher() _state->getColorAlias()._location="<<_state->getColorAlias()._location<<std::endl;
-        _colorArray = new VertexAttribArrayDispatch(_state->getColorAlias()._location);
+        int slot = _state->getColorAlias()._location;
+        VAS_NOTICE << "VertexArrayState::assignColorArrayDispatcher() _state->getColorAlias()._location = " << slot << std::endl;
+        _colorArray = getOrCreateVertexAttributeDispatch(_vertexAttribArrays, slot);
     }
 }
 
@@ -619,7 +633,9 @@ void VertexArrayState::assignSecondaryColorArrayDispatcher()
     else
 #endif
     {
-        _secondaryColorArray = new VertexAttribArrayDispatch(_state->getSecondaryColorAlias()._location);
+        int slot = _state->getSecondaryColorAlias()._location;
+        VAS_NOTICE << "VertexArrayState::assignSecondaryColorArrayDispatcher() _state->getSecondaryColorAlias()._location = " << slot << std::endl;
+        _secondaryColorArray = getOrCreateVertexAttributeDispatch(_vertexAttribArrays, slot);
     }
 }
 
@@ -635,7 +651,9 @@ void VertexArrayState::assignFogCoordArrayDispatcher()
     else
 #endif
     {
-        _fogCoordArray = new VertexAttribArrayDispatch(_state->getFogCoordAlias()._location);
+        int slot = _state->getFogCoordAlias()._location;
+        VAS_NOTICE << "VertexArrayState::assignFogCoordArrayDispatcher() _state->getFogCoordAlias()._location = " << slot << std::endl;
+        _fogCoordArray = getOrCreateVertexAttributeDispatch(_vertexAttribArrays, slot);
     }
 }
 
@@ -655,7 +673,9 @@ void VertexArrayState::assignTexCoordArrayDispatcher(unsigned int numUnits)
         else
 #endif
         {
-            _texCoordArrays[i] = new VertexAttribArrayDispatch(_state->getTexCoordAliasList()[i]._location);
+            int slot = _state->getTexCoordAliasList()[i]._location;
+            VAS_NOTICE << "VertexArrayState::assignTexCoordArrayDispatcher() _state->getTexCoordAliasList()[" << i << "]._location = " << slot << std::endl;
+            _texCoordArrays[i] = getOrCreateVertexAttributeDispatch(_vertexAttribArrays, slot);
         }
     }
 }
@@ -677,13 +697,14 @@ void VertexArrayState::assignAllDispatchers()
     unsigned int numUnits = 8;
     unsigned int numVertexAttrib = 16;
 
+    assignVertexAttribArrayDispatcher(numVertexAttrib);
+
     assignVertexArrayDispatcher();
     assignNormalArrayDispatcher();
     assignColorArrayDispatcher();
     assignSecondaryColorArrayDispatcher();
     assignFogCoordArrayDispatcher();
     assignTexCoordArrayDispatcher(numUnits);
-    assignVertexAttribArrayDispatcher(numVertexAttrib);
 }
 
 void VertexArrayState::release()

--- a/src/osg/VertexArrayState.cpp
+++ b/src/osg/VertexArrayState.cpp
@@ -565,7 +565,7 @@ namespace {
 
         return ad.get();
     }
-}// anonumous namespace
+}// anonymous namespace
 
 void VertexArrayState::assignVertexArrayDispatcher()
 {


### PR DESCRIPTION
_vertexAttribArrays must be 'shared'

NOTE: Issue #439 will be really fixed ;)
