### PR TITLE
getInternalTextureFormat() failed after reading a tiff file

### DIFF
--- a/src/osgPlugins/tiff/ReaderWriterTIFF.cpp
+++ b/src/osgPlugins/tiff/ReaderWriterTIFF.cpp
@@ -820,7 +820,41 @@ class ReaderWriterTIFF : public osgDB::ReaderWriter
                 bitspersample_ret == 16 ? GL_UNSIGNED_SHORT :
                 bitspersample_ret == 32 ? GL_FLOAT : (GLenum)-1;
 
-            int internalFormat = pixelFormat;
+            int internalFormat = 0;
+            switch (pixelFormat) {
+                case GL_LUMINANCE: {
+                    switch (dataType) {
+                        case GL_UNSIGNED_BYTE: internalFormat = GL_LUMINANCE8UI_EXT; break;
+                        case GL_UNSIGNED_SHORT: internalFormat = GL_LUMINANCE16UI_EXT; break;
+                        case GL_FLOAT : internalFormat = GL_LUMINANCE32F_ARB; break;
+                    }
+                    break;
+                }
+                case GL_LUMINANCE_ALPHA: {
+                    switch (dataType) {
+                        case GL_UNSIGNED_BYTE: internalFormat = GL_LUMINANCE_ALPHA8UI_EXT; break;
+                        case GL_UNSIGNED_SHORT: internalFormat = GL_LUMINANCE_ALPHA16UI_EXT; break;
+                        case GL_FLOAT: internalFormat = GL_LUMINANCE_ALPHA32F_ARB; break;
+                    }
+                    break;
+                }
+                case GL_RGB: {
+                    switch (dataType) {
+                        case GL_UNSIGNED_BYTE: internalFormat = GL_RGB8UI_EXT; break;
+                        case GL_UNSIGNED_SHORT: internalFormat = GL_RGB16UI_EXT; break;
+                        case GL_FLOAT: internalFormat = GL_RGB32F_ARB; break;
+                    }
+                    break;
+                }
+                case GL_RGBA : {
+                    switch (dataType) {
+                        case GL_UNSIGNED_BYTE: internalFormat = GL_RGBA8UI_EXT; break;
+                        case GL_UNSIGNED_SHORT: internalFormat = GL_RGBA16UI_EXT; break;
+                        case GL_FLOAT: internalFormat = GL_RGBA32F_ARB; break;
+                    }
+                    break;
+                }
+            }
 
             osg::Image* pOsgImage = new osg::Image;
             pOsgImage->setImage(s,t,r,

--- a/src/osgPlugins/tiff/ReaderWriterTIFF.cpp
+++ b/src/osgPlugins/tiff/ReaderWriterTIFF.cpp
@@ -824,8 +824,8 @@ class ReaderWriterTIFF : public osgDB::ReaderWriter
             switch (pixelFormat) {
                 case GL_LUMINANCE: {
                     switch (dataType) {
-                        case GL_UNSIGNED_BYTE: internalFormat = GL_LUMINANCE8UI_EXT; break;
-                        case GL_UNSIGNED_SHORT: internalFormat = GL_LUMINANCE16UI_EXT; break;
+                        case GL_UNSIGNED_BYTE: internalFormat = GL_LUMINANCE8; break;
+                        case GL_UNSIGNED_SHORT: internalFormat = GL_LUMINANCE16; break;
                         case GL_FLOAT : internalFormat = GL_LUMINANCE32F_ARB; break;
                     }
                     break;
@@ -840,16 +840,16 @@ class ReaderWriterTIFF : public osgDB::ReaderWriter
                 }
                 case GL_RGB: {
                     switch (dataType) {
-                        case GL_UNSIGNED_BYTE: internalFormat = GL_RGB8UI_EXT; break;
-                        case GL_UNSIGNED_SHORT: internalFormat = GL_RGB16UI_EXT; break;
+                        case GL_UNSIGNED_BYTE: internalFormat = GL_RGB8; break;
+                        case GL_UNSIGNED_SHORT: internalFormat = GL_RGB16; break;
                         case GL_FLOAT: internalFormat = GL_RGB32F_ARB; break;
                     }
                     break;
                 }
                 case GL_RGBA : {
                     switch (dataType) {
-                        case GL_UNSIGNED_BYTE: internalFormat = GL_RGBA8UI_EXT; break;
-                        case GL_UNSIGNED_SHORT: internalFormat = GL_RGBA16UI_EXT; break;
+                        case GL_UNSIGNED_BYTE: internalFormat = GL_RGBA8; break;
+                        case GL_UNSIGNED_SHORT: internalFormat = GL_RGBA16; break;
                         case GL_FLOAT: internalFormat = GL_RGBA32F_ARB; break;
                     }
                     break;

--- a/src/osgPlugins/tiff/ReaderWriterTIFF.cpp
+++ b/src/osgPlugins/tiff/ReaderWriterTIFF.cpp
@@ -809,19 +809,18 @@ class ReaderWriterTIFF : public osgDB::ReaderWriter
             int t = height_ret;
             int r = 1;
 
-            int internalFormat = numComponents_ret;
-
             unsigned int pixelFormat =
                 numComponents_ret == 1 ? GL_LUMINANCE :
                 numComponents_ret == 2 ? GL_LUMINANCE_ALPHA :
                 numComponents_ret == 3 ? GL_RGB :
                 numComponents_ret == 4 ? GL_RGBA : (GLenum)-1;
 
-
             unsigned int dataType =
                 bitspersample_ret == 8 ? GL_UNSIGNED_BYTE :
                 bitspersample_ret == 16 ? GL_UNSIGNED_SHORT :
                 bitspersample_ret == 32 ? GL_FLOAT : (GLenum)-1;
+
+            int internalFormat = pixelFormat;
 
             osg::Image* pOsgImage = new osg::Image;
             pOsgImage->setImage(s,t,r,


### PR DESCRIPTION
As the title.
Code like this:
```
...
tex = new osg::Teture2D();
tex->setImage(osgDB::readImageFile("x.tiff"));
...
printf("%u\n", tex->getImage()->getInternalTextureFormat());
```

The value is 3.

So i checked the plugin tiff, found that using number of components instead of which it should be.
Also plugin tga has similar problem.
I try to fix plugin tiff first, then back to work, bypassing this problem manually.