### PR TITLE
Return early in osgText::Text property setters

### DIFF
--- a/src/osgText/Text.cpp
+++ b/src/osgText/Text.cpp
@@ -1342,6 +1342,8 @@ void Text::setBackdropType(BackdropType type)
 
 void Text::setBackdropOffset(float offset)
 {
+    if (_backdropHorizontalOffset == offset && _backdropVerticalOffset == offset) return;
+
     _backdropHorizontalOffset = offset;
     _backdropVerticalOffset = offset;
 
@@ -1352,6 +1354,8 @@ void Text::setBackdropOffset(float offset)
 
 void Text::setBackdropOffset(float horizontal, float vertical)
 {
+    if (_backdropHorizontalOffset == horizontal && _backdropVerticalOffset == vertical) return;
+
     _backdropHorizontalOffset = horizontal;
     _backdropVerticalOffset = vertical;
 
@@ -1362,6 +1366,8 @@ void Text::setBackdropOffset(float horizontal, float vertical)
 
 void Text::setBackdropColor(const osg::Vec4& color)
 {
+    if (_backdropColor==color) return;
+
     _backdropColor = color;
 
     assignStateSet();


### PR DESCRIPTION
Matches what the rest of the properties are doing & avoids unnecessary
computation.