### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Project Lead.
 
 ## Section 1. How to build OpenSceneGraph
 
+If you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager you can download and install OpenSceneGraph from source with CMake integration using a single command:
+```
+vcpkg install osg
+```
+
 The OpenSceneGraph uses the CMake build system to generate a platform-specific build environment.  CMake reads the `CMakeLists.txt` files that you'll find throughout the OpenSceneGraph directories, checks for installed dependencies and then generates files for the selected build system.
 
 If you don't already have CMake installed on your system you can grab it from http://www.cmake.org, use version 2.8.0 or later.  Details on the OpenSceneGraph's CMake build can be found at:


### PR DESCRIPTION
OpenSceneGraph is available as a port in vcpkg. Adding installation instructions will help users get started by providing a single command they can use to build OpenSceneGraph and include it into their CMake projects