### PR TITLE
GL_CLAMP_VERTEX_COLOR and GL_CLAMP_FRAGMENT_COLOR deprecated in GL co…

### DIFF
--- a/src/osg/ClampColor.cpp
+++ b/src/osg/ClampColor.cpp
@@ -49,7 +49,9 @@ void ClampColor::apply(State& state) const
         return;
     }
 
+#if !defined(OSG_GL3_AVAILABLE)
     extensions->glClampColor(GL_CLAMP_VERTEX_COLOR, _clampVertexColor);
     extensions->glClampColor(GL_CLAMP_FRAGMENT_COLOR, _clampFragmentColor);
+#endif
     extensions->glClampColor(GL_CLAMP_READ_COLOR, _clampReadColor);
 }


### PR DESCRIPTION
…re profile according to OpenGL 4.5 specification.