### PR TITLE
Add FreeBSD-specific code bits for pthread_setaffinity_np support

### DIFF
--- a/src/OpenThreads/pthreads/CMakeLists.txt
+++ b/src/OpenThreads/pthreads/CMakeLists.txt
@@ -80,8 +80,15 @@ ELSE()
           # double check that pthread_setaffinity_np is available as FreeBSD header doesn't contain required function
           CHECK_CXX_SOURCE_COMPILES("
             #include <pthread.h>
+            #ifdef __FreeBSD__
+            #include <pthread_np.h>
+            #endif
             int main() {
+            #ifdef __FreeBSD__
+            cpuset_t cpumask;
+            #else
             cpu_set_t cpumask;
+            #endif
             CPU_ZERO( &cpumask );
             CPU_SET( 0, &cpumask );
             pthread_setaffinity_np( pthread_self(), sizeof(cpumask), &cpumask);

--- a/src/OpenThreads/pthreads/PThread.cpp
+++ b/src/OpenThreads/pthreads/PThread.cpp
@@ -21,6 +21,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <pthread.h>
+#if defined(HAVE_PTHREAD_SETAFFINITY_NP) && defined(__FreeBSD__)
+    #include <pthread_np.h>
+#endif
 #include <limits.h>
 
 #if defined __linux__ || defined __sun || defined __APPLE__ || ANDROID
@@ -113,7 +116,11 @@ namespace OpenThreads
 static void setAffinity(const Affinity& affinity)
 {
     //std::cout<<"setProcessAffinity : "<< affinity.activeCPUs.size() <<std::endl;
+#if defined(__FreeBSD__)
+    cpuset_t cpumask;
+#else
     cpu_set_t cpumask;
+#endif
     CPU_ZERO( &cpumask );
     unsigned int numprocessors = OpenThreads::GetNumberOfProcessors();
     if (affinity)


### PR DESCRIPTION
On FreeBSD, `pthread_setaffinity_np` lives in separate `pthread_np.h` header, and also `cpuset_t` is named differently.