### PR TITLE
DDS plugin: add support for DDPF_PALETTEINDEXED8 pixel format reading

### DIFF
--- a/src/osgPlugins/dds/ReaderWriterDDS.cpp
+++ b/src/osgPlugins/dds/ReaderWriterDDS.cpp
@@ -222,6 +222,7 @@ struct DXT1TexelsBlock
 //
 #define DDPF_ALPHAPIXELS        0x00000001l
 #define DDPF_FOURCC             0x00000004l        // Compressed formats
+#define DDPF_PALETTEINDEXED8    0x00000020l
 #define DDPF_RGB                0x00000040l        // Uncompressed formats
 #define DDPF_ALPHA              0x00000002l
 #define DDPF_COMPRESSED         0x00000080l
@@ -944,6 +945,12 @@ osg::Image* ReadDDSFile(std::istream& _istream, bool flipDDSRead)
             internalFormat = GL_ALPHA;
             pixelFormat    = GL_ALPHA;
     }
+    else if (ddsd.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8)
+    {
+            OSG_INFO << "ReadDDSFile info : format = PALETTEINDEXED8" << std::endl;
+            // The indexed data needs to first be loaded as a single-component image.
+            pixelFormat = GL_RED;
+    }
     else
     {
         OSG_WARN << "ReadDDSFile warning: unhandled pixel format (ddsd.ddpfPixelFormat.dwFlags"
@@ -984,6 +991,17 @@ osg::Image* ReadDDSFile(std::istream& _istream, bool flipDDSRead)
 
    OSG_INFO<<"ReadDDS, dataType = 0x"<<std::hex<<dataType<<std::endl;
 
+    unsigned char* palette = new unsigned char [1024];
+    if (ddsd.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8)
+    {
+        if (!_istream.read((char*)palette, 1024))
+        {
+            delete [] palette;
+            OSG_WARN << "ReadDDSFile warning: couldn't read palette" << std::endl;
+            return NULL;
+        }
+    }
+
     unsigned char* imageData = new unsigned char [sizeWithMipmaps];
     if(!imageData)
     {
@@ -1010,7 +1028,27 @@ osg::Image* ReadDDSFile(std::istream& _istream, bool flipDDSRead)
         // this memory will not be used but it will not cause leak in worst meaning of this word.
     }
 
-    osgImage->setImage(s,t,r, internalFormat, pixelFormat, dataType, imageData, osg::Image::USE_NEW_DELETE, packing);
+    if (ddsd.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8)
+    {
+        // Now we need to substitute the indexed image data with full RGBA image data.
+        unsigned char* convertedData = new unsigned char [sizeWithMipmaps * 4];
+        for (unsigned int i = 0; i < sizeWithMipmaps; i++)
+        {
+            convertedData[i * 4 + 0] = palette[imageData[i] * 4 + 0];
+            convertedData[i * 4 + 1] = palette[imageData[i] * 4 + 1];
+            convertedData[i * 4 + 2] = palette[imageData[i] * 4 + 2];
+            convertedData[i * 4 + 3] = palette[imageData[i] * 4 + 3];
+        }
+        for (unsigned int i = 0; i < mipmap_offsets.size(); i++)
+            mipmap_offsets[i] *= 4;
+        internalFormat = GL_RGBA;
+        pixelFormat = GL_RGBA;
+        osgImage->setImage(s,t,r, internalFormat, pixelFormat, dataType, convertedData, osg::Image::USE_NEW_DELETE, packing);
+    }
+    else
+    {
+        osgImage->setImage(s,t,r, internalFormat, pixelFormat, dataType, imageData, osg::Image::USE_NEW_DELETE, packing);
+    }
 
     if (mipmap_offsets.size()>0) osgImage->setMipmapLevels(mipmap_offsets);
 

--- a/src/osgPlugins/dds/ReaderWriterDDS.cpp
+++ b/src/osgPlugins/dds/ReaderWriterDDS.cpp
@@ -991,12 +991,11 @@ osg::Image* ReadDDSFile(std::istream& _istream, bool flipDDSRead)
 
    OSG_INFO<<"ReadDDS, dataType = 0x"<<std::hex<<dataType<<std::endl;
 
-    unsigned char* palette = new unsigned char [1024];
+    unsigned char palette [1024];
     if (ddsd.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8)
     {
         if (!_istream.read((char*)palette, 1024))
         {
-            delete [] palette;
             OSG_WARN << "ReadDDSFile warning: couldn't read palette" << std::endl;
             return NULL;
         }
@@ -1039,6 +1038,7 @@ osg::Image* ReadDDSFile(std::istream& _istream, bool flipDDSRead)
             convertedData[i * 4 + 2] = palette[imageData[i] * 4 + 2];
             convertedData[i * 4 + 3] = palette[imageData[i] * 4 + 3];
         }
+        delete [] imageData;
         for (unsigned int i = 0; i < mipmap_offsets.size(); i++)
             mipmap_offsets[i] *= 4;
         internalFormat = GL_RGBA;


### PR DESCRIPTION
So I've added in support for reading this rather obscure format by reconstructing the image data into a full-sized RGBA image. Used the GIMP DDS plugin for reference, apparently the 256 color palette is put right after the header. Alpha flag is never used.

I used these images to test it.
[examples.zip](https://github.com/openscenegraph/OpenSceneGraph/files/3511525/examples.zip)