### PR TITLE
add custom uniform locations

### DIFF
--- a/include/osg/Program
+++ b/include/osg/Program
@@ -156,8 +156,6 @@ class OSG_EXPORT Program : public osg::StateAttribute
         ShaderDefines& getShaderDefines() { return _shaderDefines; }
         const ShaderDefines& getShaderDefines() const { return _shaderDefines; }
 
-
-
         /** Simple class for wrapping up the data used in glProgramBinary and glGetProgramBinary.
           * On the first run of your application Programs should be assigned an empty ProgramBinary.
           * Before your application exits it should retrieve the program binary via
@@ -227,6 +225,18 @@ class OSG_EXPORT Program : public osg::StateAttribute
 
         /** Query InfoLog from a glProgram */
         bool getGlProgramInfoLog(unsigned int contextID, std::string& log) const;
+
+        struct ExtraUniformLocation {
+            ExtraUniformLocation() : _locationname(""), _type(Uniform::UNDEFINED), _size(-1) {}
+            ExtraUniformLocation( std::string locname, GLenum type, GLint size ) : _locationname(locname), _type(type), _size(size) {}
+            std::string _locationname;
+            GLenum _type;
+            GLint _size;
+        };
+        void addExtraUniformLocation(ExtraUniformLocation loc) { _extrauniformlocations.push_back(loc); }
+        void removeExtraUniformLocation(unsigned int index) { _extrauniformlocations.erase(_extrauniformlocations.begin()+index); }
+        const ExtraUniformLocation& getExtraUniformLocation(unsigned int index) const { return _extrauniformlocations[index]; }
+        unsigned int getNumExtraUniformLocations() const { return _extrauniformlocations.size(); }
 
         struct ActiveVarInfo {
             ActiveVarInfo() : _location(-1), _type(Uniform::UNDEFINED), _size(-1) {}
@@ -441,6 +451,7 @@ class OSG_EXPORT Program : public osg::StateAttribute
 
         ShaderDefines _shaderDefines;
 
+        std::vector<ExtraUniformLocation> _extrauniformlocations;
 
     private:
         Program& operator=(const Program&);        // disallowed

--- a/src/osg/Program.cpp
+++ b/src/osg/Program.cpp
@@ -184,7 +184,6 @@ int Program::compare(const osg::StateAttribute& sa) const
     return 0; // passed all the above comparison macros, must be equal.
 }
 
-
 void Program::compileGLObjects( osg::State& state ) const
 {
     if( _shaderList.empty() ) return;
@@ -927,6 +926,14 @@ void Program::PerContextProgram::linkProgram(osg::State& state)
             }
         }
         delete [] name;
+    }
+
+    ///extra uniform locations
+    for( unsigned int i=0; i<_program->getNumExtraUniformLocations(); ++i)
+    {
+        const ExtraUniformLocation& cloc = _program->getExtraUniformLocation(i);
+        GLint loc = _extensions->glGetUniformLocation(_glProgramHandle, cloc._locationname.c_str());
+        _uniformInfoMap[osg::Uniform::getNameID(cloc._locationname)] = ActiveVarInfo(loc, cloc._type, cloc._size);
     }
 
     // print atomic counter


### PR DESCRIPTION
enable support of uniform location not reported by glGetProgramiv(  GL_ACTIVE_UNIFORMS)
support array element operator "[]" and the structure field operator "."

should be added to serializer but would involve SO version increment

note : this pr is against 3.6 branch and is intended to be merge with master too
