### PR TITLE
ParticleSystem serializer: added missing osg::Node to the derivation chain

### DIFF
--- a/src/osgWrappers/serializers/osgParticle/ParticleSystem.cpp
+++ b/src/osgWrappers/serializers/osgParticle/ParticleSystem.cpp
@@ -58,7 +58,7 @@ static bool writeDefaultParticleTemplate( osgDB::OutputStream& os, const osgPart
 REGISTER_OBJECT_WRAPPER( osgParticleParticleSystem,
                          new osgParticle::ParticleSystem,
                          osgParticle::ParticleSystem,
-                         "osg::Object osg::Drawable osgParticle::ParticleSystem" )
+                         "osg::Object osg::Node osg::Drawable osgParticle::ParticleSystem" )
 {
     ADD_USER_SERIALIZER( DefaultBoundingBox );  // _def_bbox
 


### PR DESCRIPTION
missing osg::Node prevents correct serialization, for instance if a stateset is attached to the ParticleSystem