### PR TITLE
Name unnamed typedef struct {...} to fix MSVC error

### DIFF
--- a/src/osgPlugins/x/types.h
+++ b/src/osgPlugins/x/types.h
@@ -38,7 +38,7 @@ namespace DX {
      */
 
     // Vector
-    typedef struct {
+    typedef struct Vector_struct {
         float x,y,z;
 
         inline void normalize() {


### PR DESCRIPTION
Compile with latest MSVC 16.6.0 Preview Release, got error message:

> osgPlugins\x\types.h(41,20): error C7626: unnamed class used in typedef name cannot declare members other than non-static data members, member enumerations, or member classes (compiling source file ...3rdparty\OpenSceneGraph\src\osgPlugins\x\mesh.cpp)

The fix was just to give it a name, which will never be used. I picked Vector_struct, feel free to improve.