### PR TITLE
fix obj-Plugin export texture file

### DIFF
--- a/src/osgPlugins/obj/OBJWriterNodeVisitor.cpp
+++ b/src/osgPlugins/obj/OBJWriterNodeVisitor.cpp
@@ -521,7 +521,7 @@ void OBJWriterNodeVisitor::processStateSet(osg::StateSet* ss)
 
     if (mat || tex)
     {
-        _materialMap.insert(std::make_pair(osg::ref_ptr<osg::StateSet>(ss), OBJMaterial(mat, tex)));
+        _materialMap.insert(std::make_pair(osg::ref_ptr<osg::StateSet>(ss), OBJMaterial(mat, tex, _options)));
         _fout << "usemtl " << _materialMap[ss].name << std::endl;
     }
 

--- a/src/osgPlugins/obj/OBJWriterNodeVisitor.cpp
+++ b/src/osgPlugins/obj/OBJWriterNodeVisitor.cpp
@@ -18,7 +18,7 @@
 
 #include <osg/io_utils>
 #include "OBJWriterNodeVisitor.h"
-
+#include <osgDB/WriteFile>
 
 
 /** writes all values of an array out to a stream, applies a matrix beforehand if necessary */
@@ -420,7 +420,7 @@ void ObjPrimitiveIndexWriter::drawArrays(GLenum mode,GLint first,GLsizei count)
 }
 
 
-OBJWriterNodeVisitor::OBJMaterial::OBJMaterial(osg::Material* mat, osg::Texture* tex) :
+OBJWriterNodeVisitor::OBJMaterial::OBJMaterial(osg::Material* mat, osg::Texture* tex, const osgDB::Options* options) :
     diffuse(1,1,1,1),
     ambient(0.2,0.2,0.2,1),
     specular(0,0,0,1),
@@ -440,9 +440,10 @@ OBJWriterNodeVisitor::OBJMaterial::OBJMaterial(osg::Material* mat, osg::Texture*
 
     if (tex) {
         osg::Image* img = tex->getImage(0);
-        if ((img) && (!img->getFileName().empty()))
-            image = img->getFileName();
-
+		if ((img) && (!img->getFileName().empty())) {
+			image = img->getFileName();
+			osgDB::writeImageFile(*img, image, options);
+		}
     }
 
 }

--- a/src/osgPlugins/obj/OBJWriterNodeVisitor.cpp
+++ b/src/osgPlugins/obj/OBJWriterNodeVisitor.cpp
@@ -420,7 +420,7 @@ void ObjPrimitiveIndexWriter::drawArrays(GLenum mode,GLint first,GLsizei count)
 }
 
 
-OBJWriterNodeVisitor::OBJMaterial::OBJMaterial(osg::Material* mat, osg::Texture* tex, const osgDB::Options* options) :
+OBJWriterNodeVisitor::OBJMaterial::OBJMaterial(osg::Material* mat, osg::Texture* tex, bool outputTextureFiles, const osgDB::Options* options) :
     diffuse(1,1,1,1),
     ambient(0.2,0.2,0.2,1),
     specular(0,0,0,1),
@@ -442,7 +442,8 @@ OBJWriterNodeVisitor::OBJMaterial::OBJMaterial(osg::Material* mat, osg::Texture*
         osg::Image* img = tex->getImage(0);
 		if ((img) && (!img->getFileName().empty())) {
 			image = img->getFileName();
-			osgDB::writeImageFile(*img, image, options);
+			if(outputTextureFiles)
+				osgDB::writeImageFile(*img, image, options);
 		}
     }
 
@@ -521,7 +522,7 @@ void OBJWriterNodeVisitor::processStateSet(osg::StateSet* ss)
 
     if (mat || tex)
     {
-        _materialMap.insert(std::make_pair(osg::ref_ptr<osg::StateSet>(ss), OBJMaterial(mat, tex, _options)));
+        _materialMap.insert(std::make_pair(osg::ref_ptr<osg::StateSet>(ss), OBJMaterial(mat, tex, _outputTextureFiles, _options)));
         _fout << "usemtl " << _materialMap[ss].name << std::endl;
     }
 

--- a/src/osgPlugins/obj/OBJWriterNodeVisitor.h
+++ b/src/osgPlugins/obj/OBJWriterNodeVisitor.h
@@ -50,13 +50,14 @@
 class OBJWriterNodeVisitor: public osg::NodeVisitor {
 
     public:
-        OBJWriterNodeVisitor(std::ostream& fout, const std::string materialFileName = "", const osgDB::Options* options = NULL) :
+        OBJWriterNodeVisitor(std::ostream& fout, const std::string materialFileName = "", bool outputTextureFiles = false, const osgDB::Options* options = NULL) :
             osg::NodeVisitor(osg::NodeVisitor::TRAVERSE_ALL_CHILDREN),
             _fout(fout),
             _currentStateSet(new osg::StateSet()),
             _lastVertexIndex(1),
             _lastNormalIndex(1),
 			_lastTexIndex(1),
+			_outputTextureFiles(outputTextureFiles),
 			_options(options)
         {
             _fout << "# file written by OpenSceneGraph" << std::endl << std::endl;
@@ -114,7 +115,7 @@ class OBJWriterNodeVisitor: public osg::NodeVisitor {
         class OBJMaterial {
             public:
                 OBJMaterial() {}
-                OBJMaterial(osg::Material* mat, osg::Texture* tex, const osgDB::Options* options);
+                OBJMaterial(osg::Material* mat, osg::Texture* tex, bool outputTextureFiles = false, const osgDB::Options* options = NULL);
 
                 osg::Vec4  diffuse, ambient, specular;
                 std::string    image;
@@ -154,6 +155,7 @@ class OBJWriterNodeVisitor: public osg::NodeVisitor {
         std::map<std::string, unsigned int>        _nameMap;
         unsigned int                            _lastVertexIndex, _lastNormalIndex, _lastTexIndex;
         MaterialMap                                _materialMap;
+		bool                                    _outputTextureFiles;
 		osg::ref_ptr<const osgDB::Options>      _options;
 
 };

--- a/src/osgPlugins/obj/OBJWriterNodeVisitor.h
+++ b/src/osgPlugins/obj/OBJWriterNodeVisitor.h
@@ -50,13 +50,14 @@
 class OBJWriterNodeVisitor: public osg::NodeVisitor {
 
     public:
-        OBJWriterNodeVisitor(std::ostream& fout, const std::string materialFileName = "") :
+        OBJWriterNodeVisitor(std::ostream& fout, const std::string materialFileName = "", const osgDB::Options* options = NULL) :
             osg::NodeVisitor(osg::NodeVisitor::TRAVERSE_ALL_CHILDREN),
             _fout(fout),
             _currentStateSet(new osg::StateSet()),
             _lastVertexIndex(1),
             _lastNormalIndex(1),
-            _lastTexIndex(1)
+			_lastTexIndex(1),
+			_options(options)
         {
             _fout << "# file written by OpenSceneGraph" << std::endl << std::endl;
 
@@ -113,7 +114,7 @@ class OBJWriterNodeVisitor: public osg::NodeVisitor {
         class OBJMaterial {
             public:
                 OBJMaterial() {}
-                OBJMaterial(osg::Material* mat, osg::Texture* tex);
+                OBJMaterial(osg::Material* mat, osg::Texture* tex, const osgDB::Options* options);
 
                 osg::Vec4  diffuse, ambient, specular;
                 std::string    image;
@@ -153,6 +154,7 @@ class OBJWriterNodeVisitor: public osg::NodeVisitor {
         std::map<std::string, unsigned int>        _nameMap;
         unsigned int                            _lastVertexIndex, _lastNormalIndex, _lastTexIndex;
         MaterialMap                                _materialMap;
+		osg::ref_ptr<const osgDB::Options>      _options;
 
 };
 

--- a/src/osgPlugins/obj/ReaderWriterOBJ.cpp
+++ b/src/osgPlugins/obj/ReaderWriterOBJ.cpp
@@ -102,7 +102,7 @@ public:
         f.precision(localOptions.precision);
 
         std::string materialFile = osgDB::getNameLessExtension(fileName) + ".mtl";
-        OBJWriterNodeVisitor nv(f, osgDB::getSimpleFileName(materialFile));
+        OBJWriterNodeVisitor nv(f, osgDB::getSimpleFileName(materialFile), options);
 
         // we must cast away constness
         (const_cast<osg::Node*>(&node))->accept(nv);
@@ -130,7 +130,7 @@ public:
 
         // writing to a stream does not support materials
 
-        OBJWriterNodeVisitor nv(fout);
+        OBJWriterNodeVisitor nv(fout, "", options);
 
         // we must cast away constness
         (const_cast<osg::Node*>(&node))->accept(nv);

--- a/src/osgPlugins/obj/ReaderWriterOBJ.cpp
+++ b/src/osgPlugins/obj/ReaderWriterOBJ.cpp
@@ -74,6 +74,7 @@ public:
         supportsOption("REFLECTION=<unit>", "Set texture unit for reflection texture");
 
         supportsOption("precision=<digits>","Set the floating point precision when writing out files");
+		supportsOption("OutputTextureFiles", "Write out the texture images to file");
     }
 
     virtual const char* className() const { return "Wavefront OBJ Reader"; }
@@ -102,7 +103,7 @@ public:
         f.precision(localOptions.precision);
 
         std::string materialFile = osgDB::getNameLessExtension(fileName) + ".mtl";
-        OBJWriterNodeVisitor nv(f, osgDB::getSimpleFileName(materialFile), options);
+        OBJWriterNodeVisitor nv(f, osgDB::getSimpleFileName(materialFile), localOptions.outputTextureFiles, options);
 
         // we must cast away constness
         (const_cast<osg::Node*>(&node))->accept(nv);
@@ -130,7 +131,7 @@ public:
 
         // writing to a stream does not support materials
 
-        OBJWriterNodeVisitor nv(fout, "", options);
+        OBJWriterNodeVisitor nv(fout, "", localOptions.outputTextureFiles, options);
 
         // we must cast away constness
         (const_cast<osg::Node*>(&node))->accept(nv);
@@ -156,6 +157,7 @@ protected:
         TextureAllocationMap textureUnitAllocation;
         /// Coordinates precision.
         int precision;
+		bool outputTextureFiles;
 
         ObjOptionsStruct()
         {
@@ -166,6 +168,7 @@ protected:
             fixBlackMaterials = true;
             noReverseFaces = false;
             precision = std::numeric_limits<double>::digits10 + 2;
+			outputTextureFiles = false;
         }
     };
 
@@ -877,6 +880,10 @@ ReaderWriterOBJ::ObjOptionsStruct ReaderWriterOBJ::parseOptions(const osgDB::Rea
             {
                 localOptions.noReverseFaces = true;
             }
+			else if (pre_equals == "OutputTextureFiles")
+			{
+				localOptions.outputTextureFiles = true;
+			}
             else if (pre_equals == "precision")
             {
                 int val = std::atoi(post_equals.c_str());


### PR DESCRIPTION
When using osgconv to convert an osgb file into an obj file, you cannot export the texture file contained in it, even if -O OutputTextureFiles is added.
So I modified the obj plugin to support the export of texture files.
