### PR TITLE
Fix navagation error about Android GLES2 example.

### DIFF
--- a/examples/osgAndroidExampleGLES2/jni/OsgMainApp.cpp
+++ b/examples/osgAndroidExampleGLES2/jni/OsgMainApp.cpp
@@ -103,7 +103,9 @@ void OsgMainApp::initOsgWindow(int x,int y,int width,int height){
     osg::notify(osg::ALWAYS)<<"Testing"<<std::endl;
 
     _viewer = new osgViewer::Viewer();
-    _viewer->setUpViewerAsEmbeddedInWindow(x, y, width, height);
+    osgViewer::GraphicsWindowEmbedded* window = _viewer->setUpViewerAsEmbeddedInWindow(x, y, width, height);
+    _viewer->getEventQueue()->setGraphicsContext(window);
+    _viewer->getEventQueue()->syncWindowRectangleWithGraphicsContext();
     _viewer->setThreadingModel(osgViewer::ViewerBase::SingleThreaded);
 
     _root = new osg::Group();


### PR DESCRIPTION
Android GLES2 example use event queue without initializing window rectangle with graphics context,that produce navigation error.