### PR TITLE
Clone pluginOptions.options

### DIFF
--- a/src/osgPlugins/dae/ReaderWriterDAE.cpp
+++ b/src/osgPlugins/dae/ReaderWriterDAE.cpp
@@ -68,6 +68,8 @@ ReaderWriterDAE::readNode(std::istream& fin,
         }
     }
 
+    pluginOptions.options = options ? osg::clone(options, osg::CopyOp::SHALLOW_COPY) : new Options;
+
     if (NULL == pDAE)
     {
         bOwnDAE = true;


### PR DESCRIPTION
This PR fixes the pluginOptions.options being cloned in std::istream -method, similar as it's done in std::string -method of ReadNode. This enables the use of Options base class features, e.g. setReadFileCallback( ReadFileCallback* cb).