### PR TITLE
Added commment explaining that OpenThreads::Thread::CurrentThread() r…

### DIFF
--- a/include/OpenThreads/Thread
+++ b/include/OpenThreads/Thread
@@ -109,7 +109,7 @@ public:
 
 
     /**
-     *  Return a pointer to the current running thread
+     *  Return a pointer to the current running thread, returns NULL for a non OpenThreads thread.
      */
     static Thread *CurrentThread();
 


### PR DESCRIPTION
…eturn NULL on non OpenThreads thread.