### PR TITLE
Fix wxWidgets COMPONENTS specification, deprecated usage broken with CMake 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -789,9 +789,7 @@ IF(BUILD_OSG_EXAMPLES AND NOT ANDROID)
 
     FIND_PACKAGE(FLTK)
     FIND_PACKAGE(FOX)
-
-    SET(wxWidgets_USE_LIBS base core gl net)
-    FIND_PACKAGE(wxWidgets)
+    FIND_PACKAGE(wxWidgets COMPONENTS base core gl net)
 
 ENDIF()
 


### PR DESCRIPTION
Current FindWxWidgets.cmake allows to specify OPTIONAL components, unfortunately
this broke the (deprecated) use of wxWidgets_USE_LIBS.

Fixes: #779