### PR TITLE
Get names of bones and skeleton to osg nodes

### DIFF
--- a/src/osgPlugins/dae/daeRSkinning.cpp
+++ b/src/osgPlugins/dae/daeRSkinning.cpp
@@ -252,10 +252,18 @@ void daeReader::processSkeletonSkins(domNode* skeletonRoot, const domInstance_co
         {
             osgAnimation::Bone* pOsgBone = getOrCreateBone(jointsAndInverseBindMatrices[j].first);
             pOsgBone->setInvBindMatrixInSkeletonSpace(jointsAndInverseBindMatrices[j].second);
+            unsigned int numAttrs = jointsAndInverseBindMatrices[j].first->getAttributeCount();
+            for ( unsigned int currAttr = 0; currAttr < numAttrs; ++currAttr )
+                if (jointsAndInverseBindMatrices[j].first->getAttributeName(currAttr) == "name")
+                    pOsgBone->setName(jointsAndInverseBindMatrices[j].first->getAttribute( currAttr ));
         }
     }
 
     osgAnimation::Skeleton* skeleton = getOrCreateSkeleton(skeletonRoot);
+
+    unsigned int numAttrs = skeletonRoot->getAttributeCount();
+    for ( unsigned int currAttr = 0; currAttr < numAttrs; ++currAttr )
+        if (skeletonRoot->getAttributeName(currAttr) == "name") skeleton->setName(skeletonRoot->getAttribute( currAttr ));
 
     for (size_t i = 0; i < instanceControllers.size(); ++i)
     {


### PR DESCRIPTION
Dae-plugin doesn't seem to transfer dae-node names to osg-nodes. This PR browses through dae-object, and sets the names for the skeleton and bones.