### PR TITLE
fix copySubImage crash on compressed files

### DIFF
--- a/src/osg/Image.cpp
+++ b/src/osg/Image.cpp
@@ -1696,11 +1696,11 @@ void Image::copySubImage(int s_offset, int t_offset, int r_offset, const osg::Im
         }
         unsigned int rowWidthInBlocks = (_s + footprint.x() - 1) / footprint.x();
         unsigned int blockSize = computeBlockSize(_pixelFormat, 0);
-        data_destination = _data + blockSize * (rowWidthInBlocks * t_offset + (s_offset / footprint.x()));
+        data_destination = _data + blockSize * (rowWidthInBlocks * (t_offset / footprint.y()) + (s_offset / footprint.x()));
         unsigned int copy_width = (osg::minimum(source->s(), _s - s_offset) + footprint.x() - 1) / footprint.x();
         unsigned int copy_height = (osg::minimum(source->t(), _t - t_offset) + footprint.y() - 1) / footprint.y();
         unsigned int dstRowStep = blockSize * rowWidthInBlocks;
-        unsigned int srcRowStep = blockSize * (source->_s + footprint.x() - 1) / footprint.x();
+        unsigned int srcRowStep = blockSize * ((source->_s + footprint.x() - 1) / footprint.x());
         const unsigned char* data_source = source->data(0, 0, 0);
         for (unsigned int row = 0; row < copy_height; row += 1) { //copy blocks in a row, footprint.y() rows at a time
             memcpy(data_destination, data_source, copy_width * blockSize);


### PR DESCRIPTION
Using the textureatlasbuilder on (DXT) compressed textures can crash on these errors. I guess I wrote the code myself, sorry about the bug.
Same problem is in master, I will supply a PR for that as well.
Laurens.