### PR TITLE
Closing ZipArchive in destructor

### DIFF
--- a/src/osgPlugins/zip/ZipArchive.cpp
+++ b/src/osgPlugins/zip/ZipArchive.cpp
@@ -44,6 +44,7 @@ _zipLoaded( false )
 
 ZipArchive::~ZipArchive()
 {
+    close();
 }
 
 /** close the archive (on all threads) */


### PR DESCRIPTION
Hi Robert,

Here is a fix to ZipArchive to make sure the archive is closed in the destructor.  I was running a test loading many files out of a zip with archive caching turned off and noticed it eventually stopped working b/c it was opening the zip file on each read but never closing it so it would run out of file handles.

Thanks!

Jason