### PR TITLE
fix outdated dae readme

### DIFF
--- a/src/osgPlugins/dae/README.txt
+++ b/src/osgPlugins/dae/README.txt
@@ -33,15 +33,16 @@ BUILD DEPENDENCIES
 - iconv
 
 A standard "ccmake ." while in the root of the OSG source will expose
-two CMake variables: COLLADA_INCLUDE_DIR and COLLADA_LIBRARY. Using
-these two variables correctly can be a bit tricky (especially as
-the "right" and "wrong" ways to use Collada are hard to define), but
-I will briefly explain them below.
+two CMake variables: COLLADA_INCLUDE_DIR and COLLADA_DYNAMIC_LIBRARY (or
+COLLADA_STATIC_LIBRARY). Using these two variables correctly can be a bit
+tricky (especially as the "right" and "wrong" ways to use Collada are hard to
+define), but I will briefly explain them below.
 
   COLLADA_INCLUDE_DIR: This variable wants the path where it can
   find the COLLADA headers. On most systems this will be something
   like /usr/include or /usr/include/collada.
 
-  COLLADA_LIBRARY: This variable is asking for the FULL PATH to the
-  file libcollada_dom.a. As long as it can find this file, the
-  OSG Collada ReaderWriter should build just fine.
+  COLLADA_DYNAMIC_LIBRARY (or COLLADA_STATIC_LIBRARY): This variable is asking
+  for the FULL PATH to the file libcollada_dom.so (or libcollada_dom.a). As
+  long as it can find this file, the OSG Collada ReaderWriter should build
+  just fine.


### PR DESCRIPTION
Hi,

This is a really minor fix, as the documentation of the CMake variables is outdated.