### PR TITLE
OSG_TEXT_USE_FONTCONFIG cmake option added: Set to ON to enable attem…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,12 @@ ENDIF()
 
 OPTION(OSG_GL_LIBRARY_STATIC "Set to ON to statically link with OpenGL/GLES library." OFF)
 
+IF (OSG_BUILD_PLATFORM_IPHONE OR ANDROID)
+    OPTION(OSG_TEXT_USE_FONTCONFIG "Set to ON to enable attempt to use FontConfig in osgText." OFF)
+ELSE ()
+    OPTION(OSG_TEXT_USE_FONTCONFIG "Set to OFF to disable attempt to use FontConfig in osgText." ON)
+ENDIF ()
+
 # Map the OSG_GL*_AVAILABLE settings to OSG_GL_* settings
 IF (OSG_GLES2_AVAILABLE OR OSG_GLES3_AVAILABLE OR OSG_GL3_AVAILABLE)
     OPTION(OSG_GL_DISPLAYLISTS_AVAILABLE "Set to OFF to disable use of OpenGL display lists." OFF)

--- a/src/osgText/CMakeLists.txt
+++ b/src/osgText/CMakeLists.txt
@@ -50,7 +50,7 @@ SET(TARGET_LIBRARIES
     OpenThreads
 )
 
-if(Fontconfig_FOUND)
+if(OSG_TEXT_USE_FONTCONFIG AND Fontconfig_FOUND)
     MESSAGE(STATUS "osgText will be linked with FontConfig library")
     list(APPEND TARGET_LIBRARIES Fontconfig::Fontconfig)
     ADD_DEFINITIONS(-DWITH_FONTCONFIG)

--- a/src/osgText/CMakeLists.txt
+++ b/src/osgText/CMakeLists.txt
@@ -1,4 +1,4 @@
-IF(NOT OSG_BUILD_PLATFORM_IPHONE AND NOT ANDROID)
+IF(OSG_TEXT_USE_FONTCONFIG)
     find_package(Fontconfig MODULE)
 ENDIF()
 
@@ -51,8 +51,11 @@ SET(TARGET_LIBRARIES
 )
 
 if(Fontconfig_FOUND)
+    MESSAGE(STATUS "osgText will be linked with FontConfig library")
     list(APPEND TARGET_LIBRARIES Fontconfig::Fontconfig)
     ADD_DEFINITIONS(-DWITH_FONTCONFIG)
+else()
+    MESSAGE(STATUS "osgText will not be linked with FontConfig library")
 endif()
 
 SETUP_LIBRARY(${LIB_NAME})


### PR DESCRIPTION
…pt to use FontConfig in osgText; Disabled by default for iOS and Android