### PR TITLE
[Controversal:/] Changing stateattribute priority

### DIFF
--- a/include/osg/StateAttribute
+++ b/include/osg/StateAttribute
@@ -122,19 +122,38 @@ class OSG_EXPORT StateAttribute : public Object
           * that type's value. */
         enum Type
         {
+/// Renderpass attributes
+            FRAME_BUFFER_OBJECT,
+
+/// Shader attributes
+            VERTEXPROGRAM,
+            FRAGMENTPROGRAM,
+            PROGRAM,
+
+/// Material attributes
             TEXTURE,
+            SAMPLER,
+            BINDIMAGETEXTURE,
+            MATERIAL,
+            LIGHTMODEL,
+            LIGHT,
+            UNIFORMBUFFERBINDING,
+
+/// Object attributes
+            TRANSFORMFEEDBACKBUFFERBINDING,
+            ATOMICCOUNTERBUFFERBINDING,
+            SHADERSTORAGEBUFFERBINDING,
+            INDIRECTDRAWBUFFERBINDING,
+
 
             POLYGONMODE,
             POLYGONOFFSET,
-            MATERIAL,
             ALPHAFUNC,
             ANTIALIAS,
             COLORTABLE,
             CULLFACE,
             FOG,
             FRONTFACE,
-
-            LIGHT,
 
             POINT,
             LINEWIDTH,
@@ -145,7 +164,6 @@ class OSG_EXPORT StateAttribute : public Object
             TEXENVFILTER,
             TEXGEN,
             TEXMAT,
-            LIGHTMODEL,
             BLENDFUNC,
             BLENDEQUATION,
             LOGICOP,
@@ -158,10 +176,7 @@ class OSG_EXPORT StateAttribute : public Object
             MULTISAMPLE,
             CLIPPLANE,
             COLORMATRIX,
-            VERTEXPROGRAM,
-            FRAGMENTPROGRAM,
             POINTSPRITE,
-            PROGRAM,
             CLAMPCOLOR,
             HINT,
             SAMPLEMASKI,
@@ -189,27 +204,14 @@ class OSG_EXPORT StateAttribute : public Object
             // osgNVParse
             OSGNVPARSE_PROGRAM_PARSER,
 
-            UNIFORMBUFFERBINDING,
-            TRANSFORMFEEDBACKBUFFERBINDING,
-
-            ATOMICCOUNTERBUFFERBINDING,
-
             PATCH_PARAMETER,
 
-            FRAME_BUFFER_OBJECT,
-
             VERTEX_ATTRIB_DIVISOR,
-
-            SHADERSTORAGEBUFFERBINDING,
-
-            INDIRECTDRAWBUFFERBINDING,
 
             VIEWPORTINDEXED,
             DEPTHRANGEINDEXED,
             SCISSORINDEXED,
 
-            BINDIMAGETEXTURE,
-            SAMPLER,
 
             CAPABILITY = 100
         };


### PR DESCRIPTION
There's a severe under perf in the priority of the Program, i reorganized that based on AZDO guide lines
Quoting Mathias Schott from nvidia
> Sort by renderpass (framebuffer, blending, depth/stencil..)
> then sort by pipeline (shader,tesseleation..)
> then sort by material (texture,uniforms...)
> then sort by object (buffers, matrices....)

would require feedback on my compliance with this