### PR TITLE
Minor fixes to readers

### DIFF
--- a/src/osgPlugins/ac/ac3d.cpp
+++ b/src/osgPlugins/ac/ac3d.cpp
@@ -45,6 +45,7 @@ namespace ac3d {
 osg::Node*
 readFile(std::istream& stream, const osgDB::ReaderWriter::Options* options);
 
+static std::string ac3dSrcFilename;
 }
 
 class geodeVisitor : public osg::NodeVisitor { // collects geodes from scene sub-graph attached to 'this'
@@ -108,6 +109,7 @@ class ReaderWriterAC : public osgDB::ReaderWriter
                 local_opt = new Options;
             local_opt->getDatabasePathList().push_back(osgDB::getFilePath(fileName));
 
+            ac3d::ac3dSrcFilename = fileName;
             ReadResult result = readNode(fin, local_opt.get());
             if (result.validNode())
                 result.getNode()->setName(fileName);
@@ -1344,6 +1346,8 @@ readObject(std::istream& stream, FileData& fileData, const osg::Matrix& parentTr
                     // in case this is an invalid refs count for this primitive
                     // read further, but do not store that primitive
                     bool acceptPrimitive = primitiveBin->beginPrimitive(nRefs);
+                    if(!acceptPrimitive)
+                        OSG_WARN << ac3d::ac3dSrcFilename <<": -- primitive not accepted object " << group->getName() << std::endl;
                     for (unsigned i = 0; i < nRefs; ++i) {
                         // Read the vertex index
                         unsigned index;

--- a/src/osgPlugins/dds/ReaderWriterDDS.cpp
+++ b/src/osgPlugins/dds/ReaderWriterDDS.cpp
@@ -1417,7 +1417,13 @@ public:
                 }
             }
         }
+        // in the case of a .dds.gz the name of the image will blank
+        // so if the options has a name then use this (set in the DDS reader)
+        // for the image filename
+        if (options && !options->getName().empty()) {
+            if (osgImage->valid()) osgImage->setFileName(options->getName());
 
+        }
         return osgImage;
     }
 

--- a/src/osgPlugins/gz/ReaderWriterGZ.cpp
+++ b/src/osgPlugins/gz/ReaderWriterGZ.cpp
@@ -241,6 +241,8 @@ osgDB::ReaderWriter::ReadResult ReaderWriterGZ::readFile(ObjectType objectType, 
     std::stringstream strstream;
     read(fin, strstream);
 
+    local_opt.get()->setName(fileName);
+
     return readFile(objectType, rw, strstream, local_opt.get());
 }
 


### PR DESCRIPTION
AC3D reader: display filename and object when primitive not accepted.

Aids locating the cause of the problem. (e.g. not enough vertices).

.dds.gz retain original filename.

The original filename is lost during the filename.gz.dds to filename.gz load process; this change stores the filename in the options name and sets the image name after load.