### PR TITLE
fix: vendor ext prevent OQN to work on other HW

### DIFF
--- a/src/osg/GLExtensions.cpp
+++ b/src/osg/GLExtensions.cpp
@@ -743,7 +743,7 @@ GLExtensions::GLExtensions(unsigned int in_contextID):
     isSecondaryColorSupported = validContext && isGLExtensionSupported(contextID,"GL_EXT_secondary_color");
     isFogCoordSupported = validContext && isGLExtensionSupported(contextID,"GL_EXT_fog_coord");
     isMultiTexSupported = validContext && isGLExtensionSupported(contextID,"GL_ARB_multitexture");
-    isOcclusionQuerySupported = validContext && osg::isGLExtensionSupported(contextID, "GL_NV_occlusion_query");
+    isOcclusionQuerySupported = validContext && osg::isGLExtensionSupported(contextID, "GL_ARB_occlusion_query");
     isARBOcclusionQuerySupported = validContext && (OSG_GL3_FEATURES || osg::isGLExtensionSupported(contextID, "GL_ARB_occlusion_query"));
 
     isTimerQuerySupported = validContext && osg::isGLExtensionSupported(contextID, "GL_EXT_timer_query");


### PR DESCRIPTION
prevent Occlusion Qeury to work on other than NVIDIA
NB: on master too
As a general statement, we could replace all NV specific with their ARB.....most are standardized till a long time now