### PR TITLE
Fix camera callbacks of OcclusionQueryNode

### DIFF
--- a/include/osg/Callback
+++ b/include/osg/Callback
@@ -121,8 +121,33 @@ class OSG_EXPORT Callback : public virtual Object {
             }
         }
 
-    protected:
+        /** Convenience method to find a nested callback by type. */
+        template <typename T>
+        static T* findNestedCallback(osg::Callback* callback)
+        {
+            if (!callback)
+                return nullptr;
 
+            if (T* cb = dynamic_cast<T*>(callback))
+                return cb;
+
+            return findNestedCallback<T>(callback->getNestedCallback());
+        }
+
+        /** Convenience method to find a nested callback by type. */
+        template <typename T>
+        static const T* findNestedCallback(const osg::Callback* callback)
+        {
+            if (!callback)
+                return nullptr;
+
+            if (const T* cb = dynamic_cast<const T*>(callback))
+                return cb;
+
+            return findNestedCallback<T>(callback->getNestedCallback());
+        }
+
+    protected:
         virtual ~Callback() {}
         ref_ptr<Callback> _nestedCallback;
 };

--- a/include/osg/Camera
+++ b/include/osg/Camera
@@ -642,6 +642,14 @@ class OSG_EXPORT Camera : public Transform, public CullSettings
         /** Get the const initial draw callback.*/
         const DrawCallback* getInitialDrawCallback() const { return _initialDrawCallback.get(); }
 
+        /** Convenience method to find a nested initial draw callback by type. */
+        template <typename T>
+        T* findInitialDrawCallback() { return osg::Callback::findNestedCallback<T>(_initialDrawCallback.get()); }
+
+        /** Convenience method to find a nested initial draw callback by type. */
+        template <typename T>
+        const T* findInitialDrawCallback() const { return osg::Callback::findNestedCallback<T>(_initialDrawCallback.get()); }
+
         /** Convenience method that sets DrawCallback Initial callback of the node if it doesn't exist, or nest it into the existing one. */
         inline void addInitialDrawCallback(DrawCallback* nc)
         {
@@ -679,6 +687,14 @@ class OSG_EXPORT Camera : public Transform, public CullSettings
 
         /** Get the const pre draw callback.*/
         const DrawCallback* getPreDrawCallback() const { return _preDrawCallback.get(); }
+
+        /** Convenience method to find a nested pre draw callback by type. */
+        template <typename T>
+        T* findPreDrawCallback() { return osg::Callback::findNestedCallback<T>(_preDrawCallback.get()); }
+
+        /** Convenience method to find a nested pre draw callback by type. */
+        template <typename T>
+        const T* findPreDrawCallback() const { return osg::Callback::findNestedCallback<T>(_preDrawCallback.get()); }
 
         /** Convenience method that sets DrawCallback Initial callback of the node if it doesn't exist, or nest it into the existing one. */
         inline void addPreDrawCallback(DrawCallback* nc)
@@ -718,6 +734,14 @@ class OSG_EXPORT Camera : public Transform, public CullSettings
         /** Get the const post draw callback.*/
         const DrawCallback* getPostDrawCallback() const { return _postDrawCallback.get(); }
 
+        /** Convenience method to find a nested post draw callback by type. */
+        template <typename T>
+        T* findPostDrawCallback() { return osg::Callback::findNestedCallback<T>(_postDrawCallback.get()); }
+
+        /** Convenience method to find a nested post draw callback by type. */
+        template <typename T>
+        const T* findPostDrawCallback() const { return osg::Callback::findNestedCallback<T>(_postDrawCallback.get()); }
+
         /** Convenience method that sets DrawCallback Initial callback of the node if it doesn't exist, or nest it into the existing one. */
         inline void addPostDrawCallback(DrawCallback* nc)
         {
@@ -755,6 +779,14 @@ class OSG_EXPORT Camera : public Transform, public CullSettings
 
         /** Get the const final draw callback.*/
         const DrawCallback* getFinalDrawCallback() const { return _finalDrawCallback.get(); }
+
+        /** Convenience method to find a nested final draw callback by type. */
+        template <typename T>
+        T* findFinalDrawCallback() { return osg::Callback::findNestedCallback<T>(_finalDrawCallback.get()); }
+
+        /** Convenience method to find a nested final draw callback by type. */
+        template <typename T>
+        const T* findFinalDrawCallback() const { return osg::Callback::findNestedCallback<T>(_finalDrawCallback.get()); }
 
         /** Convenience method that sets DrawCallback Initial callback of the node if it doesn't exist, or nest it into the existing one. */
         inline void addFinalDrawCallback(DrawCallback* nc)


### PR DESCRIPTION
The OcclusionQueryNode uses camera callbacks for its implementation. If the camera in the scenegraph already had callbacks set, then it didn't work, because it expected to be the only one setting callbacks.

With this fix the implementation should just work, regardless if callbacks are already set or not.
