### PR TITLE
make FrameBufferObject::releaseGLObjects call releaseGLObjects on it's _attachments

### DIFF
--- a/src/osg/FrameBufferObject.cpp
+++ b/src/osg/FrameBufferObject.cpp
@@ -594,6 +594,14 @@ void FrameBufferObject::resizeGLObjectBuffers(unsigned int maxSize)
     _fboID.resize(maxSize);
     _unsupported.resize(maxSize);
     _fboID.resize(maxSize);
+    for (AttachmentMap::iterator i = _attachments.begin(); i != _attachments.end(); ++i)
+    {
+        FrameBufferAttachment &fa = i->second;
+        Texture* tex = fa.getTexture();
+        if (tex) tex->resizeGLObjectBuffers(maxSize);
+        RenderBuffer* rb = fa.getRenderBuffer();
+        if (rb) rb->resizeGLObjectBuffers(maxSize);
+    }
 }
 
 void FrameBufferObject::releaseGLObjects(osg::State* state) const
@@ -617,6 +625,14 @@ void FrameBufferObject::releaseGLObjects(osg::State* state) const
                 _fboID[i] = 0;
             }
         }
+    }
+    for (AttachmentMap::const_iterator i = _attachments.begin(); i != _attachments.end(); ++i)
+    {
+        const FrameBufferAttachment &fa = i->second;
+        const Texture* tex = fa.getTexture();
+        if (tex) tex->releaseGLObjects(state);
+        const RenderBuffer* rb = fa.getRenderBuffer();
+        if (rb) rb->releaseGLObjects(state);
     }
 }
 


### PR DESCRIPTION
Hi Robert,
At the moment I wanted to report the 3.6.4 version on windows has been without problems for me I did a final update... and got a crash on program exit.
To problem I see is the destructor ~GraphicsObjectManager() trying to log an OSG_INFO message after the 
static NotifySingleton s_NotifySingleton
was already destroyed, causing an invalid pointer dereference. 
This happens in the osg159-osgd.dll!`dynamic atexit destructor for 's_contextIDMap''()	

A very naive fix would be to comment out the OSG_INFO message in the GraphicsObjectManager destructor (OpenSceneGraph\src\osg\GLObjects.cpp line 70) which might also be a good idea, but I did a bit of digging to get to the source of the problem, and came up with these results.

When I close the programs' window, the graphics context is destroyed first. The ContextData in the s_contextIDMap is destroyed in ContextData::decrementContextIDUsageCount as it's getNumContexts() now returns zero.
But when the viewer and scenegraph are destroyed, the scenegraph objects cause a new ContextData to be made in the s_contextIDMap in order to cue the deletion of RenderBuffer's openGL objects.

While I have managed to destroy the ContextData in the s_contextIDMap with an explicit call to
osg::ContextData::decrementContextIDUsageCount(0);
at the end of my program (after releasing all ref_ptrs to all nodes and shaders) I think the real solution is different:

the FrameBufferObject needs to call releaseGLObjects on it's attachments. For symetry I added the same calls for resizeGLObjectBuffers - as I think that's appropriate.
Regards, Laurens