### PR TITLE
TextureAttribute's _textureUnit not set on copy

### DIFF
--- a/include/osg/TextureAttribute
+++ b/include/osg/TextureAttribute
@@ -28,7 +28,7 @@ class TextureAttribute : public StateAttribute
             _textureUnit(0) {}
 
         TextureAttribute(const TextureAttribute& ta, const CopyOp& copyop=CopyOp::SHALLOW_COPY):
-            StateAttribute(ta, copyop) {}
+            StateAttribute(ta, copyop), _textureUnit(ta._textureUnit) {}
 
         virtual bool isTextureAttribute() const { return true; }
 


### PR DESCRIPTION
while I cannot find any impact, I think the TextureAttribute's _textureUnit should be set in a copy operation.
While simply (deep) copying a stateset the TextureAttribute gets in the right list, while the _textureUnit  is still not set - so my simple test with read - clone - write failed to reveal anything.
The undefined value seems to be returned by "attribute->getTypeMemberPair()" used in State::applyAttribute, so I think rendering the cloned copy might cause trouble, but I did not test.
This only applies to master; 3.6 doesn't have a TextureAttribute class.
Regards, Laurens.
