### PR TITLE
[*] ParticleSystem: Use GL_TRIANGLES instead if GL_QUADS when GL{1,2}…

### DIFF
--- a/src/osgParticle/ParticleSystem.cpp
+++ b/src/osgParticle/ParticleSystem.cpp
@@ -411,7 +411,7 @@ void osgParticle::ParticleSystem::drawImplementation(osg::RenderInfo& renderInfo
                         texcoords.push_back(t1);
                         texcoords.push_back(t2);
 
-#if !defined(OSG_GLES2_AVAILABLE)
+#if defined(OSG_GL1_AVAILABLE) || defined(OSG_GL2_AVAILABLE) || defined(OSG_GLES1_AVAILABLE)
                         const unsigned int count = 4;
                         const GLenum mode = GL_QUADS;
 
@@ -419,7 +419,7 @@ void osgParticle::ParticleSystem::drawImplementation(osg::RenderInfo& renderInfo
                         vertices.push_back(c3);
                         texcoords.push_back(t3);
 #else
-                        // No GL_QUADS mode on GLES2 and upper
+                        // No GL_QUADS mode on OpenGL 3 and upper / GLES2 and upper
                         const unsigned int count = 6;
                         const GLenum mode = GL_TRIANGLES;
 


### PR DESCRIPTION
… or GLES1 are unavailable