### PR TITLE
fix debug compile error for ReaderWriterTGA

### DIFF
--- a/src/osgPlugins/tga/ReaderWriterTGA.cpp
+++ b/src/osgPlugins/tga/ReaderWriterTGA.cpp
@@ -656,7 +656,7 @@ int *numComponents_ret)
                 {
                     rle_decode(&src, linebuf.data(), width*depth, &rleRemaining,
                         &rleIsCompressed, rleCurrent, rleEntrySize);
-                    assert(src <= buf + size);
+                    assert(src <= buf.data() + size);
 
                     for (x = 0; x < width; x++)
                     {
@@ -722,7 +722,7 @@ int *numComponents_ret)
                 {
                     rle_decode(&src, linebuf.data(), width*depth, &rleRemaining,
                         &rleIsCompressed, rleCurrent, rleEntrySize);
-                    assert(src <= buf + size);
+                    assert(src <= buf.data() + size);
                     for (x = 0; x < width; x++)
                     {
                         convert_data(linebuf.data(), dest,  bLeftToRight ? x : (width-1) - x, depth, format);


### PR DESCRIPTION
Hi Robert,
I get a compile error in the debug config in Visual Studio Community 15.9.18 & 16.4.1:
OpenSceneGraph\src\osgPlugins\tga\ReaderWriterTGA.cpp(725): error C2676: binary '+': 'SafeArray<unsigned char>' does not define this operator or a conversion to a type acceptable to the predefined operator
This was introduced by "Fix clang 8 & libc++ build errors" from "elsid" (22/11/2019).
This is a PR for master; identical to the PR for 3.6
Regards, Laurens.