### PR TITLE
Fixed bug where FFmpeg Image Stream would stop if paused for more tha…

### DIFF
--- a/src/osgPlugins/ffmpeg/FFmpegImageStream.cpp
+++ b/src/osgPlugins/ffmpeg/FFmpegImageStream.cpp
@@ -305,6 +305,8 @@ void FFmpegImageStream::cmdPlay()
 
         m_decoder->video_decoder().pause(false);
         m_decoder->audio_decoder().pause(false);
+        
+        _lastUpdateTS = 0.;
     }
 
     _status = PLAYING;


### PR DESCRIPTION
…n 10 seconds

The FFmpeg image stream class uses a 10 second timeout between frames to determine if the stream is dead and if so closes it. However, the timeout is determined using the variable lastUpdateTS which stores the last time the publishNewFrame function was called, and if the video has been playing and then is paused for longer than 10 seconds, when it is unpaused this timeout will fire and the stream will be closed, stopping the video playing beyond what has been buffered.

To stop this timeout from happening before the video starts playing, the timeout checks to see if the lastUpdateTS > 0 (at initialization it is set to 0). In this fix, we simply set the value of lastUpdateTS to 0 when the video is unpaused, this will force the check to skip on unpause, and from then on lastUpdateTS will have the correct value again.

The lastUpdateTS variable is private and only used for this one function, so there should be no side effects from the change.