### PR TITLE
ReaderWriterLAS recenter bug fixed, final batch of points was missed in translating the center point.

### DIFF
--- a/src/osgPlugins/las/ReaderWriterLAS.cpp
+++ b/src/osgPlugins/las/ReaderWriterLAS.cpp
@@ -214,6 +214,24 @@ class ReaderWriterLAS : public osgDB::ReaderWriter
             double mid_y = 0.5*(my.second + my.first);
             double mid_z = 0.5*(mz.second + mz.first);
             osg::Vec3 midVec(mid_x, mid_y, mid_z);
+
+            geometry->setUseDisplayList(true);
+            geometry->setUseVertexBufferObjects(true);
+            geometry->setVertexArray(vertices);
+            if (singleColor)
+            {
+                colours->resize(1);
+                geometry->setColorArray(colours, osg::Array::BIND_OVERALL);
+            }
+            else
+            {
+                geometry->setColorArray(colours, osg::Array::BIND_PER_VERTEX);
+
+            }
+            geometry->addPrimitiveSet(new osg::DrawArrays(GL_POINTS, 0, vertices->size()));
+
+            geode->addDrawable(geometry);
+
             if (_recenter)
             {
                 //Transform vertices to midpoint
@@ -238,24 +256,6 @@ class ReaderWriterLAS : public osgDB::ReaderWriter
                 std::cout << "Read points: " << i << " Elapsed Time: " << d2
                     << std::endl << std::endl;
             }
-
-            geometry->setUseDisplayList(true);
-            geometry->setUseVertexBufferObjects(true);
-            geometry->setVertexArray(vertices);
-            if (singleColor)
-            {
-                colours->resize(1);
-                geometry->setColorArray(colours, osg::Array::BIND_OVERALL);
-            }
-            else
-            {
-                geometry->setColorArray(colours, osg::Array::BIND_PER_VERTEX);
-
-            }
-            geometry->addPrimitiveSet(new osg::DrawArrays(GL_POINTS, 0, vertices->size()));
-
-            geode->addDrawable(geometry);
-
 
             // MatrixTransform with the mid-point translation
 


### PR DESCRIPTION
Hi Robert,
there is a bug in the las reader:
the final drawable needs to be added to the geode before iterating all drawables of the geode for recentering.
The option "noReCenter" can be used as work-around for this bug.

This PR is for branch OpenScenGraph-3.6, but the same changes apply to master as well.

Regards, Laurens.