### PR TITLE
Add getPreRenderList, getPostRenderList to RenderStage.

### DIFF
--- a/include/osgUtil/RenderStage
+++ b/include/osgUtil/RenderStage
@@ -38,6 +38,8 @@ class OSGUTIL_EXPORT RenderStage : public RenderBin
 {
     public:
 
+        typedef std::pair< int , osg::ref_ptr<RenderStage> > RenderStageOrderPair;
+        typedef std::list< RenderStageOrderPair > RenderStageList;
 
         RenderStage();
         RenderStage(SortMode mode);
@@ -236,6 +238,12 @@ class OSGUTIL_EXPORT RenderStage : public RenderBin
 
         void addPostRenderStage(RenderStage* rs, int order = 0);
 
+        const RenderStageList& getPreRenderList() const { return _preRenderList; }
+        RenderStageList& getPreRenderList() { return _preRenderList; }
+
+        const RenderStageList& getPostRenderList() const { return _postRenderList; }
+        RenderStageList& getPostRenderList() { return _postRenderList; }
+
         /** Extract stats for current draw list. */
         bool getStats(Statistics& stats) const;
 
@@ -266,8 +274,6 @@ protected:
 
         virtual ~RenderStage();
 
-        typedef std::pair< int , osg::ref_ptr<RenderStage> > RenderStageOrderPair;
-        typedef std::list< RenderStageOrderPair > RenderStageList;
         typedef std::vector< osg::ref_ptr<osg::Camera> > Cameras;
 
         bool                                _stageDrawnThisFrame;


### PR DESCRIPTION
This is mostly for debug purpose, users should get a chance to to recursively parse `RenderStages`.

I'm writtng a `RenderPrinter` to print all  `RenderBin`, `RenderLeaf` in all RenderStages by render order, can't do it  without these functions.