### PR TITLE
Fix bug in matrix transpose() and transpose3x3

### DIFF
--- a/src/osg/Matrix_implementation.cpp
+++ b/src/osg/Matrix_implementation.cpp
@@ -747,18 +747,22 @@ bool Matrix_implementation::transpose(const Matrix_implementation&mat){
        Matrix_implementation tm(mat);
        return transpose(tm);
     }
+    _mat[0][0]=mat._mat[0][0];
     _mat[0][1]=mat._mat[1][0];
     _mat[0][2]=mat._mat[2][0];
     _mat[0][3]=mat._mat[3][0];
     _mat[1][0]=mat._mat[0][1];
+    _mat[1][1]=mat._mat[1][1];
     _mat[1][2]=mat._mat[2][1];
     _mat[1][3]=mat._mat[3][1];
     _mat[2][0]=mat._mat[0][2];
     _mat[2][1]=mat._mat[1][2];
+    _mat[2][2]=mat._mat[2][2];
     _mat[2][3]=mat._mat[3][2];
     _mat[3][0]=mat._mat[0][3];
     _mat[3][1]=mat._mat[1][3];
     _mat[3][2]=mat._mat[2][3];
+    _mat[3][3]=mat._mat[3][3];
     return true;
 }
 
@@ -767,12 +771,15 @@ bool Matrix_implementation::transpose3x3(const Matrix_implementation&mat){
        Matrix_implementation tm(mat);
        return transpose3x3(tm);
     }
+    _mat[0][0]=mat._mat[0][0];
     _mat[0][1]=mat._mat[1][0];
     _mat[0][2]=mat._mat[2][0];
     _mat[1][0]=mat._mat[0][1];
+    _mat[1][1]=mat._mat[1][1];
     _mat[1][2]=mat._mat[2][1];
     _mat[2][0]=mat._mat[0][2];
     _mat[2][1]=mat._mat[1][2];
+    _mat[2][2]=mat._mat[2][2];
 
     return true;
 }


### PR DESCRIPTION
The diagonal elements were not copied from the source matrix.