### PR TITLE
Fix not checking num lock state when remapping keypad keys on Windows.

### DIFF
--- a/src/osgViewer/GraphicsWindowWin32.cpp
+++ b/src/osgViewer/GraphicsWindowWin32.cpp
@@ -688,6 +688,16 @@ class Win32KeyboardMap
 static Win32KeyboardMap s_win32KeyboardMap;
 static int remapWin32Key(int key)
 {
+    bool numlockIsActive = static_cast<bool>(GetKeyState(VK_NUMLOCK) & 0x1);
+    if (numlockIsActive)
+    {
+        if (key >= VK_NUMPAD0 && key <= VK_NUMPAD9)
+            return key - VK_NUMPAD0 + osgGA::GUIEventAdapter::KEY_KP_0;
+
+        if (key == VK_DECIMAL)
+            return osgGA::GUIEventAdapter::KEY_KP_Decimal;
+    }
+
     return s_win32KeyboardMap.remapKey(key);
 }
 


### PR DESCRIPTION
Num lock state was never checked during remapping keypad keys on Windows. Now when num lock is  active, keypad numeric keys and keypad delimeter key should work as expected (return KEY_KP_0 to KEY_KP_9 and KEY_KP_Decimal respectivly).