### PR TITLE
This stops OpenMW from crashing when using getTextureAttribute

### DIFF
--- a/include/osg/PointSprite
+++ b/include/osg/PointSprite
@@ -15,7 +15,7 @@
 #define OSG_POINTSPRITE 1
 
 #include <osg/GL>
-#include <osg/StateAttribute>
+#include <osg/TextureAttribute>
 
 #ifndef GL_ARB_point_sprite
 #define GL_POINT_SPRITE_ARB               0x8861
@@ -31,14 +31,14 @@
 namespace osg {
 
 /** PointSprite base class which encapsulates enabling of point sprites .*/
-class OSG_EXPORT PointSprite : public osg::StateAttribute {
+class OSG_EXPORT PointSprite : public TextureAttribute {
 public:
 
         PointSprite();
 
         /** Copy constructor using CopyOp to manage deep vs shallow copy.*/
         PointSprite(const PointSprite& ps,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY):
-            StateAttribute(ps,copyop),
+            TextureAttribute(ps,copyop),
             _coordOriginMode(ps._coordOriginMode) {}
 
 
@@ -54,8 +54,6 @@ public:
         }
 
         virtual bool checkValidityOfAssociatedModes(osg::State&) const;
-
-        virtual bool isTextureAttribute() const { return true; }
 
         virtual void apply(osg::State& state) const;
 

--- a/include/osg/Sampler
+++ b/include/osg/Sampler
@@ -25,7 +25,7 @@ namespace osg{
 */
 
 
-class OSG_EXPORT Sampler : public osg::StateAttribute
+class OSG_EXPORT Sampler : public TextureAttribute
 {
     public:
         Sampler();
@@ -34,8 +34,6 @@ class OSG_EXPORT Sampler : public osg::StateAttribute
         Sampler(const Sampler& text,const CopyOp& copyop=CopyOp::SHALLOW_COPY);
 
         META_StateAttribute(osg,Sampler,SAMPLER)
-
-        virtual bool isTextureAttribute() const { return true; }
 
         /** Sets the texture wrap mode. */
         void setWrap(Texture::WrapParameter which, Texture::WrapMode wrap);

--- a/include/osg/TexEnvCombine
+++ b/include/osg/TexEnvCombine
@@ -58,7 +58,7 @@ namespace osg {
 
 /** TexEnvCombine encapsulates the OpenGL glTexEnvCombine (texture
   * environment) state. */
-class OSG_EXPORT TexEnvCombine : public StateAttribute
+class OSG_EXPORT TexEnvCombine : public TextureAttribute
 {
     public :
 
@@ -66,7 +66,7 @@ class OSG_EXPORT TexEnvCombine : public StateAttribute
 
         /** Copy constructor using CopyOp to manage deep vs shallow copy. */
         TexEnvCombine(const TexEnvCombine& texenv,const CopyOp& copyop=CopyOp::SHALLOW_COPY):
-            StateAttribute(texenv,copyop),
+            TextureAttribute(texenv,copyop),
             _needsTexEnvCrossbar(texenv._needsTexEnvCrossbar),
             _combine_RGB(texenv._combine_RGB),
             _combine_Alpha(texenv._combine_Alpha),
@@ -89,8 +89,6 @@ class OSG_EXPORT TexEnvCombine : public StateAttribute
 
         META_StateAttribute(osg, TexEnvCombine, TEXENV);
 
-
-        virtual bool isTextureAttribute() const { return true; }
 
         /** Return -1 if *this < *rhs, 0 if *this==*rhs, 1 if *this>*rhs. */
         virtual int compare(const StateAttribute& sa) const

--- a/include/osg/TexEnvFilter
+++ b/include/osg/TexEnvFilter
@@ -15,7 +15,7 @@
 #define OSG_TEXENVFILTER 1
 
 #include <osg/GL>
-#include <osg/StateAttribute>
+#include <osg/TextureAttribute>
 
 #ifndef GL_EXT_texture_lod_bias
 #define GL_MAX_TEXTURE_LOD_BIAS_EXT       0x84FD
@@ -26,19 +26,17 @@
 namespace osg {
 
 /** TexEnvFilter - encapsulates the OpenGL glTexEnv (GL_TEXTURE_FILTER_CONTROL) state.*/
-class OSG_EXPORT TexEnvFilter : public StateAttribute
+class OSG_EXPORT TexEnvFilter : public TextureAttribute
 {
   public:
     TexEnvFilter(float lodBias = 0.0f);
 
     /** Copy constructor using CopyOp to manage deep vs shallow copy.*/
     TexEnvFilter(const TexEnvFilter& texenv,const CopyOp& copyop=CopyOp::SHALLOW_COPY):
-            StateAttribute(texenv,copyop),
+            TextureAttribute(texenv,copyop),
             _lodBias(texenv._lodBias) {}
 
     META_StateAttribute(osg, TexEnvFilter, TEXENVFILTER);
-
-    virtual bool isTextureAttribute() const { return true; }
 
     /** return -1 if *this < *rhs, 0 if *this==*rhs, 1 if *this>*rhs.*/
     virtual int compare(const StateAttribute& sa) const

--- a/include/osg/TexMat
+++ b/include/osg/TexMat
@@ -14,14 +14,14 @@
 #ifndef OSG_TEXMAT
 #define OSG_TEXMAT 1
 
-#include <osg/StateAttribute>
+#include <osg/TextureAttribute>
 #include <osg/Matrix>
 
 namespace osg {
 
 /** A texture matrix state class that encapsulates OpenGL texture matrix
   * functionality. */
-class OSG_EXPORT TexMat : public StateAttribute
+class OSG_EXPORT TexMat : public TextureAttribute
 {
     public :
 
@@ -31,13 +31,11 @@ class OSG_EXPORT TexMat : public StateAttribute
 
         /** Copy constructor using CopyOp to manage deep vs shallow copy. */
         TexMat(const TexMat& texmat,const CopyOp& copyop=CopyOp::SHALLOW_COPY):
-            StateAttribute(texmat,copyop),
+            TextureAttribute(texmat,copyop),
             _matrix(texmat._matrix),
             _scaleByTextureRectangleSize(texmat._scaleByTextureRectangleSize) {}
 
         META_StateAttribute(osg, TexMat, TEXMAT);
-
-        virtual bool isTextureAttribute() const { return true; }
 
         /** Return -1 if *this < *rhs, 0 if *this==*rhs, 1 if *this>*rhs. */
         virtual int compare(const StateAttribute& sa) const

--- a/src/osg/Sampler.cpp
+++ b/src/osg/Sampler.cpp
@@ -31,7 +31,7 @@
 
 using namespace osg;
 
-Sampler::Sampler(): StateAttribute(),
+Sampler::Sampler(): TextureAttribute(),
     _wrap_s(Texture::CLAMP),
     _wrap_t(Texture::CLAMP),
     _wrap_r(Texture::CLAMP),
@@ -48,7 +48,7 @@ Sampler::Sampler(): StateAttribute(),
     _PCsampler.setAllElementsTo(0);
 }
 
-Sampler::Sampler(const Sampler& sampler,const CopyOp &copyop ):StateAttribute(sampler,copyop),
+Sampler::Sampler(const Sampler& sampler,const CopyOp &copyop ):TextureAttribute(sampler,copyop),
     _wrap_s(sampler._wrap_s),
     _wrap_t(sampler._wrap_t),
     _wrap_r(sampler._wrap_r),


### PR DESCRIPTION
This stops OpenMW from crashing when creating an object, putting it into a StateSet and then attempting to retrieve it again. OSG master breaks this as a getTextureAttribute wrongly returns 0.

1040 osg::ref_ptr<osg::TexEnvCombine> texEnv2 = new osg::TexEnvCombine;
...
1048 stateset->setTextureAttributeAndModes(1, texEnv2, osg::StateAttribute::ON);
...
1058 osg::TexEnvCombine* texEnv2 = static_cast<osg::TexEnvCombine*>(stateset->getTextureAttribute(1, osg::StateAttribute::TEXENV));
1059 texEnv2->setConstantColor(osg::Vec4f(mAtmosphereColor.x(), mAtmosphereColor.y(), mAtmosphereColor.z(), mTransparency));
// ^^^crash

For reference: https://github.com/OpenMW/openmw/blob/master/apps/openmw/mwrender/sky.cpp#L1040-L1059