### PR TITLE
Fix build iOS: when using Toolchain or building with Makefiles (not X…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,13 +73,13 @@ ELSEIF(APPLE)
         SET (IPHONE_ENABLE_BITCODE "NO" CACHE STRING "IOS Enable Bitcode")
 
         # seamless toggle between device and simulator
-        SET(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos;-iphonesimulator")
+        SET(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos;-iphonesimulator" CACHE STRING "Xcode effective platforms for iOS")
 
         # set deployment target to min version
-        SET(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "${IPHONE_VERSION_MIN}" CACHE STRING "Deployment target for iOS" FORCE)
+        SET(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "${IPHONE_VERSION_MIN}" CACHE STRING "Xcode deployment target for iOS")
 
         # Set standard architectures
-        SET(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")
+        SET(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)" CACHE STRING "Build architectures for iOS")
 
     ELSE()
         # OSX >= 10.5 uses Cocoa windowing system, otherwise Carbon


### PR DESCRIPTION
…code)

`SET(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")`
causes
`clang:error: invalid arch name '-arch -isysroot'`
while building OSG with CMake's Makefile generator.
