### PR TITLE
Set OpenSceneGraph_${component}_FOUND to TRUE for existing target.

### DIFF
--- a/packaging/cmake/OpenSceneGraphConfig.cmake.in
+++ b/packaging/cmake/OpenSceneGraphConfig.cmake.in
@@ -95,6 +95,8 @@ foreach(component OpenThreads osg ${OpenSceneGraph_FIND_COMPONENTS})
 
     if(TARGET @PKG_NAMESPACE@::${component})
         # This component has already been found, so we'll skip it
+        set(OpenSceneGraph_${component}_FOUND TRUE)
+        set(OPENSCENEGRAPH_${component}_FOUND TRUE)
         continue()
     endif()
 


### PR DESCRIPTION
Following statement will never set OpenSceneGraph_osgText_FOUND to TRUE:

```
FIND_PACKAGE(OpenSceneGraph REQUIRED COMPONENTS osgViewer osgText CONFIG)
```

It cause cmake failure, the error message is confusing:
```
Found package configuration file:

/usr/local/osg/gl2/lib/cmake/OpenSceneGraph/OpenSceneGraphConfig.cmake

but it set OpenSceneGraph_FOUND to FALSE so package "OpenSceneGraph" is
considered to be NOT FOUND.
```

I know one doesn't need to add osgText after osgViewer, but it should not cause an error
 with confusing message.