### PR TITLE
Osgply

### DIFF
--- a/src/osgPlugins/ply/ReaderWriterPLY.cpp
+++ b/src/osgPlugins/ply/ReaderWriterPLY.cpp
@@ -60,6 +60,8 @@ public:
         _semantic.push_back({ "alpha", PLY_FLOAT,  2});
         _semantic.push_back({ "u", PLY_FLOAT, 3});
         _semantic.push_back({ "v", PLY_FLOAT,  3});
+        _semantic.push_back({ "texture_u", PLY_FLOAT, 3});
+        _semantic.push_back({ "texture_v", PLY_FLOAT,  3});
         _semantic.push_back({ "ambient_red", PLY_UCHAR, 4});
         _semantic.push_back({ "ambient_green", PLY_UCHAR, 4});
         _semantic.push_back({ "ambient_blue", PLY_UCHAR, 4});

--- a/src/osgPlugins/ply/ReaderWriterPLY.cpp
+++ b/src/osgPlugins/ply/ReaderWriterPLY.cpp
@@ -37,7 +37,6 @@ using namespace std;
 //! \brief This is the Reader for the ply file format
 //!
 //////////////////////////////////////////////////////////////////////////////
-///
 
 class ReaderWriterPLY : public osgDB::ReaderWriter
 {
@@ -48,16 +47,17 @@ public:
 
         /** Note semantics from Equalizer LGPL source.*/
         //assuming compact aliasing (only name and internal format is meaningfull
+/// element properties to read and their mapping
         _semantic.push_back({ "x", PLY_FLOAT, 0 });
         _semantic.push_back({ "y", PLY_FLOAT,  0});
         _semantic.push_back({ "z", PLY_FLOAT,  0});
         _semantic.push_back({ "nx", PLY_FLOAT, 1});
         _semantic.push_back({ "ny", PLY_FLOAT,  1});
         _semantic.push_back({ "nz", PLY_FLOAT,  1});
-        _semantic.push_back({ "red", PLY_UCHAR,  2});
-        _semantic.push_back({ "green", PLY_UCHAR,  2});
-        _semantic.push_back({ "blue", PLY_UCHAR,  2});
-        _semantic.push_back({ "alpha", PLY_UCHAR,  2});
+        _semantic.push_back({ "red", PLY_FLOAT,  2});
+        _semantic.push_back({ "green", PLY_FLOAT,  2});
+        _semantic.push_back({ "blue", PLY_FLOAT,  2});
+        _semantic.push_back({ "alpha", PLY_FLOAT,  2});
         _semantic.push_back({ "u", PLY_FLOAT, 3});
         _semantic.push_back({ "v", PLY_FLOAT,  3});
         _semantic.push_back({ "ambient_red", PLY_UCHAR, 4});
@@ -71,9 +71,12 @@ public:
         _semantic.push_back({ "specular_blue", PLY_UCHAR, 6});
         _semantic.push_back({ "specular_coeff", PLY_FLOAT,  7});
         _semantic.push_back({ "specular_power", PLY_FLOAT, 7});
-
-
-        _semantic.push_back({ "vertex_indices", -1, -1}); //autotyped uint
+        _semantic.push_back({ "tx", PLY_UCHAR, 6});
+        _semantic.push_back({ "tn", PLY_UINT, 7});
+/// list properties to read (first found is set as primitiveset)
+        _semantic.push_back({ "vertex_indices", -1, -2}); //autotyped uint
+        _semantic.push_back({ "vertex_index", -1, -2}); //autotyped uint
+        _semantic.push_back({ "texture_vertex_indices", -1, -1}); //autotyped uint
     }
 
     virtual const char* className() const { return "ReaderWriterPLY"; }

--- a/src/osgPlugins/ply/ReaderWriterPLY.cpp
+++ b/src/osgPlugins/ply/ReaderWriterPLY.cpp
@@ -38,33 +38,6 @@ using namespace std;
 //!
 //////////////////////////////////////////////////////////////////////////////
 ///
-/** Note semantics from Equalizer LGPL source.*/
-struct _Vertex
-{
-    float           x;
-    float           y;
-    float           z;
-    float           nx;
-    float           ny;
-    float           nz;
-    unsigned char   red;
-    unsigned char   green;
-    unsigned char   blue;
-    unsigned char   alpha;
-    unsigned char   ambient_red;
-    unsigned char   ambient_green;
-    unsigned char   ambient_blue;
-    unsigned char   diffuse_red;
-    unsigned char   diffuse_green;
-    unsigned char   diffuse_blue;
-    unsigned char   specular_red;
-    unsigned char   specular_green;
-    unsigned char   specular_blue;
-    float           specular_coeff;
-    float           specular_power;
-    float           texture_u;
-    float           texture_v;
-};
 
 class ReaderWriterPLY : public osgDB::ReaderWriter
 {
@@ -73,30 +46,31 @@ public:
     {
         supportsExtension("ply","Stanford Triangle Meta Format");
 
-        //assuming compact aliasing
-        _semantic.push_back(ply::VertexSemantic({ "x", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, x ), 0, 0, 0, 0 }, 0));
-        _semantic.push_back(ply::VertexSemantic({ "y", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, y ), 0, 0, 0, 0 }, 0));
-        _semantic.push_back(ply::VertexSemantic({ "z", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, z ), 0, 0, 0, 0 }, 0));
-        _semantic.push_back(ply::VertexSemantic({ "nx", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, nx ), 0, 0, 0, 0 }, 1));
-        _semantic.push_back(ply::VertexSemantic({ "ny", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, ny), 0, 0, 0, 0 }, 1));
-        _semantic.push_back(ply::VertexSemantic({ "nz", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, nz), 0, 0, 0, 0 }, 1));
-        _semantic.push_back(ply::VertexSemantic({ "red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, red ), 0, 0, 0, 0 }, 2));
-        _semantic.push_back(ply::VertexSemantic({ "green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, green ), 0, 0, 0, 0 }, 2));
-        _semantic.push_back(ply::VertexSemantic({ "blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, blue ), 0, 0, 0, 0 } , 2));
-        _semantic.push_back(ply::VertexSemantic({ "alpha", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, alpha ), 0, 0, 0, 0 }, 2));
-        _semantic.push_back(ply::VertexSemantic({ "texture_u", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, texture_u), 0, 0, 0, 0 }, 3));
-        _semantic.push_back(ply::VertexSemantic({ "texture_v", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, texture_v), 0, 0, 0, 0 }, 3));
-        _semantic.push_back(ply::VertexSemantic({ "ambient_red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, ambient_red ), 0, 0, 0, 0 }, 4));
-        _semantic.push_back(ply::VertexSemantic({ "ambient_green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, ambient_green ), 0, 0, 0, 0 }, 4));
-        _semantic.push_back(ply::VertexSemantic({ "ambient_blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, ambient_blue ), 0, 0, 0, 0 }, 4));
-        _semantic.push_back(ply::VertexSemantic({ "diffuse_red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_red ), 0, 0, 0, 0 }, 5));
-        _semantic.push_back(ply::VertexSemantic({ "diffuse_green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_green ), 0, 0, 0, 0 }, 5));
-        _semantic.push_back(ply::VertexSemantic({ "diffuse_blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_blue ), 0, 0, 0, 0 }, 5));
-        _semantic.push_back(ply::VertexSemantic({ "specular_red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_red ), 0, 0, 0, 0 }, 6));
-        _semantic.push_back(ply::VertexSemantic({ "specular_green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_green ), 0, 0, 0, 0 }, 6));
-        _semantic.push_back(ply::VertexSemantic({ "specular_blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_blue ), 0, 0, 0, 0 }, 6));
-        _semantic.push_back(ply::VertexSemantic({ "specular_coeff", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, specular_coeff ), 0, 0, 0, 0 }, 7));
-        _semantic.push_back(ply::VertexSemantic({ "specular_power", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, specular_power ), 0, 0, 0, 0 }, 7));
+        /** Note semantics from Equalizer LGPL source.*/
+        //assuming compact aliasing (only name and internal format is meaningfull
+        _semantic.push_back(ply::VertexSemantic({ "x", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 0));
+        _semantic.push_back(ply::VertexSemantic({ "y", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 0));
+        _semantic.push_back(ply::VertexSemantic({ "z", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 0));
+        _semantic.push_back(ply::VertexSemantic({ "nx", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 1));
+        _semantic.push_back(ply::VertexSemantic({ "ny", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 1));
+        _semantic.push_back(ply::VertexSemantic({ "nz", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 1));
+        _semantic.push_back(ply::VertexSemantic({ "red", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 2));
+        _semantic.push_back(ply::VertexSemantic({ "green", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 2));
+        _semantic.push_back(ply::VertexSemantic({ "blue", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 } , 2));
+        _semantic.push_back(ply::VertexSemantic({ "alpha", PLY_UCHAR, PLY_UCHAR,0, 0, 0, 0, 0 }, 2));
+        _semantic.push_back(ply::VertexSemantic({ "u", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 3));
+        _semantic.push_back(ply::VertexSemantic({ "v", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 3));
+        _semantic.push_back(ply::VertexSemantic({ "ambient_red", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 4));
+        _semantic.push_back(ply::VertexSemantic({ "ambient_green", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 4));
+        _semantic.push_back(ply::VertexSemantic({ "ambient_blue", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 4));
+        _semantic.push_back(ply::VertexSemantic({ "diffuse_red", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 5));
+        _semantic.push_back(ply::VertexSemantic({ "diffuse_green", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 5));
+        _semantic.push_back(ply::VertexSemantic({ "diffuse_blue", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 5));
+        _semantic.push_back(ply::VertexSemantic({ "specular_red", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 6));
+        _semantic.push_back(ply::VertexSemantic({ "specular_green", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 6));
+        _semantic.push_back(ply::VertexSemantic({ "specular_blue", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 6));
+        _semantic.push_back(ply::VertexSemantic({ "specular_coeff", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 7));
+        _semantic.push_back(ply::VertexSemantic({ "specular_power", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 7));
     }
 
     virtual const char* className() const { return "ReaderWriterPLY"; }

--- a/src/osgPlugins/ply/ReaderWriterPLY.cpp
+++ b/src/osgPlugins/ply/ReaderWriterPLY.cpp
@@ -48,29 +48,29 @@ public:
 
         /** Note semantics from Equalizer LGPL source.*/
         //assuming compact aliasing (only name and internal format is meaningfull
-        _semantic.push_back(ply::VertexSemantic({ "x", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 0));
-        _semantic.push_back(ply::VertexSemantic({ "y", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 0));
-        _semantic.push_back(ply::VertexSemantic({ "z", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 0));
-        _semantic.push_back(ply::VertexSemantic({ "nx", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 1));
-        _semantic.push_back(ply::VertexSemantic({ "ny", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 1));
-        _semantic.push_back(ply::VertexSemantic({ "nz", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 1));
-        _semantic.push_back(ply::VertexSemantic({ "red", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 2));
-        _semantic.push_back(ply::VertexSemantic({ "green", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 2));
-        _semantic.push_back(ply::VertexSemantic({ "blue", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 } , 2));
-        _semantic.push_back(ply::VertexSemantic({ "alpha", PLY_UCHAR, PLY_UCHAR,0, 0, 0, 0, 0 }, 2));
-        _semantic.push_back(ply::VertexSemantic({ "u", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 3));
-        _semantic.push_back(ply::VertexSemantic({ "v", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 3));
-        _semantic.push_back(ply::VertexSemantic({ "ambient_red", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 4));
-        _semantic.push_back(ply::VertexSemantic({ "ambient_green", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 4));
-        _semantic.push_back(ply::VertexSemantic({ "ambient_blue", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 4));
-        _semantic.push_back(ply::VertexSemantic({ "diffuse_red", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 5));
-        _semantic.push_back(ply::VertexSemantic({ "diffuse_green", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 5));
-        _semantic.push_back(ply::VertexSemantic({ "diffuse_blue", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 5));
-        _semantic.push_back(ply::VertexSemantic({ "specular_red", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 6));
-        _semantic.push_back(ply::VertexSemantic({ "specular_green", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 6));
-        _semantic.push_back(ply::VertexSemantic({ "specular_blue", PLY_UCHAR, PLY_UCHAR, 0, 0, 0, 0, 0 }, 6));
-        _semantic.push_back(ply::VertexSemantic({ "specular_coeff", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 7));
-        _semantic.push_back(ply::VertexSemantic({ "specular_power", PLY_FLOAT, PLY_FLOAT, 0, 0, 0, 0, 0 }, 7));
+        _semantic.push_back({ "x", PLY_FLOAT, 0 });
+        _semantic.push_back({ "y", PLY_FLOAT,  0});
+        _semantic.push_back({ "z", PLY_FLOAT,  0});
+        _semantic.push_back({ "nx", PLY_FLOAT, 1});
+        _semantic.push_back({ "ny", PLY_FLOAT,  1});
+        _semantic.push_back({ "nz", PLY_FLOAT,  1});
+        _semantic.push_back({ "red", PLY_UCHAR,  2});
+        _semantic.push_back({ "green", PLY_UCHAR,  2});
+        _semantic.push_back({ "blue", PLY_UCHAR,  2});
+        _semantic.push_back({ "alpha", PLY_UCHAR,  2});
+        _semantic.push_back({ "u", PLY_FLOAT, 3});
+        _semantic.push_back({ "v", PLY_FLOAT,  3});
+        _semantic.push_back({ "ambient_red", PLY_UCHAR, 4});
+        _semantic.push_back({ "ambient_green", PLY_UCHAR, 4});
+        _semantic.push_back({ "ambient_blue", PLY_UCHAR, 4});
+        _semantic.push_back({ "diffuse_red", PLY_UCHAR,  5});
+        _semantic.push_back({ "diffuse_green", PLY_UCHAR,  5});
+        _semantic.push_back({ "diffuse_blue", PLY_UCHAR, 5});
+        _semantic.push_back({ "specular_red", PLY_UCHAR, 6});
+        _semantic.push_back({ "specular_green", PLY_UCHAR,  6});
+        _semantic.push_back({ "specular_blue", PLY_UCHAR, 6});
+        _semantic.push_back({ "specular_coeff", PLY_FLOAT,  7});
+        _semantic.push_back({ "specular_power", PLY_FLOAT, 7});
     }
 
     virtual const char* className() const { return "ReaderWriterPLY"; }

--- a/src/osgPlugins/ply/ReaderWriterPLY.cpp
+++ b/src/osgPlugins/ply/ReaderWriterPLY.cpp
@@ -44,7 +44,7 @@ class ReaderWriterPLY : public osgDB::ReaderWriter
 public:
     ReaderWriterPLY()
     {
-        supportsExtension("ply","Stanford Triangle Meta Format");
+        supportsExtension("ply","Stanford Meta Format");
 
         /** Note semantics from Equalizer LGPL source.*/
         //assuming compact aliasing (only name and internal format is meaningfull
@@ -71,6 +71,9 @@ public:
         _semantic.push_back({ "specular_blue", PLY_UCHAR, 6});
         _semantic.push_back({ "specular_coeff", PLY_FLOAT,  7});
         _semantic.push_back({ "specular_power", PLY_FLOAT, 7});
+
+
+        _semantic.push_back({ "vertex_indices", -1, -1}); //autotyped uint
     }
 
     virtual const char* className() const { return "ReaderWriterPLY"; }

--- a/src/osgPlugins/ply/ReaderWriterPLY.cpp
+++ b/src/osgPlugins/ply/ReaderWriterPLY.cpp
@@ -51,9 +51,9 @@ struct _Vertex
     unsigned char   green;
     unsigned char   blue;
     unsigned char   alpha;
-    float   ambient_red;
-   float   ambient_green;
-    float   ambient_blue;
+    unsigned char   ambient_red;
+    unsigned char   ambient_green;
+    unsigned char   ambient_blue;
     unsigned char   diffuse_red;
     unsigned char   diffuse_green;
     unsigned char   diffuse_blue;
@@ -62,9 +62,9 @@ struct _Vertex
     unsigned char   specular_blue;
     float           specular_coeff;
     float           specular_power;
-    float texture_u;
-    float texture_v;
-} vertex;
+    float           texture_u;
+    float           texture_v;
+};
 
 class ReaderWriterPLY : public osgDB::ReaderWriter
 {
@@ -72,29 +72,31 @@ public:
     ReaderWriterPLY()
     {
         supportsExtension("ply","Stanford Triangle Meta Format");
-        _semantic.push_back(ply::VertexSemantic({ "x", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, x ), 0, 0, 0, 0 },0));
-        _semantic.push_back(ply::VertexSemantic({ "y", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, y ), 0, 0, 0, 0 },0));
-        _semantic.push_back(ply::VertexSemantic({ "z", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, z ), 0, 0, 0, 0 },0));
-        _semantic.push_back(ply::VertexSemantic({ "nx", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, nx ), 0, 0, 0, 0 },1));
-        _semantic.push_back(ply::VertexSemantic({ "ny", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, ny), 0, 0, 0, 0 },1));
-        _semantic.push_back(ply::VertexSemantic({ "nz", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, nz), 0, 0, 0, 0 },1));
-        _semantic.push_back(ply::VertexSemantic({ "red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, red ), 0, 0, 0, 0 },2));
-        _semantic.push_back(ply::VertexSemantic({ "green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, green ), 0, 0, 0, 0 },2));
-        _semantic.push_back(ply::VertexSemantic({ "blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, blue ), 0, 0, 0, 0 },2));
-        _semantic.push_back(ply::VertexSemantic({ "alpha", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, alpha ), 0, 0, 0, 0 },2));
-        _semantic.push_back(ply::VertexSemantic({ "ambient_red", PLY_UCHAR, PLY_FLOAT, offsetof( _Vertex, ambient_red ), 0, 0, 0, 0 },3));
-        _semantic.push_back(ply::VertexSemantic({ "ambient_green", PLY_UCHAR, PLY_FLOAT, offsetof( _Vertex, ambient_green ), 0, 0, 0, 0 },3));
-        _semantic.push_back(ply::VertexSemantic({ "ambient_blue", PLY_UCHAR, PLY_FLOAT, offsetof( _Vertex, ambient_blue ), 0, 0, 0, 0 },3));
-        _semantic.push_back(ply::VertexSemantic({ "diffuse_red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_red ), 0, 0, 0, 0 },4));
-        _semantic.push_back(ply::VertexSemantic({ "diffuse_green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_green ), 0, 0, 0, 0 },4));
-        _semantic.push_back(ply::VertexSemantic({ "diffuse_blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_blue ), 0, 0, 0, 0 },4));
-        _semantic.push_back(ply::VertexSemantic({ "specular_red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_red ), 0, 0, 0, 0 },5));
-        _semantic.push_back(ply::VertexSemantic({ "specular_green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_green ), 0, 0, 0, 0 },5));
-        _semantic.push_back(ply::VertexSemantic({ "specular_blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_blue ), 0, 0, 0, 0 },5));
-        _semantic.push_back(ply::VertexSemantic({ "specular_coeff", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, specular_coeff ), 0, 0, 0, 0 },6));
-        _semantic.push_back(ply::VertexSemantic({ "specular_power", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, specular_power ), 0, 0, 0, 0 },6));
-        _semantic.push_back(ply::VertexSemantic({ "texture_u", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, texture_u), 0, 0, 0, 0 },7));
-        _semantic.push_back(ply::VertexSemantic({ "texture_v", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, texture_v), 0, 0, 0, 0 },7));
+
+        //assuming compact aliasing
+        _semantic.push_back(ply::VertexSemantic({ "x", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, x ), 0, 0, 0, 0 }, 0));
+        _semantic.push_back(ply::VertexSemantic({ "y", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, y ), 0, 0, 0, 0 }, 0));
+        _semantic.push_back(ply::VertexSemantic({ "z", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, z ), 0, 0, 0, 0 }, 0));
+        _semantic.push_back(ply::VertexSemantic({ "nx", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, nx ), 0, 0, 0, 0 }, 1));
+        _semantic.push_back(ply::VertexSemantic({ "ny", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, ny), 0, 0, 0, 0 }, 1));
+        _semantic.push_back(ply::VertexSemantic({ "nz", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, nz), 0, 0, 0, 0 }, 1));
+        _semantic.push_back(ply::VertexSemantic({ "red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, red ), 0, 0, 0, 0 }, 2));
+        _semantic.push_back(ply::VertexSemantic({ "green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, green ), 0, 0, 0, 0 }, 2));
+        _semantic.push_back(ply::VertexSemantic({ "blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, blue ), 0, 0, 0, 0 } , 2));
+        _semantic.push_back(ply::VertexSemantic({ "alpha", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, alpha ), 0, 0, 0, 0 }, 2));
+        _semantic.push_back(ply::VertexSemantic({ "texture_u", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, texture_u), 0, 0, 0, 0 }, 3));
+        _semantic.push_back(ply::VertexSemantic({ "texture_v", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, texture_v), 0, 0, 0, 0 }, 3));
+        _semantic.push_back(ply::VertexSemantic({ "ambient_red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, ambient_red ), 0, 0, 0, 0 }, 4));
+        _semantic.push_back(ply::VertexSemantic({ "ambient_green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, ambient_green ), 0, 0, 0, 0 }, 4));
+        _semantic.push_back(ply::VertexSemantic({ "ambient_blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, ambient_blue ), 0, 0, 0, 0 }, 4));
+        _semantic.push_back(ply::VertexSemantic({ "diffuse_red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_red ), 0, 0, 0, 0 }, 5));
+        _semantic.push_back(ply::VertexSemantic({ "diffuse_green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_green ), 0, 0, 0, 0 }, 5));
+        _semantic.push_back(ply::VertexSemantic({ "diffuse_blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_blue ), 0, 0, 0, 0 }, 5));
+        _semantic.push_back(ply::VertexSemantic({ "specular_red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_red ), 0, 0, 0, 0 }, 6));
+        _semantic.push_back(ply::VertexSemantic({ "specular_green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_green ), 0, 0, 0, 0 }, 6));
+        _semantic.push_back(ply::VertexSemantic({ "specular_blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_blue ), 0, 0, 0, 0 }, 6));
+        _semantic.push_back(ply::VertexSemantic({ "specular_coeff", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, specular_coeff ), 0, 0, 0, 0 }, 7));
+        _semantic.push_back(ply::VertexSemantic({ "specular_power", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, specular_power ), 0, 0, 0, 0 }, 7));
     }
 
     virtual const char* className() const { return "ReaderWriterPLY"; }

--- a/src/osgPlugins/ply/vertexData.cpp
+++ b/src/osgPlugins/ply/vertexData.cpp
@@ -1,6 +1,7 @@
 /*
     vertexData.cpp
     Copyright (c) 2007, Tobias Wolf <twolf@access.unizh.ch>
+    Copyright (c) 2020, Julien Valentin <mp3butcher@hotmail.com>
     All rights reserved.
 
     Implementation of the VertexData class.
@@ -26,200 +27,200 @@ using namespace ply;
 
 template<int PLYType> struct DrawElementCreator: public DrawElementFactory
 {
-    virtual osg::DrawElements * getDrawElement(){ OSG_FATAL<<"ply::VertexData: DrawElementCreator not implemented: "<<std::endl; return 0;}
+    virtual osg::DrawElements * createDrawElement(){ OSG_FATAL<<"ply::VertexData: DrawElementCreator not implemented: "<<std::endl; return 0;}
     virtual void addElement(char * dataptr,osg::Array* arr){ OSG_FATAL<<"ply::VertexData: DrawElementCreator not implemented: "<<std::endl;}
 };
 template<> struct DrawElementCreator<PLY_UCHAR>: public DrawElementFactory
 {
-    virtual osg::DrawElements * getDrawElement(){ return new osg::DrawElementsUByte; }
-    virtual void addElement(char * dataptr,osg::DrawElements* arr){ char *ptr=dataptr; static_cast<osg::DrawElementsUByte*>(arr)->push_back(ptr[0]); }
+    virtual osg::DrawElements * createDrawElement(){ return new osg::DrawElementsUByte; }
+    virtual void addElement(char * dataptr,osg::DrawElements* arr){ unsigned char *ptr=(unsigned char*)dataptr; static_cast<osg::DrawElementsUByte*>(arr)->push_back(ptr[0]); }
 };
 template<> struct DrawElementCreator<PLY_USHORT>: public DrawElementFactory
 {
-    virtual osg::DrawElements * getDrawElement(){ return new osg::DrawElementsUShort; }
-    virtual void addElement(char * dataptr,osg::DrawElements* arr){ char *ptr=dataptr; static_cast<osg::DrawElementsUShort*>(arr)->push_back(ptr[0]); }
+    virtual osg::DrawElements * createDrawElement(){ return new osg::DrawElementsUShort; }
+    virtual void addElement(char * dataptr,osg::DrawElements* arr){ unsigned short *ptr=(unsigned short*)dataptr; static_cast<osg::DrawElementsUShort*>(arr)->push_back(ptr[0]); }
 };
 template<> struct DrawElementCreator<PLY_UINT>: public DrawElementFactory
 {
-    virtual osg::DrawElements * getDrawElement(){ return new osg::DrawElementsUInt; }
-    virtual void addElement(char * dataptr,osg::DrawElements* arr){ char *ptr=dataptr; static_cast<osg::DrawElementsUInt*>(arr)->push_back(ptr[0]); }
+    virtual osg::DrawElements * createDrawElement(){ return new osg::DrawElementsUInt; }
+    virtual void addElement(char * dataptr,osg::DrawElements* arr){ unsigned int *ptr=(unsigned int*)dataptr; static_cast<osg::DrawElementsUInt*>(arr)->push_back(ptr[0]); }
 };
 
 
 template<int PLYType, int numcomp> struct ArrayCreator: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ OSG_FATAL<<"ply::VertexData: ArrayCreator not implemented: "<<std::endl; return 0;}
+    virtual osg::Array * createArray(){ OSG_FATAL<<"ply::VertexData: ArrayCreator not implemented: "<<std::endl; return 0;}
     virtual void addElement(char * dataptr,osg::Array* arr){ OSG_FATAL<<"ply::VertexData: ArrayCreator not implemented: "<<std::endl;}
 };
 //
 template<> struct ArrayCreator<PLY_CHAR,0>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::ByteArray; }
+    virtual osg::Array * createArray(){ return new osg::ByteArray; }
     virtual void addElement(char * dataptr,osg::Array* arr){ char *ptr=dataptr; static_cast<osg::ByteArray*>(arr)->push_back(ptr[0]); }
 };
 template<> struct ArrayCreator<PLY_CHAR,1>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec2bArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec2bArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ char *ptr=dataptr; static_cast<osg::Vec2bArray*>(arr)->push_back(osg::Vec2b(ptr[0],ptr[1])); }
 };
 template<> struct ArrayCreator<PLY_CHAR,2>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec3bArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec3bArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ char *ptr=dataptr; static_cast<osg::Vec3bArray*>(arr)->push_back(osg::Vec3b(ptr[0],ptr[1],ptr[2])); }
 };
 template<> struct ArrayCreator<PLY_CHAR,3>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec4bArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec4bArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ char *ptr=dataptr; static_cast<osg::Vec4bArray*>(arr)->push_back(osg::Vec4b(ptr[0],ptr[1],ptr[2],ptr[3])); }
 };
 //
 template<> struct ArrayCreator<PLY_UCHAR,0>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::UByteArray; }
+    virtual osg::Array * createArray(){ return new osg::UByteArray; }
     virtual void addElement(char * dataptr,osg::Array* arr){ unsigned char *ptr=(unsigned char*)dataptr; static_cast<osg::UByteArray*>(arr)->push_back(ptr[0]); }
 };
 template<> struct ArrayCreator<PLY_UCHAR,1>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec2ubArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec2ubArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ unsigned char *ptr=(unsigned char*)dataptr; static_cast<osg::Vec2ubArray*>(arr)->push_back(osg::Vec2ub(ptr[0],ptr[1])); }
 };
 template<> struct ArrayCreator<PLY_UCHAR,2>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec3ubArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec3ubArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ unsigned char *ptr=(unsigned char*)dataptr; static_cast<osg::Vec3ubArray*>(arr)->push_back(osg::Vec3ub(ptr[0],ptr[1],ptr[2])); }
 };
 template<> struct ArrayCreator<PLY_UCHAR,3>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec4ubArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec4ubArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ unsigned char *ptr=(unsigned char*)dataptr; static_cast<osg::Vec4ubArray*>(arr)->push_back(osg::Vec4ub(ptr[0],ptr[1],ptr[2],ptr[3])); }
 };
 //
 template<> struct ArrayCreator<PLY_SHORT,0>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::ShortArray; }
+    virtual osg::Array * createArray(){ return new osg::ShortArray; }
     virtual void addElement(char * dataptr,osg::Array* arr){ short *ptr=(short*)dataptr; static_cast<osg::ShortArray*>(arr)->push_back(ptr[0]); }
 };
 template<> struct ArrayCreator<PLY_SHORT,1>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec2sArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec2sArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ short *ptr=(short*)dataptr; static_cast<osg::Vec2sArray*>(arr)->push_back(osg::Vec2s(ptr[0],ptr[1])); }
 };
 template<> struct ArrayCreator<PLY_SHORT,2>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec3sArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec3sArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ short *ptr=(short*)dataptr; static_cast<osg::Vec3sArray*>(arr)->push_back(osg::Vec3s(ptr[0],ptr[1],ptr[2])); }
 };
 template<> struct ArrayCreator<PLY_SHORT,3>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec4sArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec4sArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ short *ptr=(short*)dataptr; static_cast<osg::Vec4sArray*>(arr)->push_back(osg::Vec4s(ptr[0],ptr[1],ptr[2],ptr[3])); }
 };
 //
 template<> struct ArrayCreator<PLY_USHORT,0>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::UShortArray; }
+    virtual osg::Array * createArray(){ return new osg::UShortArray; }
     virtual void addElement(char * dataptr,osg::Array* arr){ unsigned short *ptr=(unsigned short*)dataptr; static_cast<osg::UShortArray*>(arr)->push_back(ptr[0]); }
 };
 template<> struct ArrayCreator<PLY_USHORT,1>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec2usArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec2usArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ unsigned short *ptr=(unsigned short*)dataptr; static_cast<osg::Vec2usArray*>(arr)->push_back(osg::Vec2us(ptr[0],ptr[1])); }
 };
 template<> struct ArrayCreator<PLY_USHORT,2>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec3usArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec3usArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ unsigned short *ptr=(unsigned short*)dataptr; static_cast<osg::Vec3usArray*>(arr)->push_back(osg::Vec3us(ptr[0],ptr[1],ptr[2])); }
 };
 template<> struct ArrayCreator<PLY_USHORT,3>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec4usArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec4usArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ unsigned short *ptr=(unsigned short*)dataptr; static_cast<osg::Vec4usArray*>(arr)->push_back(osg::Vec4us(ptr[0],ptr[1],ptr[2],ptr[3])); }
 };
 
 //
 template<> struct ArrayCreator<PLY_INT,0>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::IntArray; }
+    virtual osg::Array * createArray(){ return new osg::IntArray; }
     virtual void addElement(char * dataptr,osg::Array* arr){ int *ptr=(int*)dataptr; static_cast<osg::IntArray*>(arr)->push_back(ptr[0]); }
 };
 template<> struct ArrayCreator<PLY_INT,1>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec2iArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec2iArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ int *ptr=(int*)dataptr; static_cast<osg::Vec2iArray*>(arr)->push_back(osg::Vec2i(ptr[0],ptr[1])); }
 };
 template<> struct ArrayCreator<PLY_INT,2>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec3iArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec3iArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ int *ptr=(int*)dataptr; static_cast<osg::Vec3iArray*>(arr)->push_back(osg::Vec3i(ptr[0],ptr[1],ptr[2])); }
 };
 template<> struct ArrayCreator<PLY_INT,3>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec4iArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec4iArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ int *ptr=(int*)dataptr; static_cast<osg::Vec4iArray*>(arr)->push_back(osg::Vec4i(ptr[0],ptr[1],ptr[2],ptr[3])); }
 };
 //
 template<> struct ArrayCreator<PLY_UINT,0>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::UIntArray; }
+    virtual osg::Array * createArray(){ return new osg::UIntArray; }
     virtual void addElement(char * dataptr,osg::Array* arr){ unsigned int *ptr=(unsigned int*)dataptr; static_cast<osg::UIntArray*>(arr)->push_back(ptr[0]); }
 };
 template<> struct ArrayCreator<PLY_UINT,1>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec2uiArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec2uiArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ unsigned int *ptr=(unsigned int*)dataptr; static_cast<osg::Vec2uiArray*>(arr)->push_back(osg::Vec2ui(ptr[0],ptr[1])); }
 };
 template<> struct ArrayCreator<PLY_UINT,2>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec3uiArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec3uiArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ unsigned int *ptr=(unsigned int*)dataptr; static_cast<osg::Vec3uiArray*>(arr)->push_back(osg::Vec3ui(ptr[0],ptr[1],ptr[2])); }
 };
 template<> struct ArrayCreator<PLY_UINT,3>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec4uiArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec4uiArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ unsigned int *ptr=(unsigned int*)dataptr; static_cast<osg::Vec4uiArray*>(arr)->push_back(osg::Vec4ui(ptr[0],ptr[1],ptr[2],ptr[3])); }
 };
 
 //
 template<> struct ArrayCreator<PLY_FLOAT,0>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::FloatArray; }
+    virtual osg::Array * createArray(){ return new osg::FloatArray; }
     virtual void addElement(char * dataptr,osg::Array* arr){ float *ptr=(float*)dataptr; static_cast<osg::FloatArray*>(arr)->push_back(ptr[0]); }
 };
 template<> struct ArrayCreator<PLY_FLOAT,1>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec2Array; }
+    virtual osg::Array * createArray(){ return new osg::Vec2Array; }
     virtual void addElement(char * dataptr, osg::Array* arr){ float *ptr=(float*)dataptr; static_cast<osg::Vec2Array*>(arr)->push_back(osg::Vec2(ptr[0],ptr[1])); }
 };
 template<> struct ArrayCreator<PLY_FLOAT,2>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec3Array; }
+    virtual osg::Array * createArray(){ return new osg::Vec3Array; }
     virtual void addElement(char * dataptr, osg::Array* arr){ float *ptr=(float*)dataptr; static_cast<osg::Vec3Array*>(arr)->push_back(osg::Vec3(ptr[0],ptr[1],ptr[2])); }
 };
 template<> struct ArrayCreator<PLY_FLOAT,3>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec4Array; }
+    virtual osg::Array * createArray(){ return new osg::Vec4Array; }
     virtual void addElement(char * dataptr, osg::Array* arr){ float *ptr=(float*)dataptr; static_cast<osg::Vec4Array*>(arr)->push_back(osg::Vec4(ptr[0],ptr[1],ptr[2],ptr[3])); }
 };
 
 //
 template<> struct ArrayCreator<PLY_DOUBLE,0>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::DoubleArray; }
+    virtual osg::Array * createArray(){ return new osg::DoubleArray; }
     virtual void addElement(char * dataptr,osg::Array* arr){ double *ptr=(double*)dataptr; static_cast<osg::DoubleArray*>(arr)->push_back(ptr[0]); }
 };
 template<> struct ArrayCreator<PLY_DOUBLE,1>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec2dArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec2dArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ double *ptr=(double*)dataptr; static_cast<osg::Vec2dArray*>(arr)->push_back(osg::Vec2d(ptr[0],ptr[1])); }
 };
 template<> struct ArrayCreator<PLY_DOUBLE,2>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec3dArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec3dArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ double *ptr=(double*)dataptr; static_cast<osg::Vec3dArray*>(arr)->push_back(osg::Vec3d(ptr[0],ptr[1],ptr[2])); }
 };
 template<> struct ArrayCreator<PLY_DOUBLE,3>: public ArrayFactory
 {
-    virtual osg::Array * getArray(){ return new osg::Vec4dArray; }
+    virtual osg::Array * createArray(){ return new osg::Vec4dArray; }
     virtual void addElement(char * dataptr, osg::Array* arr){ double *ptr=(double*)dataptr; static_cast<osg::Vec4dArray*>(arr)->push_back(osg::Vec4d(ptr[0],ptr[1],ptr[2],ptr[3])); }
 };
 
@@ -273,103 +274,45 @@ VertexData::VertexData(const VertexSemantics& s)
     _arrayfactories[PLY_DOUBLE][3] = new ArrayCreator<PLY_DOUBLE,3>;
 }
 
-
-/*  Read the index data from the open file.  */
-void VertexData::readListProperty( PlyFile* file, const int nFaces, char*  elemName, PlyProperty* listprop )
+inline osg::Array * getArrayFromFactory(ArrayFactory*factarray, const char *name, int osgmapping)
 {
-    PFactAndDrawElements & out = _factoryarrayspair.back().second.second;
-    //PFactAndDrawElement triangles(_prfactories[/*listprop->internal_type*/PLY_UINT], _prfactories[/*listprop->internal_type*/PLY_UINT]->getDrawElement());
-    //PFactAndDrawElement quads(_prfactories[/*listprop->internal_type*/PLY_UINT], _prfactories[/*listprop->internal_type*/PLY_UINT]->getDrawElement());
-    osg::ref_ptr<osg::DrawElementsUInt> triangles = new osg::DrawElementsUInt(osg::PrimitiveSet::TRIANGLES);
-    osg::ref_ptr<osg::DrawElementsUInt> quads = new osg::DrawElementsUInt(osg::PrimitiveSet::QUADS);
-    // temporary face structure for ply loading
-    struct _Face
-    {
-        unsigned int   nVertices;
-        unsigned int*   vertices;
-    } face;
-
-    PlyProperty faceProps[] =
-    {
-        { listprop->name, listprop->external_type, PLY_UINT, offsetof( _Face, vertices ),
-          1, listprop->count_external, PLY_UINT, offsetof( _Face, nVertices ) }
-    };
-
-    ply_get_property( file,elemName, &faceProps[0] );
-
-    const char NUM_VERTICES_TRIANGLE(3);
-    const char NUM_VERTICES_QUAD(4);
-
-    // read the faces, reversing the reading direction if _invertFaces is true
-    for( int i = 0 ; i < nFaces; i++ )
-    {
-        // initialize face values
-        face.nVertices = 0;
-        face.vertices = 0;
-
-        ply_get_element( file, static_cast< void* >( &face ) );
-        if (face.vertices)
-        {
-            if (face.nVertices == NUM_VERTICES_TRIANGLE ||  face.nVertices == NUM_VERTICES_QUAD)
-            {
-                unsigned short index;
-                for(int j = 0 ; j < face.nVertices ; j++)
-                {
-                    index = ( _invertFaces ? face.nVertices - 1 - j : j );
-                    if(face.nVertices == 4)
-                        quads->push_back(face.vertices[index]);
-                    else
-                        triangles->push_back(face.vertices[index]);
-                }
-            }
-            // free the memory that was allocated by ply_get_element
-            free( face.vertices );
-        }
-    }
-    if(!triangles->empty())
-        out.push_back(PFactAndDrawElement(0, triangles));
-    if(!quads->empty())
-        out.push_back(PFactAndDrawElement(0, quads));
-
-}
-
-inline osg::Array * getArrayFromFactory(ArrayFactory*factarray, int curchannel)
-{
-        osg::Array* arr = factarray->getArray();
-        arr->setUserData(new osg::IntValueObject(curchannel));
+        osg::Array* arr = factarray->createArray();
+        arr->setName(name);
+        arr->setUserData(new osg::IntValueObject(osgmapping));
         return arr;
 }
 
-/*  Read the vertex and (if available/wanted) color data from the open file.  */
-void VertexData::readVertices( PlyFile* file, const int nVertices,char*  elemName, PlyProperty** props, int numprops)
+/*  Read the vertex data from the open file.  */
+void VertexData::readVertices( PlyFile* file, const int nVertices, char*  elemName, PlyProperty** props, int numprops)
 {
-    // read in the vertices
-    std::vector<int> propertyOffsets;
+    std::vector<int> arrOffsets, prOffsets;
     unsigned int totalvertexsize = 0;
-
     std::pair<std::string, APFactAndArrays> newarrayvector(elemName, APFactAndArrays());
     _factoryarrayspair.push_back(newarrayvector);
+    // read in the vertices properties
     AFactAndArrays &factoryarrays = _factoryarrayspair.back().second.first;
+    //read in lists properties
+    PFactAndDrawElements &factorydrs = _factoryarrayspair.back().second.second;
+
     {
         int curchannel = -1, numcomp = 0, curcompsize = 0; const VertexSemantic* cursem = 0;
         for(int propcpt=0; propcpt < numprops; ++propcpt)
         {
-        //search for prop in user semantics and goto next if not found (TODO add semantics through reader options)
+            //search for prop in user semantics and goto next if not found (TODO add semantics through reader options)
             VertexSemantics::iterator semit;
-            for( semit =_semantics.begin(); semit!=_semantics.end() &&strcmp(props[propcpt]->name,semit->name)!=0; ++semit);
-            if(semit==_semantics.end()) continue;
+            for(semit =_semantics.begin(); semit != _semantics.end() && strcmp(props[propcpt]->name, semit->name)!=0; ++semit);
+            if(semit == _semantics.end()) continue;
+
             VertexSemantic &sem = *semit;
-            if(props[propcpt]->is_list )
+
+            if(props[propcpt]->is_list==0)
             {
-                readListProperty(  file, nVertices, elemName, props[propcpt]);
-                continue;
+                //setup user property
+                PlyProperty &propcop  = *props[propcpt];
+                propcop.offset = totalvertexsize + curcompsize;
+                propcop.internal_type = sem.internal_type;
+                ply_get_property( file, elemName, &propcop);
             }
-
-            //setup user property
-            props[propcpt]->offset = totalvertexsize+curcompsize;
-            props[propcpt]->internal_type = sem.internal_type;
-            ply_get_property( file, elemName, props[propcpt]);
-
 
             if(curchannel != sem.osgmapping)
             {
@@ -377,13 +320,44 @@ void VertexData::readVertices( PlyFile* file, const int nVertices,char*  elemNam
                 {
                     if(numcomp>4) { OSG_FATAL<<"osg ply plugin doesn't support "<<numcomp<<" components arrays, trying 4 instead"<<std::endl; numcomp = 4; }
                     ArrayFactory * factarray = _arrayfactories[cursem->internal_type][numcomp-1];
-                    if(factarray) factoryarrays.push_back(AFactAndArray(factarray, getArrayFromFactory(factarray, curchannel)));
-                    propertyOffsets.push_back(totalvertexsize);
+                    if(factarray) factoryarrays.push_back(AFactAndArray(factarray, getArrayFromFactory(factarray, cursem->name, curchannel)));
+                    arrOffsets.push_back(totalvertexsize);
                     totalvertexsize +=  curcompsize;
                 }
                 numcomp = 0; curcompsize = 0; cursem = &sem;
                 curchannel = sem.osgmapping;
             }
+
+            if( props[propcpt]->is_list == 1 )
+            {
+                DrawElementFactory * factarray = _prfactories[PLY_UINT];
+                if(factarray)
+                {
+                    osg::DrawElements* dr;
+                    factorydrs.push_back(PFactAndDrawElement(factarray, factarray->createDrawElement())); dr = factorydrs.back().second;
+                    dr->setName(cursem->name); dr->setMode(GL_LINES);
+                    factorydrs.push_back(PFactAndDrawElement(factarray, factarray->createDrawElement())); dr = factorydrs.back().second;
+                    dr->setName(cursem->name); dr->setMode(GL_TRIANGLES);
+                    factorydrs.push_back(PFactAndDrawElement(factarray, factarray->createDrawElement())); dr = factorydrs.back().second;
+                    dr->setName(cursem->name); dr->setMode(GL_QUADS);
+                    factorydrs.push_back(PFactAndDrawElement(factarray, factarray->createDrawElement())); dr = factorydrs.back().second;
+                    dr->setName(cursem->name); dr->setMode(GL_POLYGON);
+                }
+                prOffsets.push_back(totalvertexsize);
+                prOffsets.push_back(totalvertexsize+4);
+                //setup user property
+                PlyProperty &propcop  = *props[propcpt];
+                propcop.offset = totalvertexsize + 4;
+                propcop.count_offset = totalvertexsize;
+                propcop.internal_type = PLY_UINT;
+                propcop.count_internal = PLY_UINT;
+                ply_get_property( file, elemName, &propcop);
+                totalvertexsize += 8;
+                numcomp = 0; curcompsize = 0; cursem = &sem;
+                curchannel = sem.osgmapping;
+                continue;
+            }
+
             numcomp++;
             switch (sem.internal_type)
             {
@@ -402,28 +376,57 @@ void VertexData::readVertices( PlyFile* file, const int nVertices,char*  elemNam
                     OSG_WARN<<"ply::VertexData: unknown internal_type" <<sem.internal_type<<" not implemented,"<<std::endl;
             }
 
+
         }
-        if(numcomp != 0){
+        if(numcomp != 0)
+        {
             if(numcomp>4) { OSG_FATAL<<"osg ply plugin doesn't support "<<numcomp<<" components arrays, trying 4 instead"<<std::endl; numcomp = 4; }
             ArrayFactory * factarray = _arrayfactories[cursem->internal_type][numcomp-1];
-            if(factarray) factoryarrays.push_back(AFactAndArray(factarray, getArrayFromFactory(factarray, curchannel)));
-            propertyOffsets.push_back(totalvertexsize);
+            if(factarray) factoryarrays.push_back(AFactAndArray(factarray, getArrayFromFactory(factarray, cursem->name, curchannel)));
+            arrOffsets.push_back(totalvertexsize);
             totalvertexsize +=  curcompsize;
         }
     }
-    if(totalvertexsize>0)
+    if(totalvertexsize > 0)
     {
         char * rawvertex= new char[totalvertexsize];
-        for( int i = 0; i < nVertices; ++i )
+        for( int vertcpt = 0; vertcpt < nVertices; ++vertcpt )
         {
             ply_get_element( file, static_cast< void* >( rawvertex ) );
 
             ///convert rawvertex to osg
             int curprop = 0;
-            for(std::vector<AFactAndArray>::iterator arrit = factoryarrays.begin(); arrit != factoryarrays.end(); ++arrit)
+            for(AFactAndArrays::iterator arrit = factoryarrays.begin(); arrit != factoryarrays.end(); ++arrit)
             {
-                arrit->first->addElement((char*)rawvertex+propertyOffsets[curprop++], arrit->second);
+                arrit->first->addElement(rawvertex + arrOffsets[curprop++], arrit->second);
             }
+            curprop = 0; unsigned int *face=0;
+
+            for(PFactAndDrawElements::iterator arrit = factorydrs.begin(); arrit != factorydrs.end(); arrit+=4)
+            {
+                osg::DrawElements * lines = arrit->second;
+                osg::DrawElements * triangles = (arrit+1)->second;
+                osg::DrawElements * quads = (arrit+2)->second;
+                osg::DrawElements * polygons = (arrit+3)->second;
+
+                unsigned int vcount = *(unsigned int*)( rawvertex + prOffsets[curprop++]);
+                osg::DrawElements * drelmt = 0;
+                switch(vcount){
+                    case 2: drelmt = lines;     break;
+                    case 3: drelmt = triangles; break;
+                    case 4: drelmt = quads;     break;
+                default:
+                    drelmt = polygons;
+                }
+
+                face = *(unsigned int**)( rawvertex + prOffsets[curprop++] );
+                for(unsigned int j=0; j<vcount; ++j)
+                {
+                    arrit->first->addElement((char*)(face+j), drelmt);
+                }
+               free(face);
+            }
+
         }
         delete rawvertex;
     }
@@ -519,7 +522,8 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
         #endif
 
         {
-            try {
+            try
+            {
                 // Read vertices and store in a std::vector array
                 readVertices( file, nElems, elemNames[i], props, nProps );
                 result = true;
@@ -531,7 +535,6 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
                 // stop for loop by setting the loop variable to break condition
                 // this way resources still get released even on error cases
                 i = nPlyElems;
-
             }
         }       
 
@@ -554,24 +557,10 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
         // Create geometry node
         osg::Geometry* geom  =  new osg::Geometry;
 
-        // Add the primitive set
-        bool hasTriOrQuads = false;
-        if (_triangles.valid() && _triangles->size() > 0 )
-        {
-            geom->addPrimitiveSet(_triangles.get());
-            hasTriOrQuads = true;
-        }
-
-        if (_quads.valid() && _quads->size() > 0 )
-        {
-            geom->addPrimitiveSet(_quads.get());
-            hasTriOrQuads = true;
-        }
-        // Assuming First Element is vertices
+        //1 Assuming First Element is vertices
         std::vector< std::pair<std::string, APFactAndArrays> >::iterator elementarraysit = _factoryarrayspair.begin();
         AFactAndArrays &factoryarrays = elementarraysit->second.first;
         int numvertices = factoryarrays[0].second->getNumElements();
-
 
        for(std::vector<AFactAndArray>::iterator arrit = factoryarrays.begin(); arrit != factoryarrays.end(); ++arrit)
        {
@@ -581,39 +570,48 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
             a->setUserData(NULL);
         }
 
-        // Assuming Second Element has a list with primitiveset indices
+        //2 Assuming Second Element has a list with primitiveset indices
         elementarraysit++;
         PFactAndDrawElements &factoryprs = elementarraysit->second.second;
 
         // Print points if the file contains unsupported primitives
         if(factoryprs.empty())
             geom->addPrimitiveSet(new osg::DrawArrays(GL_POINTS, 0, numvertices));
+        else
+            for(std::vector<PFactAndDrawElement>::iterator arrit = factoryprs.begin(); arrit != factoryprs.end(); ++arrit)
+            {
+                osg::DrawElements* a = arrit->second;
+                if(a->getNumIndices()>0)
+                    geom->addPrimitiveSet(a);
+                a->setUserData(NULL);
+            }
 
-        for(std::vector<PFactAndDrawElement>::iterator arrit = factoryprs.begin(); arrit != factoryprs.end(); ++arrit)
+        /// create Object Hierarchy and set it as geoemtry userdata
+        osg::Node * plyobj = new osg::Node;
+        for(elementarraysit = _factoryarrayspair.begin(); elementarraysit != _factoryarrayspair.end(); ++elementarraysit)
         {
-            osg::DrawElements* a = arrit->second;
-            geom->addPrimitiveSet(a);
-            a->setUserData(NULL);
-        }
-
-        for(; elementarraysit!=_factoryarrayspair.end(); ++elementarraysit)
-        {
+             osg::Node * elmt = new osg::Node;
+             elmt->setName(elementarraysit->first);
             factoryarrays = elementarraysit->second.first;
             for(std::vector<AFactAndArray>::iterator arrit = factoryarrays.begin(); arrit != factoryarrays.end(); ++arrit)
             {
                  osg::Array* a = arrit->second;
-                 geom->getOrCreateUserDataContainer()->addUserObject(a);
+                 elmt->getOrCreateUserDataContainer()->addUserObject(a);
                  a->setUserData(NULL);
              }
             factoryprs = elementarraysit->second.second;
             for(std::vector<PFactAndDrawElement>::iterator arrit = factoryprs.begin(); arrit != factoryprs.end(); ++arrit)
             {
                 osg::DrawElements* a = arrit->second;
-                geom->getOrCreateUserDataContainer()->addUserObject(a);
+                if(a->getNumIndices()>0)
+                    elmt->getOrCreateUserDataContainer()->addUserObject(a);
                 a->setUserData(NULL);
             }
+            plyobj->getOrCreateUserDataContainer()->addUserObject(elmt);
         }
-        // set flage true to activate the vertex buffer object of drawable
+        geom->setUserData(plyobj);
+
+        // set flag true to activate the vertex buffer object of drawable
         geom->setUseVertexBufferObjects(true);
 
         osg::ref_ptr<osg::Image> image;

--- a/src/osgPlugins/ply/vertexData.cpp
+++ b/src/osgPlugins/ply/vertexData.cpp
@@ -10,7 +10,6 @@
 
 #include "typedefs.h"
 #include "vertexData.h"
-#include "ply.h"
 
 #include <cstdlib>
 #include <algorithm>
@@ -27,187 +26,314 @@
 using namespace std;
 using namespace ply;
 
+template<int PLYType, int numcomp>
+struct ArrayCreator: public ArrayFactory{
+virtual osg::Array * getArray(){ OSG_WARN<<"ply::VertexData: ArrayCreator not implemented: "<<std::endl; return 0;}
+    virtual void addElement(char * dataptr,osg::Array* arr){ OSG_WARN<<"ply::VertexData: ArrayCreator not implemented: "<<std::endl;}
+};
+//
+template<> struct ArrayCreator<PLY_CHAR,0>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::ByteArray; }
+    virtual void addElement(char * dataptr,osg::Array* arr){ char *ptr=dataptr; static_cast<osg::ByteArray*>(arr)->push_back(ptr[0]); }
+};
+template<> struct ArrayCreator<PLY_CHAR,1>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec2bArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ char *ptr=dataptr; static_cast<osg::Vec2bArray*>(arr)->push_back(osg::Vec2b(ptr[0],ptr[1])); }
+};
+template<> struct ArrayCreator<PLY_CHAR,2>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec3bArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ char *ptr=dataptr; static_cast<osg::Vec3bArray*>(arr)->push_back(osg::Vec3b(ptr[0],ptr[1],ptr[2])); }
+};
+template<> struct ArrayCreator<PLY_CHAR,3>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec4bArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ char *ptr=dataptr; static_cast<osg::Vec4bArray*>(arr)->push_back(osg::Vec4b(ptr[0],ptr[1],ptr[2],ptr[3])); }
+};
+//
+template<> struct ArrayCreator<PLY_UCHAR,0>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::UByteArray; }
+    virtual void addElement(char * dataptr,osg::Array* arr){ unsigned char *ptr=(unsigned char*)dataptr; static_cast<osg::UByteArray*>(arr)->push_back(ptr[0]); }
+};
+template<> struct ArrayCreator<PLY_UCHAR,1>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec2ubArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ unsigned char *ptr=(unsigned char*)dataptr; static_cast<osg::Vec2ubArray*>(arr)->push_back(osg::Vec2ub(ptr[0],ptr[1])); }
+};
+template<> struct ArrayCreator<PLY_UCHAR,2>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec3ubArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ unsigned char *ptr=(unsigned char*)dataptr; static_cast<osg::Vec3ubArray*>(arr)->push_back(osg::Vec3ub(ptr[0],ptr[1],ptr[2])); }
+};
+template<> struct ArrayCreator<PLY_UCHAR,3>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec4ubArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ unsigned char *ptr=(unsigned char*)dataptr; static_cast<osg::Vec4ubArray*>(arr)->push_back(osg::Vec4ub(ptr[0],ptr[1],ptr[2],ptr[3])); }
+};
+//
+template<> struct ArrayCreator<PLY_SHORT,0>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::ShortArray; }
+    virtual void addElement(char * dataptr,osg::Array* arr){ short *ptr=(short*)dataptr; static_cast<osg::ShortArray*>(arr)->push_back(ptr[0]); }
+};
+template<> struct ArrayCreator<PLY_SHORT,1>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec2sArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ short *ptr=(short*)dataptr; static_cast<osg::Vec2sArray*>(arr)->push_back(osg::Vec2s(ptr[0],ptr[1])); }
+};
+template<> struct ArrayCreator<PLY_SHORT,2>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec3sArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ short *ptr=(short*)dataptr; static_cast<osg::Vec3sArray*>(arr)->push_back(osg::Vec3s(ptr[0],ptr[1],ptr[2])); }
+};
+template<> struct ArrayCreator<PLY_SHORT,3>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec4sArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ short *ptr=(short*)dataptr; static_cast<osg::Vec4sArray*>(arr)->push_back(osg::Vec4s(ptr[0],ptr[1],ptr[2],ptr[3])); }
+};
+//
+template<> struct ArrayCreator<PLY_USHORT,0>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::UShortArray; }
+    virtual void addElement(char * dataptr,osg::Array* arr){ unsigned short *ptr=(unsigned short*)dataptr; static_cast<osg::UShortArray*>(arr)->push_back(ptr[0]); }
+};
+template<> struct ArrayCreator<PLY_USHORT,1>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec2usArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ unsigned short *ptr=(unsigned short*)dataptr; static_cast<osg::Vec2usArray*>(arr)->push_back(osg::Vec2us(ptr[0],ptr[1])); }
+};
+template<> struct ArrayCreator<PLY_USHORT,2>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec3usArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ unsigned short *ptr=(unsigned short*)dataptr; static_cast<osg::Vec3usArray*>(arr)->push_back(osg::Vec3us(ptr[0],ptr[1],ptr[2])); }
+};
+template<> struct ArrayCreator<PLY_USHORT,3>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec4usArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ unsigned short *ptr=(unsigned short*)dataptr; static_cast<osg::Vec4usArray*>(arr)->push_back(osg::Vec4us(ptr[0],ptr[1],ptr[2],ptr[3])); }
+};
+
+//
+template<> struct ArrayCreator<PLY_INT,0>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::IntArray; }
+    virtual void addElement(char * dataptr,osg::Array* arr){ int *ptr=(int*)dataptr; static_cast<osg::IntArray*>(arr)->push_back(ptr[0]); }
+};
+template<> struct ArrayCreator<PLY_INT,1>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec2iArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ int *ptr=(int*)dataptr; static_cast<osg::Vec2iArray*>(arr)->push_back(osg::Vec2i(ptr[0],ptr[1])); }
+};
+template<> struct ArrayCreator<PLY_INT,2>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec3iArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ int *ptr=(int*)dataptr; static_cast<osg::Vec3iArray*>(arr)->push_back(osg::Vec3i(ptr[0],ptr[1],ptr[2])); }
+};
+template<> struct ArrayCreator<PLY_INT,3>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec4iArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ int *ptr=(int*)dataptr; static_cast<osg::Vec4iArray*>(arr)->push_back(osg::Vec4i(ptr[0],ptr[1],ptr[2],ptr[3])); }
+};
+//
+template<> struct ArrayCreator<PLY_UINT,0>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::UIntArray; }
+    virtual void addElement(char * dataptr,osg::Array* arr){ unsigned int *ptr=(unsigned int*)dataptr; static_cast<osg::UIntArray*>(arr)->push_back(ptr[0]); }
+};
+template<> struct ArrayCreator<PLY_UINT,1>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec2uiArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ unsigned int *ptr=(unsigned int*)dataptr; static_cast<osg::Vec2uiArray*>(arr)->push_back(osg::Vec2ui(ptr[0],ptr[1])); }
+};
+template<> struct ArrayCreator<PLY_UINT,2>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec3uiArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ unsigned int *ptr=(unsigned int*)dataptr; static_cast<osg::Vec3uiArray*>(arr)->push_back(osg::Vec3ui(ptr[0],ptr[1],ptr[2])); }
+};
+template<> struct ArrayCreator<PLY_UINT,3>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec4uiArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ unsigned int *ptr=(unsigned int*)dataptr; static_cast<osg::Vec4uiArray*>(arr)->push_back(osg::Vec4ui(ptr[0],ptr[1],ptr[2],ptr[3])); }
+};
+
+//
+template<> struct ArrayCreator<PLY_FLOAT,0>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::FloatArray; }
+    virtual void addElement(char * dataptr,osg::Array* arr){ float *ptr=(float*)dataptr; static_cast<osg::FloatArray*>(arr)->push_back(ptr[0]); }
+};
+template<> struct ArrayCreator<PLY_FLOAT,1>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec2Array; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ float *ptr=(float*)dataptr; static_cast<osg::Vec2Array*>(arr)->push_back(osg::Vec2(ptr[0],ptr[1])); }
+};
+template<> struct ArrayCreator<PLY_FLOAT,2>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec3Array; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ float *ptr=(float*)dataptr; static_cast<osg::Vec3Array*>(arr)->push_back(osg::Vec3(ptr[0],ptr[1],ptr[2])); }
+};
+template<> struct ArrayCreator<PLY_FLOAT,3>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec4Array; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ float *ptr=(float*)dataptr; static_cast<osg::Vec4Array*>(arr)->push_back(osg::Vec4(ptr[0],ptr[1],ptr[2],ptr[3])); }
+};
+
+//
+template<> struct ArrayCreator<PLY_DOUBLE,0>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::DoubleArray; }
+    virtual void addElement(char * dataptr,osg::Array* arr){ double *ptr=(double*)dataptr; static_cast<osg::DoubleArray*>(arr)->push_back(ptr[0]); }
+};
+template<> struct ArrayCreator<PLY_DOUBLE,1>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec2dArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ double *ptr=(double*)dataptr; static_cast<osg::Vec2dArray*>(arr)->push_back(osg::Vec2d(ptr[0],ptr[1])); }
+};
+template<> struct ArrayCreator<PLY_DOUBLE,2>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec3dArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ double *ptr=(double*)dataptr; static_cast<osg::Vec3dArray*>(arr)->push_back(osg::Vec3d(ptr[0],ptr[1],ptr[2])); }
+};
+template<> struct ArrayCreator<PLY_DOUBLE,3>: public ArrayFactory
+{
+    virtual osg::Array * getArray(){ return new osg::Vec4dArray; }
+    virtual void addElement(char * dataptr, osg::Array* arr){ double *ptr=(double*)dataptr; static_cast<osg::Vec4dArray*>(arr)->push_back(osg::Vec4d(ptr[0],ptr[1],ptr[2],ptr[3])); }
+};
 
 /*  Constructor.  */
-VertexData::VertexData()
-    : _invertFaces( false )
+VertexData::VertexData(const VertexSemantics& s)
+    : _semantics(s), _invertFaces( false )
 {
-    // Initialize the members
-    _vertices = NULL;
-    _colors = NULL;
-    _normals = NULL;
-    _triangles = NULL;
-    _diffuse = NULL;
-    _ambient = NULL;
-    _specular = NULL;
-    _texcoord = NULL;
+    // Initialize array factories
+    _arrayfactories[PLY_CHAR][0]=new ArrayCreator<PLY_CHAR,0>();
+    _arrayfactories[PLY_CHAR][1]=new ArrayCreator<PLY_CHAR,1>;
+    _arrayfactories[PLY_CHAR][2]=new ArrayCreator<PLY_CHAR,2>;
+    _arrayfactories[PLY_CHAR][3]=new ArrayCreator<PLY_CHAR,3>;
+
+    _arrayfactories[PLY_UCHAR][0]=_arrayfactories[PLY_UINT8][0]=new ArrayCreator<PLY_UCHAR,0>;
+    _arrayfactories[PLY_UCHAR][1]=_arrayfactories[PLY_UINT8][1]=new ArrayCreator<PLY_UCHAR,1>;
+    _arrayfactories[PLY_UCHAR][2]=_arrayfactories[PLY_UINT8][2]=new ArrayCreator<PLY_UCHAR,2>;
+    _arrayfactories[PLY_UCHAR][3]=_arrayfactories[PLY_UINT8][3]= new ArrayCreator<PLY_UCHAR,3>;
+
+    _arrayfactories[PLY_SHORT][0]=new ArrayCreator<PLY_SHORT,0>;
+    _arrayfactories[PLY_SHORT][1]=new ArrayCreator<PLY_SHORT,1>;
+    _arrayfactories[PLY_SHORT][2]=new ArrayCreator<PLY_SHORT,2>;
+    _arrayfactories[PLY_SHORT][3]=new ArrayCreator<PLY_SHORT,3>;
+
+    _arrayfactories[PLY_USHORT][0]=new ArrayCreator<PLY_USHORT,0>;
+    _arrayfactories[PLY_USHORT][1]=new ArrayCreator<PLY_USHORT,1>;
+    _arrayfactories[PLY_USHORT][2]=new ArrayCreator<PLY_USHORT,2>;
+    _arrayfactories[PLY_USHORT][3]=new ArrayCreator<PLY_USHORT,3>;
+
+    _arrayfactories[PLY_INT][0]=_arrayfactories[PLY_UINT][0]=new ArrayCreator<PLY_INT,0>;
+    _arrayfactories[PLY_INT][1]=_arrayfactories[PLY_UINT][1]=new ArrayCreator<PLY_INT,1>;
+    _arrayfactories[PLY_INT][2]=_arrayfactories[PLY_UINT][2]=new ArrayCreator<PLY_INT,2>;
+    _arrayfactories[PLY_INT][3]=_arrayfactories[PLY_UINT][3]=new ArrayCreator<PLY_INT,3>;
+
+    _arrayfactories[PLY_UINT][0]=new ArrayCreator<PLY_UINT,0>;
+    _arrayfactories[PLY_UINT][1]=new ArrayCreator<PLY_UINT,1>;
+    _arrayfactories[PLY_UINT][2]=new ArrayCreator<PLY_UINT,2>;
+    _arrayfactories[PLY_UINT][3]=new ArrayCreator<PLY_UINT,3>;
+
+
+    _arrayfactories[PLY_FLOAT][0]=_arrayfactories[PLY_FLOAT32][0]=new ArrayCreator<PLY_FLOAT,0>;
+    _arrayfactories[PLY_FLOAT][1]=_arrayfactories[PLY_FLOAT32][1]=new ArrayCreator<PLY_FLOAT,1>;
+    _arrayfactories[PLY_FLOAT][2]=_arrayfactories[PLY_FLOAT32][2]=new ArrayCreator<PLY_FLOAT,2>;
+    _arrayfactories[PLY_FLOAT][3]=_arrayfactories[PLY_FLOAT32][3]=new ArrayCreator<PLY_FLOAT,3>;
+
+
+    _arrayfactories[PLY_DOUBLE][0]=new ArrayCreator<PLY_DOUBLE,0>;
+    _arrayfactories[PLY_DOUBLE][1]=new ArrayCreator<PLY_DOUBLE,1>;
+    _arrayfactories[PLY_DOUBLE][2]=new ArrayCreator<PLY_DOUBLE,2>;
+    _arrayfactories[PLY_DOUBLE][3]=new ArrayCreator<PLY_DOUBLE,3>;
 }
 
 
 /*  Read the vertex and (if available/wanted) color data from the open file.  */
-void VertexData::readVertices( PlyFile* file, const int nVertices,
-                               const int fields )
+void VertexData::readVertices( PlyFile* file, const int nVertices, PlyProperty** props, int numprops)
+                               //const int fields )
 {
-    // temporary vertex structure for ply loading
-    struct _Vertex
-    {
-        float           x;
-        float           y;
-        float           z;
-        float           nx;
-        float           ny;
-        float           nz;
-        unsigned char   red;
-        unsigned char   green;
-        unsigned char   blue;
-        unsigned char   alpha;
-        unsigned char   ambient_red;
-        unsigned char   ambient_green;
-        unsigned char   ambient_blue;
-        unsigned char   diffuse_red;
-        unsigned char   diffuse_green;
-        unsigned char   diffuse_blue;
-        unsigned char   specular_red;
-        unsigned char   specular_green;
-        unsigned char   specular_blue;
-        float           specular_coeff;
-        float           specular_power;
-        float texture_u;
-        float texture_v;
-    } vertex;
-
-    PlyProperty vertexProps[] =
-    {
-        { "x", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, x ), 0, 0, 0, 0 },
-        { "y", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, y ), 0, 0, 0, 0 },
-        { "z", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, z ), 0, 0, 0, 0 },
-        { "nx", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, nx ), 0, 0, 0, 0 },
-        { "ny", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, ny), 0, 0, 0, 0 },
-        { "nz", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, nz), 0, 0, 0, 0 },
-        { "red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, red ), 0, 0, 0, 0 },
-        { "green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, green ), 0, 0, 0, 0 },
-        { "blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, blue ), 0, 0, 0, 0 },
-        { "alpha", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, alpha ), 0, 0, 0, 0 },
-        { "ambient_red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, ambient_red ), 0, 0, 0, 0 },
-        { "ambient_green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, ambient_green ), 0, 0, 0, 0 },
-        { "ambient_blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, ambient_blue ), 0, 0, 0, 0 },
-        { "diffuse_red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_red ), 0, 0, 0, 0 },
-        { "diffuse_green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_green ), 0, 0, 0, 0 },
-        { "diffuse_blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, diffuse_blue ), 0, 0, 0, 0 },
-        { "specular_red", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_red ), 0, 0, 0, 0 },
-        { "specular_green", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_green ), 0, 0, 0, 0 },
-        { "specular_blue", PLY_UCHAR, PLY_UCHAR, offsetof( _Vertex, specular_blue ), 0, 0, 0, 0 },
-        { "specular_coeff", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, specular_coeff ), 0, 0, 0, 0 },
-        { "specular_power", PLY_FLOAT, PLY_FLOAT, offsetof( _Vertex, specular_power ), 0, 0, 0, 0 },
-        { "texture_u", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, texture_u), 0, 0, 0, 0 },
-        { "texture_v", PLY_FLOAT, PLY_FLOAT, offsetof(_Vertex, texture_v), 0, 0, 0, 0 },
-    };
-
-    // use all 6 properties when reading colors, only the first 3 otherwise
-    for( int i = 0; i < 3; ++i )
-        ply_get_property( file, "vertex", &vertexProps[i] );
-
-    if (fields & NORMALS)
-      for( int i = 3; i < 6; ++i )
-        ply_get_property( file, "vertex", &vertexProps[i] );
-
-    if (fields & RGB)
-      for( int i = 6; i < 9; ++i )
-        ply_get_property( file, "vertex", &vertexProps[i] );
-
-    if (fields & RGBA)
-        ply_get_property( file, "vertex", &vertexProps[9] );
-
-    if (fields & AMBIENT)
-      for( int i = 10; i < 13; ++i )
-        ply_get_property( file, "vertex", &vertexProps[i] );
-
-    if (fields & DIFFUSE)
-      for( int i = 13; i < 16; ++i )
-        ply_get_property( file, "vertex", &vertexProps[i] );
-
-    if (fields & SPECULAR)
-      for( int i = 16; i < 21; ++i )
-        ply_get_property( file, "vertex", &vertexProps[i] );
-
-    if (fields & TEXCOORD)
-        for (int i = 21; i < 23; ++i)
-            ply_get_property(file, "vertex", &vertexProps[i]);
-
-    // check whether array is valid otherwise allocate the space
-    if(!_vertices.valid())
-        _vertices = new osg::Vec3Array;
-
-    if( fields & NORMALS )
-    {
-        if(!_normals.valid())
-            _normals = new osg::Vec3Array;
-    }
-
-    // If read colors allocate space for color array
-    if( fields & RGB || fields & RGBA)
-    {
-        if(!_colors.valid())
-            _colors = new osg::Vec4Array;
-    }
-
-    if( fields & AMBIENT )
-    {
-        if(!_ambient.valid())
-            _ambient = new osg::Vec4Array;
-    }
-
-    if( fields & DIFFUSE )
-    {
-        if(!_diffuse.valid())
-            _diffuse = new osg::Vec4Array;
-    }
-
-    if( fields & SPECULAR )
-    {
-        if(!_specular.valid())
-            _specular = new osg::Vec4Array;
-    }
-    if (fields & TEXCOORD)
-    {
-        if (!_texcoord.valid())
-            _texcoord = new osg::Vec2Array;
-    }
-
     // read in the vertices
+    std::vector<int> propertyOffsets;    
+//    propertyOffsets.push_back(0);
+
+    unsigned int totalvertexsize = 0;
+    {
+        int curchannel = -1, numcomp = 0, curcompsize = 0; const PlyProperty* cursem = 0;
+        for(VertexSemantics::iterator semit =_semantics.begin(); semit!=_semantics.end(); ++semit)
+        {
+            VertexSemantic &sem = *semit;
+           //search for sem in props and goto next if not found
+            int propcpt;
+            for(propcpt = 0; propcpt< numprops && strcmp(props[propcpt]->name, sem.first.name)!=0; ++propcpt);
+            if(propcpt == numprops) continue;
+            ply_get_property( file, "vertex", &sem.first);
+            if(curchannel != sem.second)
+            {
+                if(numcomp != 0)
+                {
+                    ArrayFactory * newarray = 0;
+                    newarray = _arrayfactories[cursem->internal_type][numcomp-1];
+                    if(newarray) {
+                        osg::ref_ptr<osg::Array> arr=newarray->getArray();
+                        arr->setUserData(new osg::IntValueObject(curchannel));
+                        _factoryarrayspair.push_back(FactAndArrays(newarray,arr));
+                    }
+
+                    totalvertexsize=cursem->offset+curcompsize;
+                    propertyOffsets.push_back(cursem->offset);
+                }
+                numcomp = 0; curcompsize = 0; cursem = &sem.first;
+                curchannel = sem.second;
+            }
+            numcomp++;
+            switch (sem.first.internal_type)
+            {
+                case PLY_UINT8:    curcompsize+=sizeof(uint8_t);        break;
+                case PLY_UCHAR:    curcompsize+=sizeof(unsigned char);  break;
+                case PLY_CHAR:     curcompsize+=sizeof(char);           break;
+                case PLY_USHORT:   curcompsize+=sizeof(unsigned short); break;
+                case PLY_SHORT:    curcompsize+=sizeof(short);          break;
+                case PLY_UINT:     curcompsize+=sizeof(unsigned int);   break;
+                case PLY_INT:      curcompsize+=sizeof(int);            break;
+                case PLY_FLOAT:    curcompsize+=sizeof(float);          break;
+                case PLY_DOUBLE:   curcompsize+=sizeof(double);         break;
+                case PLY_INT32:    curcompsize+=sizeof(int32_t);        break;
+                case PLY_FLOAT32:  curcompsize+=4;                      break;
+                default:
+                    OSG_WARN<<"ply::VertexData: unknown internal_type" <<sem.first.internal_type<<" not implemented,"<<std::endl;
+            }
+
+        }
+        if(numcomp != 0){
+            ArrayFactory * newarray = 0;
+            newarray = _arrayfactories[cursem->internal_type][numcomp-1];
+            if(newarray) {
+                osg::ref_ptr<osg::Array> arr = newarray->getArray();
+                arr->setUserData(new osg::IntValueObject(curchannel));
+                _factoryarrayspair.push_back(FactAndArrays(newarray, arr));
+            }
+            totalvertexsize=cursem->offset+curcompsize;
+            propertyOffsets.push_back(cursem->offset);
+        }
+    }
+    char * rawvertex= new char[totalvertexsize];
     for( int i = 0; i < nVertices; ++i )
     {
-        ply_get_element( file, static_cast< void* >( &vertex ) );
-        _vertices->push_back( osg::Vec3( vertex.x, vertex.y, vertex.z ) );
-        if (fields & NORMALS)
-            _normals->push_back( osg::Vec3( vertex.nx, vertex.ny, vertex.nz ) );
+        ply_get_element( file, static_cast< void* >( rawvertex ) );
 
-        if( fields & RGBA )
-            _colors->push_back( osg::Vec4( (unsigned int) vertex.red / 255.0,
-                                           (unsigned int) vertex.green / 255.0 ,
-                                           (unsigned int) vertex.blue / 255.0,
-                                           (unsigned int) vertex.alpha / 255.0) );
-        else if( fields & RGB )
-            _colors->push_back( osg::Vec4( (unsigned int) vertex.red / 255.0,
-                                           (unsigned int) vertex.green / 255.0 ,
-                                           (unsigned int) vertex.blue / 255.0, 1.0 ) );
-        if( fields & AMBIENT )
-            _ambient->push_back( osg::Vec4( (unsigned int) vertex.ambient_red / 255.0,
-                                            (unsigned int) vertex.ambient_green / 255.0 ,
-                                            (unsigned int) vertex.ambient_blue / 255.0, 1.0 ) );
+        ///convert rawvertex to osg
+        int curprop=0;
 
-        if( fields & DIFFUSE )
-            _diffuse->push_back( osg::Vec4( (unsigned int) vertex.diffuse_red / 255.0,
-                                            (unsigned int) vertex.diffuse_green / 255.0 ,
-                                            (unsigned int) vertex.diffuse_blue / 255.0, 1.0 ) );
-
-        if( fields & SPECULAR )
-            _specular->push_back( osg::Vec4( (unsigned int) vertex.specular_red / 255.0,
-                                             (unsigned int) vertex.specular_green / 255.0 ,
-                                             (unsigned int) vertex.specular_blue / 255.0, 1.0 ) );
-        if (fields & TEXCOORD)
-            _texcoord->push_back(osg::Vec2(vertex.texture_u,vertex.texture_v));
+        for(std::vector<FactAndArrays>::iterator arrit = _factoryarrayspair.begin(); arrit != _factoryarrayspair.end(); ++arrit)
+        {
+            arrit->first->addElement((char*)rawvertex+propertyOffsets[curprop++], arrit->second);
+        }
     }
+    delete rawvertex;
 }
 
 
@@ -282,7 +408,8 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
     PlyFile* file = NULL;
 
     // Try to open ply file as for reading
-    try{
+    try
+    {
             file  = ply_open_for_reading( const_cast< char* >( filename ),
                                           &nPlyElems, &elemNames,
                                           &fileType, &version );
@@ -359,69 +486,9 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
         // if the string is vertex means vertex data is started
         if( equal_strings( elemNames[i], "vertex" ) )
         {
-            int fields = NONE;
-            // determine if the file stores vertex colors
-            for( int j = 0; j < nProps; ++j )
-            {
-                // if the string have the red means color info is there
-                if( equal_strings( props[j]->name, "x" ) )
-                    fields |= XYZ;
-                if( equal_strings( props[j]->name, "nx" ) )
-                    fields |= NORMALS;
-                if( equal_strings( props[j]->name, "alpha" ) )
-                    fields |= RGBA;
-                if ( equal_strings( props[j]->name, "red" ) )
-                    fields |= RGB;
-                if( equal_strings( props[j]->name, "ambient" ) )
-                    fields |= AMBIENT;
-                if( equal_strings( props[j]->name, "diffuse_red" ) )
-                    fields |= DIFFUSE;
-                if (equal_strings(props[j]->name, "specular_red"))
-                    fields |= SPECULAR;
-                if (equal_strings(props[j]->name, "texture_u"))
-                    fields |= TEXCOORD;
-                if (equal_strings(props[j]->name, "texture_v"))
-                    fields |= TEXCOORD;
-            }
-
-            if( ignoreColors )
-            {
-                fields &= ~(XYZ | NORMALS);
-                    MESHINFO << "Colors in PLY file ignored per request." << endl;
-            }
-
             try {
                 // Read vertices and store in a std::vector array
-                readVertices( file, nElems, fields );
-                // Check whether all vertices are loaded or not
-                MESHASSERT( _vertices->size() == static_cast< size_t >( nElems ) );
-
-                // Check if all the optional elements were read or not
-                if( fields & NORMALS )
-                {
-                    MESHASSERT( _normals->size() == static_cast< size_t >( nElems ) );
-                }
-                if( fields & RGB || fields & RGBA)
-                {
-                    MESHASSERT( _colors->size() == static_cast< size_t >( nElems ) );
-                }
-                if( fields & AMBIENT )
-                {
-                    MESHASSERT( _ambient->size() == static_cast< size_t >( nElems ) );
-                }
-                if( fields & DIFFUSE )
-                {
-                    MESHASSERT( _diffuse->size() == static_cast< size_t >( nElems ) );
-                }
-                if (fields & SPECULAR)
-                {
-                    MESHASSERT(_specular->size() == static_cast< size_t >(nElems));
-                }
-                if (fields & TEXCOORD)
-                {
-                    MESHASSERT(_texcoord->size() == static_cast< size_t >(nElems));
-                }
-
+                readVertices( file, nElems, props, nProps );
                 result = true;
             }
             catch( exception& e )
@@ -478,7 +545,7 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
         osg::Geometry* geom  =  new osg::Geometry;
 
         // set the vertex array
-        geom->setVertexArray(_vertices.get());
+        //geom->setVertexArray(_vertices.get());
 
         // Add the primitive set
         bool hasTriOrQuads = false;
@@ -496,13 +563,13 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
 
         // Print points if the file contains unsupported primitives
         if(!hasTriOrQuads)
-            geom->addPrimitiveSet(new osg::DrawArrays(GL_POINTS, 0, _vertices->size()));
+            geom->addPrimitiveSet(new osg::DrawArrays(GL_POINTS, 0, _factoryarrayspair[0].second->getNumElements()));
 
 
         // Apply the colours to the model; at the moment this is a
         // kludge because we only use one kind and apply them all the
         // same way. Also, the priority order is completely arbitrary
-
+/*
         if(_colors.valid())
         {
             geom->setColorArray(_colors.get(), osg::Array::BIND_PER_VERTEX );
@@ -533,6 +600,13 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
         {   // If not, use the smoothing visitor to generate them
             // (quads will be triangulated by the smoothing visitor)
             osgUtil::SmoothingVisitor::smooth((*geom), osg::PI/2);
+        }*/
+       for(std::vector<FactAndArrays>::iterator arrit = _factoryarrayspair.begin(); arrit != _factoryarrayspair.end(); ++arrit)
+       {
+            osg::Array* a = arrit->second;
+            int index = static_cast<osg::IntValueObject*>(a->getUserData())->getValue();
+            geom->setVertexAttribArray(index, a, osg::Array::BIND_PER_VERTEX );
+            a->setUserData(NULL);
         }
 
         // set flage true to activate the vertex buffer object of drawable

--- a/src/osgPlugins/ply/vertexData.cpp
+++ b/src/osgPlugins/ply/vertexData.cpp
@@ -6,8 +6,6 @@
     Implementation of the VertexData class.
 */
 
-/** note, derived from Equalizer LGPL source.*/
-
 #include "typedefs.h"
 #include "vertexData.h"
 
@@ -28,8 +26,8 @@ using namespace ply;
 
 template<int PLYType, int numcomp>
 struct ArrayCreator: public ArrayFactory{
-virtual osg::Array * getArray(){ OSG_WARN<<"ply::VertexData: ArrayCreator not implemented: "<<std::endl; return 0;}
-    virtual void addElement(char * dataptr,osg::Array* arr){ OSG_WARN<<"ply::VertexData: ArrayCreator not implemented: "<<std::endl;}
+virtual osg::Array * getArray(){ OSG_FATAL<<"ply::VertexData: ArrayCreator not implemented: "<<std::endl; return 0;}
+    virtual void addElement(char * dataptr,osg::Array* arr){ OSG_FATAL<<"ply::VertexData: ArrayCreator not implemented: "<<std::endl;}
 };
 //
 template<> struct ArrayCreator<PLY_CHAR,0>: public ArrayFactory
@@ -208,82 +206,80 @@ VertexData::VertexData(const VertexSemantics& s)
     : _semantics(s), _invertFaces( false )
 {
     // Initialize array factories
-    _arrayfactories[PLY_CHAR][0]=new ArrayCreator<PLY_CHAR,0>();
-    _arrayfactories[PLY_CHAR][1]=new ArrayCreator<PLY_CHAR,1>;
-    _arrayfactories[PLY_CHAR][2]=new ArrayCreator<PLY_CHAR,2>;
-    _arrayfactories[PLY_CHAR][3]=new ArrayCreator<PLY_CHAR,3>;
+    _arrayfactories[PLY_CHAR][0] = new ArrayCreator<PLY_CHAR,0>;
+    _arrayfactories[PLY_CHAR][1] = new ArrayCreator<PLY_CHAR,1>;
+    _arrayfactories[PLY_CHAR][2] = new ArrayCreator<PLY_CHAR,2>;
+    _arrayfactories[PLY_CHAR][3] = new ArrayCreator<PLY_CHAR,3>;
 
-    _arrayfactories[PLY_UCHAR][0]=_arrayfactories[PLY_UINT8][0]=new ArrayCreator<PLY_UCHAR,0>;
-    _arrayfactories[PLY_UCHAR][1]=_arrayfactories[PLY_UINT8][1]=new ArrayCreator<PLY_UCHAR,1>;
-    _arrayfactories[PLY_UCHAR][2]=_arrayfactories[PLY_UINT8][2]=new ArrayCreator<PLY_UCHAR,2>;
-    _arrayfactories[PLY_UCHAR][3]=_arrayfactories[PLY_UINT8][3]= new ArrayCreator<PLY_UCHAR,3>;
+    _arrayfactories[PLY_UCHAR][0] = _arrayfactories[PLY_UINT8][0] = new ArrayCreator<PLY_UCHAR,0>;
+    _arrayfactories[PLY_UCHAR][1] = _arrayfactories[PLY_UINT8][1] = new ArrayCreator<PLY_UCHAR,1>;
+    _arrayfactories[PLY_UCHAR][2] = _arrayfactories[PLY_UINT8][2] = new ArrayCreator<PLY_UCHAR,2>;
+    _arrayfactories[PLY_UCHAR][3] = _arrayfactories[PLY_UINT8][3] = new ArrayCreator<PLY_UCHAR,3>;
 
-    _arrayfactories[PLY_SHORT][0]=new ArrayCreator<PLY_SHORT,0>;
-    _arrayfactories[PLY_SHORT][1]=new ArrayCreator<PLY_SHORT,1>;
-    _arrayfactories[PLY_SHORT][2]=new ArrayCreator<PLY_SHORT,2>;
-    _arrayfactories[PLY_SHORT][3]=new ArrayCreator<PLY_SHORT,3>;
+    _arrayfactories[PLY_SHORT][0] = new ArrayCreator<PLY_SHORT,0>;
+    _arrayfactories[PLY_SHORT][1] = new ArrayCreator<PLY_SHORT,1>;
+    _arrayfactories[PLY_SHORT][2] = new ArrayCreator<PLY_SHORT,2>;
+    _arrayfactories[PLY_SHORT][3] = new ArrayCreator<PLY_SHORT,3>;
 
-    _arrayfactories[PLY_USHORT][0]=new ArrayCreator<PLY_USHORT,0>;
-    _arrayfactories[PLY_USHORT][1]=new ArrayCreator<PLY_USHORT,1>;
-    _arrayfactories[PLY_USHORT][2]=new ArrayCreator<PLY_USHORT,2>;
-    _arrayfactories[PLY_USHORT][3]=new ArrayCreator<PLY_USHORT,3>;
+    _arrayfactories[PLY_USHORT][0] = new ArrayCreator<PLY_USHORT,0>;
+    _arrayfactories[PLY_USHORT][1] = new ArrayCreator<PLY_USHORT,1>;
+    _arrayfactories[PLY_USHORT][2] = new ArrayCreator<PLY_USHORT,2>;
+    _arrayfactories[PLY_USHORT][3] = new ArrayCreator<PLY_USHORT,3>;
 
-    _arrayfactories[PLY_INT][0]=_arrayfactories[PLY_UINT][0]=new ArrayCreator<PLY_INT,0>;
-    _arrayfactories[PLY_INT][1]=_arrayfactories[PLY_UINT][1]=new ArrayCreator<PLY_INT,1>;
-    _arrayfactories[PLY_INT][2]=_arrayfactories[PLY_UINT][2]=new ArrayCreator<PLY_INT,2>;
-    _arrayfactories[PLY_INT][3]=_arrayfactories[PLY_UINT][3]=new ArrayCreator<PLY_INT,3>;
+    _arrayfactories[PLY_INT][0] = _arrayfactories[PLY_UINT][0] = new ArrayCreator<PLY_INT,0>;
+    _arrayfactories[PLY_INT][1] = _arrayfactories[PLY_UINT][1] = new ArrayCreator<PLY_INT,1>;
+    _arrayfactories[PLY_INT][2] = _arrayfactories[PLY_UINT][2] = new ArrayCreator<PLY_INT,2>;
+    _arrayfactories[PLY_INT][3] = _arrayfactories[PLY_UINT][3] = new ArrayCreator<PLY_INT,3>;
 
-    _arrayfactories[PLY_UINT][0]=new ArrayCreator<PLY_UINT,0>;
-    _arrayfactories[PLY_UINT][1]=new ArrayCreator<PLY_UINT,1>;
-    _arrayfactories[PLY_UINT][2]=new ArrayCreator<PLY_UINT,2>;
-    _arrayfactories[PLY_UINT][3]=new ArrayCreator<PLY_UINT,3>;
+    _arrayfactories[PLY_UINT][0] = new ArrayCreator<PLY_UINT,0>;
+    _arrayfactories[PLY_UINT][1] = new ArrayCreator<PLY_UINT,1>;
+    _arrayfactories[PLY_UINT][2] = new ArrayCreator<PLY_UINT,2>;
+    _arrayfactories[PLY_UINT][3] = new ArrayCreator<PLY_UINT,3>;
 
+    _arrayfactories[PLY_FLOAT][0] = _arrayfactories[PLY_FLOAT32][0] = new ArrayCreator<PLY_FLOAT,0>;
+    _arrayfactories[PLY_FLOAT][1] = _arrayfactories[PLY_FLOAT32][1] = new ArrayCreator<PLY_FLOAT,1>;
+    _arrayfactories[PLY_FLOAT][2] = _arrayfactories[PLY_FLOAT32][2] = new ArrayCreator<PLY_FLOAT,2>;
+    _arrayfactories[PLY_FLOAT][3] = _arrayfactories[PLY_FLOAT32][3] = new ArrayCreator<PLY_FLOAT,3>;
 
-    _arrayfactories[PLY_FLOAT][0]=_arrayfactories[PLY_FLOAT32][0]=new ArrayCreator<PLY_FLOAT,0>;
-    _arrayfactories[PLY_FLOAT][1]=_arrayfactories[PLY_FLOAT32][1]=new ArrayCreator<PLY_FLOAT,1>;
-    _arrayfactories[PLY_FLOAT][2]=_arrayfactories[PLY_FLOAT32][2]=new ArrayCreator<PLY_FLOAT,2>;
-    _arrayfactories[PLY_FLOAT][3]=_arrayfactories[PLY_FLOAT32][3]=new ArrayCreator<PLY_FLOAT,3>;
-
-
-    _arrayfactories[PLY_DOUBLE][0]=new ArrayCreator<PLY_DOUBLE,0>;
-    _arrayfactories[PLY_DOUBLE][1]=new ArrayCreator<PLY_DOUBLE,1>;
-    _arrayfactories[PLY_DOUBLE][2]=new ArrayCreator<PLY_DOUBLE,2>;
-    _arrayfactories[PLY_DOUBLE][3]=new ArrayCreator<PLY_DOUBLE,3>;
+    _arrayfactories[PLY_DOUBLE][0] = new ArrayCreator<PLY_DOUBLE,0>;
+    _arrayfactories[PLY_DOUBLE][1] = new ArrayCreator<PLY_DOUBLE,1>;
+    _arrayfactories[PLY_DOUBLE][2] = new ArrayCreator<PLY_DOUBLE,2>;
+    _arrayfactories[PLY_DOUBLE][3] = new ArrayCreator<PLY_DOUBLE,3>;
 }
 
-
+inline osg::Array * getArrayFromFactory(ArrayFactory*factarray, int curchannel)
+{
+        osg::Array* arr = factarray->getArray();
+        arr->setUserData(new osg::IntValueObject(curchannel));
+        return arr;
+}
 /*  Read the vertex and (if available/wanted) color data from the open file.  */
 void VertexData::readVertices( PlyFile* file, const int nVertices, PlyProperty** props, int numprops)
                                //const int fields )
 {
     // read in the vertices
-    std::vector<int> propertyOffsets;    
-//    propertyOffsets.push_back(0);
-
+    std::vector<int> propertyOffsets;
     unsigned int totalvertexsize = 0;
+
     {
         int curchannel = -1, numcomp = 0, curcompsize = 0; const PlyProperty* cursem = 0;
         for(VertexSemantics::iterator semit =_semantics.begin(); semit!=_semantics.end(); ++semit)
         {
             VertexSemantic &sem = *semit;
-           //search for sem in props and goto next if not found
+            //search for sem in props and goto next if not found
             int propcpt;
             for(propcpt = 0; propcpt< numprops && strcmp(props[propcpt]->name, sem.first.name)!=0; ++propcpt);
             if(propcpt == numprops) continue;
+
             ply_get_property( file, "vertex", &sem.first);
             if(curchannel != sem.second)
             {
                 if(numcomp != 0)
                 {
-                    ArrayFactory * newarray = 0;
-                    newarray = _arrayfactories[cursem->internal_type][numcomp-1];
-                    if(newarray) {
-                        osg::ref_ptr<osg::Array> arr=newarray->getArray();
-                        arr->setUserData(new osg::IntValueObject(curchannel));
-                        _factoryarrayspair.push_back(FactAndArrays(newarray,arr));
-                    }
-
-                    totalvertexsize=cursem->offset+curcompsize;
+                    if(numcomp>4) { OSG_FATAL<<"osg ply plugin doesn't support "<<numcomp<<" components arrays, trying 4 instead"<<std::endl; numcomp = 4; }
+                    ArrayFactory * factarray = _arrayfactories[cursem->internal_type][numcomp-1];
+                    if(factarray) _factoryarrayspair.push_back(FactAndArrays(factarray, getArrayFromFactory(factarray, curchannel)));
+                    totalvertexsize = cursem->offset + curcompsize;
                     propertyOffsets.push_back(cursem->offset);
                 }
                 numcomp = 0; curcompsize = 0; cursem = &sem.first;
@@ -309,14 +305,10 @@ void VertexData::readVertices( PlyFile* file, const int nVertices, PlyProperty**
 
         }
         if(numcomp != 0){
-            ArrayFactory * newarray = 0;
-            newarray = _arrayfactories[cursem->internal_type][numcomp-1];
-            if(newarray) {
-                osg::ref_ptr<osg::Array> arr = newarray->getArray();
-                arr->setUserData(new osg::IntValueObject(curchannel));
-                _factoryarrayspair.push_back(FactAndArrays(newarray, arr));
-            }
-            totalvertexsize=cursem->offset+curcompsize;
+            if(numcomp>4) { OSG_FATAL<<"osg ply plugin doesn't support "<<numcomp<<" components arrays, trying 4 instead"<<std::endl; numcomp = 4; }
+            ArrayFactory * factarray = _arrayfactories[cursem->internal_type][numcomp-1];
+            if(factarray) _factoryarrayspair.push_back(FactAndArrays(factarray, getArrayFromFactory(factarray, curchannel)));
+            totalvertexsize = cursem->offset + curcompsize;
             propertyOffsets.push_back(cursem->offset);
         }
     }
@@ -326,8 +318,7 @@ void VertexData::readVertices( PlyFile* file, const int nVertices, PlyProperty**
         ply_get_element( file, static_cast< void* >( rawvertex ) );
 
         ///convert rawvertex to osg
-        int curprop=0;
-
+        int curprop = 0;
         for(std::vector<FactAndArrays>::iterator arrit = _factoryarrayspair.begin(); arrit != _factoryarrayspair.end(); ++arrit)
         {
             arrit->first->addElement((char*)rawvertex+propertyOffsets[curprop++], arrit->second);
@@ -544,9 +535,6 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
         // Create geometry node
         osg::Geometry* geom  =  new osg::Geometry;
 
-        // set the vertex array
-        //geom->setVertexArray(_vertices.get());
-
         // Add the primitive set
         bool hasTriOrQuads = false;
         if (_triangles.valid() && _triangles->size() > 0 )
@@ -565,42 +553,6 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
         if(!hasTriOrQuads)
             geom->addPrimitiveSet(new osg::DrawArrays(GL_POINTS, 0, _factoryarrayspair[0].second->getNumElements()));
 
-
-        // Apply the colours to the model; at the moment this is a
-        // kludge because we only use one kind and apply them all the
-        // same way. Also, the priority order is completely arbitrary
-/*
-        if(_colors.valid())
-        {
-            geom->setColorArray(_colors.get(), osg::Array::BIND_PER_VERTEX );
-        }
-        else if(_ambient.valid())
-        {
-            geom->setColorArray(_ambient.get(), osg::Array::BIND_PER_VERTEX );
-        }
-        else if(_diffuse.valid())
-        {
-            geom->setColorArray(_diffuse.get(), osg::Array::BIND_PER_VERTEX );
-        }
-        else if(_specular.valid())
-        {
-            geom->setColorArray(_specular.get(), osg::Array::BIND_PER_VERTEX );
-        }
-        else if (_texcoord.valid())
-        {
-            geom->setTexCoordArray(0, _texcoord.get());
-        }
-
-        // If the model has normals, add them to the geometry
-        if(_normals.valid())
-        {
-            geom->setNormalArray(_normals.get(), osg::Array::BIND_PER_VERTEX);
-        }
-        else
-        {   // If not, use the smoothing visitor to generate them
-            // (quads will be triangulated by the smoothing visitor)
-            osgUtil::SmoothingVisitor::smooth((*geom), osg::PI/2);
-        }*/
        for(std::vector<FactAndArrays>::iterator arrit = _factoryarrayspair.begin(); arrit != _factoryarrayspair.end(); ++arrit)
        {
             osg::Array* a = arrit->second;

--- a/src/osgPlugins/ply/vertexData.cpp
+++ b/src/osgPlugins/ply/vertexData.cpp
@@ -351,7 +351,7 @@ void VertexData::readVertices( PlyFile* file, const int nVertices,char*  elemNam
     _factoryarrayspair.push_back(newarrayvector);
     AFactAndArrays &factoryarrays = _factoryarrayspair.back().second.first;
     {
-        int curchannel = -1, numcomp = 0, curcompsize = 0; const PlyProperty* cursem = 0;
+        int curchannel = -1, numcomp = 0, curcompsize = 0; const VertexSemantic* cursem = 0;
         for(int propcpt=0; propcpt < numprops; ++propcpt)
         {
             if(props[propcpt]->is_list )
@@ -361,17 +361,17 @@ void VertexData::readVertices( PlyFile* file, const int nVertices,char*  elemNam
             }
             //search for prop in user semantics and goto next if not found (TODO add semantics through reader options)
             VertexSemantics::iterator semit;
-            for( semit =_semantics.begin(); semit!=_semantics.end() &&strcmp(props[propcpt]->name,semit->first.name)!=0; ++semit);
+            for( semit =_semantics.begin(); semit!=_semantics.end() &&strcmp(props[propcpt]->name,semit->name)!=0; ++semit);
             if(semit==_semantics.end()) continue;
             VertexSemantic &sem = *semit;
 
             //setup user property
             props[propcpt]->offset = totalvertexsize+curcompsize;
-            props[propcpt]->internal_type = sem.first.internal_type;
+            props[propcpt]->internal_type = sem.internal_type;
             ply_get_property( file, elemName, props[propcpt]);
 
 
-            if(curchannel != sem.second)
+            if(curchannel != sem.osgmapping)
             {
                 if(numcomp != 0)
                 {
@@ -383,11 +383,11 @@ void VertexData::readVertices( PlyFile* file, const int nVertices,char*  elemNam
                     propertyOffsets.push_back(totalvertexsize);
                     totalvertexsize +=  curcompsize;
                 }
-                numcomp = 0; curcompsize = 0; cursem = &sem.first;
-                curchannel = sem.second;
+                numcomp = 0; curcompsize = 0; cursem = &sem;
+                curchannel = sem.osgmapping;
             }
             numcomp++;
-            switch (sem.first.internal_type)
+            switch (sem.internal_type)
             {
                 case PLY_UINT8:    curcompsize+=sizeof(uint8_t);        break;
                 case PLY_UCHAR:    curcompsize+=sizeof(unsigned char);  break;
@@ -401,7 +401,7 @@ void VertexData::readVertices( PlyFile* file, const int nVertices,char*  elemNam
                 case PLY_INT32:    curcompsize+=sizeof(int32_t);        break;
                 case PLY_FLOAT32:  curcompsize+=4;                      break;
                 default:
-                    OSG_WARN<<"ply::VertexData: unknown internal_type" <<sem.first.internal_type<<" not implemented,"<<std::endl;
+                    OSG_WARN<<"ply::VertexData: unknown internal_type" <<sem.internal_type<<" not implemented,"<<std::endl;
             }
 
         }

--- a/src/osgPlugins/ply/vertexData.cpp
+++ b/src/osgPlugins/ply/vertexData.cpp
@@ -354,16 +354,16 @@ void VertexData::readVertices( PlyFile* file, const int nVertices,char*  elemNam
         int curchannel = -1, numcomp = 0, curcompsize = 0; const VertexSemantic* cursem = 0;
         for(int propcpt=0; propcpt < numprops; ++propcpt)
         {
+        //search for prop in user semantics and goto next if not found (TODO add semantics through reader options)
+            VertexSemantics::iterator semit;
+            for( semit =_semantics.begin(); semit!=_semantics.end() &&strcmp(props[propcpt]->name,semit->name)!=0; ++semit);
+            if(semit==_semantics.end()) continue;
+            VertexSemantic &sem = *semit;
             if(props[propcpt]->is_list )
             {
                 readListProperty(  file, nVertices, elemName, props[propcpt]);
                 continue;
             }
-            //search for prop in user semantics and goto next if not found (TODO add semantics through reader options)
-            VertexSemantics::iterator semit;
-            for( semit =_semantics.begin(); semit!=_semantics.end() &&strcmp(props[propcpt]->name,semit->name)!=0; ++semit);
-            if(semit==_semantics.end()) continue;
-            VertexSemantic &sem = *semit;
 
             //setup user property
             props[propcpt]->offset = totalvertexsize+curcompsize;
@@ -378,8 +378,6 @@ void VertexData::readVertices( PlyFile* file, const int nVertices,char*  elemNam
                     if(numcomp>4) { OSG_FATAL<<"osg ply plugin doesn't support "<<numcomp<<" components arrays, trying 4 instead"<<std::endl; numcomp = 4; }
                     ArrayFactory * factarray = _arrayfactories[cursem->internal_type][numcomp-1];
                     if(factarray) factoryarrays.push_back(AFactAndArray(factarray, getArrayFromFactory(factarray, curchannel)));
-                    /*totalvertexsize = cursem->offset + curcompsize;
-                    propertyOffsets.push_back(cursem->offset);*/
                     propertyOffsets.push_back(totalvertexsize);
                     totalvertexsize +=  curcompsize;
                 }
@@ -409,8 +407,6 @@ void VertexData::readVertices( PlyFile* file, const int nVertices,char*  elemNam
             if(numcomp>4) { OSG_FATAL<<"osg ply plugin doesn't support "<<numcomp<<" components arrays, trying 4 instead"<<std::endl; numcomp = 4; }
             ArrayFactory * factarray = _arrayfactories[cursem->internal_type][numcomp-1];
             if(factarray) factoryarrays.push_back(AFactAndArray(factarray, getArrayFromFactory(factarray, curchannel)));
-            /*totalvertexsize = cursem->offset + curcompsize;
-            propertyOffsets.push_back(cursem->offset);*/
             propertyOffsets.push_back(totalvertexsize);
             totalvertexsize +=  curcompsize;
         }

--- a/src/osgPlugins/ply/vertexData.h
+++ b/src/osgPlugins/ply/vertexData.h
@@ -23,30 +23,32 @@
 //!
 //! \class VertexData
 //! \brief helps to read ply file and converts in to osg::Node format
+//! \details element properties grouped according @osgmapping (max 4)
+//! \details first element property is considered as geometry vertices
+//! \details second element list properties are considered as primitivesets
 //!
 ///////////////////////////////////////////////////////////////////////////////
 
 namespace ply
 {
-    typedef struct VertexSemantic {    /* description of a property */
-      const char *name;                           /* property name */
-      int internal_type;                    /* program's data type */
-      int osgmapping;                       /* index of the array to mapping int out geometry... */
+    typedef struct VertexSemantic {    /* description of a mapping */
+      const char *name;                 /* property name retrieve from the file */
+      int internal_type;               /* target data type */
+      int osgmapping;                  /* index of the array to mapping int out geometry... */
     } VertexSemantic;
 
     typedef std::vector<VertexSemantic> VertexSemantics;
     struct ArrayFactory : public osg::Referenced
     {
-        virtual osg::Array * getArray() { return 0; }
+        virtual osg::Array * createArray() = 0;
         virtual void addElement(char * dataptr, osg::Array*) = 0;
     };
     struct DrawElementFactory : public osg::Referenced
     {
-        virtual osg::DrawElements * getDrawElement() = 0;
+        virtual osg::DrawElements * createDrawElement() = 0;
         virtual void addElement(char * dataptr, osg::DrawElements*) = 0;
     };
 
-    /*  Holds the flat data and offers routines to read, scale and sort it.  */
     class VertexData
     {
         osg::ref_ptr<ArrayFactory> _arrayfactories[PLY_END_TYPE-1][4];
@@ -74,18 +76,10 @@ namespace ply
     private:
         VertexSemantics _semantics;
 
-        // Function which reads all the vertices and colors if color info is
-        // given and also if the user wants that information
+        ///  Read the vertex data from the open file.
         void readVertices( PlyFile* file, const int nVertices, char*  elemName,
                          PlyProperty** props, int numprops);
-
-        // Reads the triangle indices from the ply file
-        void readListProperty( PlyFile* file, const int nFaces, char*  elemName, PlyProperty* listprop);
         bool _invertFaces;
-
-        // The indices of the faces in premitive set
-        osg::ref_ptr<osg::DrawElementsUInt> _triangles;
-        osg::ref_ptr<osg::DrawElementsUInt> _quads;
     };
 }
 

--- a/src/osgPlugins/ply/vertexData.h
+++ b/src/osgPlugins/ply/vertexData.h
@@ -51,14 +51,6 @@ namespace ply
     {
         osg::ref_ptr<ArrayFactory> _arrayfactories[PLY_END_TYPE-1][4];
         osg::ref_ptr<DrawElementFactory> _prfactories[PLY_END_TYPE-1];
-        /*struct name
-        {
-            name() {}
-            ArrayFactory* factory;
-            osg::ref_ptr<osg::Array> arr;
-            int osgmapping;
-
-        };*/
 
         typedef std::pair< ArrayFactory*, osg::ref_ptr<osg::Array> > AFactAndArray;
         typedef std::vector<AFactAndArray> AFactAndArrays;
@@ -67,7 +59,6 @@ namespace ply
         typedef std::vector<PFactAndDrawElement> PFactAndDrawElements;
 
         typedef std::pair<AFactAndArrays , PFactAndDrawElements > APFactAndArrays;
-
         std::vector< std::pair< std::string, APFactAndArrays > > _factoryarrayspair; //per element name
     public:
 

--- a/src/osgPlugins/ply/vertexData.h
+++ b/src/osgPlugins/ply/vertexData.h
@@ -51,8 +51,8 @@ namespace ply
 
     class VertexData
     {
-        osg::ref_ptr<ArrayFactory> _arrayfactories[PLY_END_TYPE-1][4];
-        osg::ref_ptr<DrawElementFactory> _prfactories[PLY_END_TYPE-1];
+        osg::ref_ptr<ArrayFactory> _arrayfactories[PLY_END_TYPE][4];
+        osg::ref_ptr<DrawElementFactory> _prfactories[PLY_END_TYPE];
 
         typedef std::pair< ArrayFactory*, osg::ref_ptr<osg::Array> > AFactAndArray;
         typedef std::vector<AFactAndArray> AFactAndArrays;

--- a/src/osgPlugins/ply/vertexData.h
+++ b/src/osgPlugins/ply/vertexData.h
@@ -28,8 +28,12 @@
 
 namespace ply
 {
+    typedef struct VertexSemantic {    /* description of a property */
+      const char *name;                           /* property name */
+      int internal_type;                    /* program's data type */
+      int osgmapping;                       /* index of the array to mapping int out geometry... */
+    } VertexSemantic;
 
-    typedef std::pair<PlyProperty, int> VertexSemantic;
     typedef std::vector<VertexSemantic> VertexSemantics;
     struct ArrayFactory : public osg::Referenced
     {


### PR DESCRIPTION
I did mod on ply plugin in order to make Equalizer application specifics overridable
the idea is to downcast Reader in the code and customize VertexSemantics (perhaps via options too)
ex:  _semantic.push_back({ "texture_u", PLY_FLOAT, 3});
here i tell that "texture_u" property will be map on VertexAttributeArray no 3 and converted to float if required

not backward compatible 
- color scaling removed, normal generation removed

what's new added:
- more generic support 
- Element Tree Is setted as Geometry UserData Tree (PLY(Node)->ELMENT(Node)->PROP(DrawElments or Arrays name after first PLY composite) so user can hack its own semantic out of it.

complex header example that works (**_format keyword highlighted_**), test with your own with Notifylevel=INFO greping OSGPLY

**ply**
**format binary_little_endian** 1.0
**comment** https://www.artec3d.com/3d-models/fox-skull
**element** vertex 349950
**property float** x
**property float** y
**property float** z
**element** face 699976
**property list uchar int** vertex_indices
**element** multi_texture_vertex 365208
**property uchar** tx
**property float** texture_u
**property float** texture_v
**element** multi_texture_face 699976
**property uchar** tx
**property uint** tn
**property list uchar int** texture_vertex_indices
**end_header**


Sample interpretation (ply is a metaformat):
"multi_texture_face" is per "face" data (tx tn and texture_vertex_indices are per faces data)
"multi_texture_face" could be seen as redondant and could have been merged with "face" like that

**element** face 699976
**property list uchar int** vertex_indices
**property uchar** tx
**property uint** tn
**property list uchar int** texture_vertex_indices

However "texture_vertex_indices" don't refer to "vertex" but to "multi_texture_vertex" so separate 2 element have sense...