### PR TITLE
Improve PkgConfig usage

### DIFF
--- a/CMakeModules/FindGTA.cmake
+++ b/CMakeModules/FindGTA.cmake
@@ -8,14 +8,10 @@
 # correspond to the ./configure --prefix=$GTA_DIR
 # used in building libgta.
 
-INCLUDE(FindPkgConfig OPTIONAL)
+find_package(PkgConfig QUIET)
 
 IF(PKG_CONFIG_FOUND)
-
-    INCLUDE(FindPkgConfig)
-
     PKG_CHECK_MODULES(GTA gta)
-
 ENDIF(PKG_CONFIG_FOUND)
 
 IF(NOT GTA_FOUND)

--- a/CMakeModules/FindGtkGl.cmake
+++ b/CMakeModules/FindGtkGl.cmake
@@ -1,10 +1,7 @@
 #use pkg-config to find various modues
-INCLUDE(FindPkgConfig OPTIONAL)
+find_package(PkgConfig QUIET)
 
 IF(PKG_CONFIG_FOUND)
-
-    INCLUDE(FindPkgConfig)
-
     PKG_CHECK_MODULES(GTK gtk+-2.0)
 
     IF(WIN32)

--- a/CMakeModules/FindPoppler-glib.cmake
+++ b/CMakeModules/FindPoppler-glib.cmake
@@ -1,10 +1,7 @@
 #use pkg-config to find various modues
-INCLUDE(FindPkgConfig OPTIONAL)
+find_package(PkgConfig QUIET)
 
 IF(PKG_CONFIG_FOUND)
-
-    INCLUDE(FindPkgConfig)
-
     PKG_CHECK_MODULES(CAIRO cairo)
     PKG_CHECK_MODULES(POPPLER poppler-glib)
 

--- a/CMakeModules/FindRSVG.cmake
+++ b/CMakeModules/FindRSVG.cmake
@@ -1,10 +1,7 @@
 #use pkg-config to find various modues
-INCLUDE(FindPkgConfig OPTIONAL)
+find_package(PkgConfig QUIET)
 
 IF(PKG_CONFIG_FOUND)
-
-    INCLUDE(FindPkgConfig)
-
     #Version 2.35 introduces the rsvg_cleanup function which is used
     PKG_CHECK_MODULES(RSVG librsvg-2.0>=2.35)
 
@@ -13,6 +10,5 @@ IF(PKG_CONFIG_FOUND)
     IF (RSVG_FOUND AND NOT CAIRO_FOUND)
        SET(RSVG_FOUND FALSE)
     ENDIF()
-
 
 ENDIF()

--- a/src/osgViewer/CMakeLists.txt
+++ b/src/osgViewer/CMakeLists.txt
@@ -185,7 +185,7 @@ ELSE()
 
     ELSEIF(${OSG_WINDOWING_SYSTEM} STREQUAL "X11")
         # X11 for everybody else
-        INCLUDE(FindPkgConfig OPTIONAL)
+        find_package(PkgConfig QUIET)
         IF(PKG_CONFIG_FOUND)
 
             PKG_CHECK_MODULES(XRANDR xrandr)


### PR DESCRIPTION
Including FindPkgConfig directly into scripts is not a recommended practice.
Doing so will cause CMake to complain with a warning.
Replaced with find_package(PkgConfig QUIET)