### PR TITLE
Removed line that forces to store all images in the object cache.

### DIFF
--- a/src/osgPlugins/fbx/ReaderWriterFBX.cpp
+++ b/src/osgPlugins/fbx/ReaderWriterFBX.cpp
@@ -308,7 +308,6 @@ ReaderWriterFBX::readNode(const std::string& filenameInit,
                 localOptions = options->cloneOptions();
             else
                 localOptions = new osgDB::Options();
-            localOptions->setObjectCacheHint(osgDB::ReaderWriter::Options::CACHE_IMAGES);
 
             std::string filePath = osgDB::getFilePath(filename);
             FbxMaterialToOsgStateSet fbxMaterialToOsgStateSet(filePath, localOptions.get(), lightmapTextures);


### PR DESCRIPTION
Setting the objectCacheHint to always store the images in the cache can lead to problems with excessive memory usage when dealing with large models with multiple textures. By removing this line, it's up to the caller of the method to configure the options if he wants to store the images in the object cache.