### PR TITLE
Fontconfig should be external library.

### DIFF
--- a/src/osgText/CMakeLists.txt
+++ b/src/osgText/CMakeLists.txt
@@ -54,7 +54,7 @@ SET(COMPONENT_PKGCONFIG_DESCRIPTION "Text rendering library for OpenSceneGraph")
 
 if(OSG_TEXT_USE_FONTCONFIG AND Fontconfig_FOUND)
     MESSAGE(STATUS "osgText will be linked with FontConfig library")
-    list(APPEND TARGET_LIBRARIES Fontconfig::Fontconfig)
+    LIST(APPEND TARGET_EXTERNAL_LIBRARIES Fontconfig::Fontconfig)
     ADD_DEFINITIONS(-DWITH_FONTCONFIG)
 else()
     MESSAGE(STATUS "osgText will not be linked with FontConfig library")


### PR DESCRIPTION
Add Fontconfig to TARGET_LIBRARIES cause osg3::osgText target looking for
openscegraph-Fontconfig-import-targets.cmake, which doesn't exists.