### PR TITLE
fallback for DCMTK_ROOT_INCLUDE_DIR 

### DIFF
--- a/src/osgPlugins/dicom/CMakeLists.txt
+++ b/src/osgPlugins/dicom/CMakeLists.txt
@@ -1,7 +1,22 @@
 IF  (DCMTK_FOUND)
 
-    # note, we have to include a '/' in front of the directory string to prevent a CMake bug from ignoring the directory
-    INCLUDE_DIRECTORIES(${DCMTK_ROOT_INCLUDE_DIR})
+    IF (DCMTK_ROOT_INCLUDE_DIR)
+        # osg used to have a FindOurDCMTK.cmake until 2017/7/26 (3.5.6); it defined this DCMTK_ROOT_INCLUDE_DIR
+        # keep using this if it's provided on command line
+        
+        # note, we have to include a '/' in front of the directory string to prevent a CMake bug from ignoring the directory
+        INCLUDE_DIRECTORIES(${DCMTK_ROOT_INCLUDE_DIR})
+    ELSE (DCMTK_ROOT_INCLUDE_DIR)
+        IF (DCMTK_INCLUDE_DIRS)
+            #CMake 3.4.1 and up define this in FindDCMTK.cmake
+            INCLUDE_DIRECTORIES(${DCMTK_INCLUDE_DIRS})
+        ELSE (DCMTK_INCLUDE_DIRS)
+            #final fall-back:
+            #CMake 2.1.0 22/4/2004 until now (2019) have DCMTK_DIR
+            INCLUDE_DIRECTORIES(${DCMTK_DIR}/include)
+        ENDIF (DCMTK_INCLUDE_DIRS)
+    ENDIF (DCMTK_ROOT_INCLUDE_DIR)
+    
 
     SET(TARGET_SRC ReaderWriterDICOM.cpp )
 


### PR DESCRIPTION
with the removal of FindOurDCMTK.cmake (2017/7/26) the variable DCMTK_ROOT_INCLUDE_DIR is not set by cmake anymore.
I did not notice this before because I set this variable on the cmake command line in my build script, but while building osg with vcpkg I noticed that the dicom plugin failed to build.
For the master tree I suggest to remove the variable entirely, for 3.6.5 I would like to suggest this conservative approach, with a fallback in case the variable is not defined.
Regards, Laurens.