### PR TITLE
Fix linking with Xinerama

### DIFF
--- a/src/osgViewer/CMakeLists.txt
+++ b/src/osgViewer/CMakeLists.txt
@@ -217,7 +217,7 @@ ELSE()
         IF(OSGVIEWER_USE_XINERAMA)
             ADD_DEFINITIONS(-DOSGVIEWER_USE_XINERAMA)
             SET(LIB_PRIVATE_HEADERS ${LIB_PRIVATE_HEADERS} ${XINERAMA_INCLUDE_DIRS} )
-            SET(LIB_EXTRA_LIBS -lXinerama ${LIB_EXTRA_LIBS})
+            SET(LIB_EXTRA_LIBS ${X11_Xinerama_LIB} ${LIB_EXTRA_LIBS})
         ENDIF()
 
         # X11 on Apple requires X11 library plus OpenGL linking hack on Leopard


### PR DESCRIPTION
`-lXinerama` breaks the build as the linked does not know where to find the library. Using properly detected library fixed this.