### PR TITLE
fix bug in ProxyNode with DEFER_LOADING_TO_DATABASE_PAGER

### DIFF
--- a/src/osgDB/DatabasePager.cpp
+++ b/src/osgDB/DatabasePager.cpp
@@ -1646,7 +1646,12 @@ void DatabasePager::addLoadedDataToSceneGraph(const osg::FrameStamp &frameStamp)
                 osg::ProxyNode* proxyNode = dynamic_cast<osg::ProxyNode*>(group.get());
                 if (proxyNode)
                 {
-                    proxyNode->getDatabaseRequest(proxyNode->getNumChildren()) = 0;
+                    for (unsigned int i = 0; i < proxyNode->getNumFileNames(); ++i) {
+                        if (proxyNode->getDatabaseRequest(i) == databaseRequest) {
+                            proxyNode->getDatabaseRequest(i) = 0;
+                            break;
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
fix bug in ProxyNode with DEFER_LOADING_TO_DATABASE_PAGER causing crash when children reorder during load.

Hi Robert,
I got a crash while using a proxyNode to load a few files from a remote webserver, using mutiple database pager threads. While the pagedLOD can rely on the children to be added in fixed order, the children of a proxyNode can be added in any order.
This patch applies both to 3.6 and master branch.
Regards, Laurens.