### PR TITLE
Avoid that mingw cross-compilation choosing X11 as the windowing system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ IF(APPLE)
     OSG_OSX_VERSION "${OSG_OSX_VERSION}")
 ENDIF()
 
+PROJECT(OpenSceneGraph)
+
 # Set OSX architecture flags here, since they must be specified before
 # creating the actual OSG project.
 # Note that the CMAKE_OSX_* variables are not well documented in
@@ -51,7 +53,7 @@ ENDIF()
 
 IF(ANDROID)
     SET(OSG_WINDOWING_SYSTEM "None" CACHE STRING "Windowing system type for graphics window creation; options: None.")
-ELSEIF(WIN32)
+ELSEIF(WIN32 OR MINGW)
     SET(OSG_WINDOWING_SYSTEM "Win32" CACHE STRING "Windowing system type for graphics window creation; options: Win32 or None.")
 ELSEIF(APPLE)
     # custom option to flag an iOS build
@@ -115,8 +117,6 @@ ELSE()
     SET(OSG_WINDOWING_SYSTEM "X11" CACHE STRING "Windowing system type for graphics window creation; options: X11 or None.")
 ENDIF()
 
-
-PROJECT(OpenSceneGraph)
 
 SET(OPENSCENEGRAPH_VERSION ${OPENSCENEGRAPH_MAJOR_VERSION}.${OPENSCENEGRAPH_MINOR_VERSION}.${OPENSCENEGRAPH_PATCH_VERSION})
 


### PR DESCRIPTION
I have moved the `PROJECT` stanza before the conditionals, because
otherwise expressions like `IF(MINGW)` always fail.