### PR TITLE
Remove "file" protocol check

### DIFF
--- a/src/osgPlugins/dae/daeRMaterials.cpp
+++ b/src/osgPlugins/dae/daeRMaterials.cpp
@@ -897,27 +897,20 @@ std::string daeReader::processImagePath(const domImage* pDomImage) const
     if (pDomImage->getInit_from())
     {
         pDomImage->getInit_from()->getValue().validate();
-        if (strcmp(pDomImage->getInit_from()->getValue().getProtocol(), "file") == 0)
+        std::string path = pDomImage->getInit_from()->getValue().pathDir() +
+            pDomImage->getInit_from()->getValue().pathFile();
+        path = ReaderWriterDAE::ConvertColladaCompatibleURIToFilePath(path);
+        if (path.empty())
         {
-            std::string path = pDomImage->getInit_from()->getValue().pathDir() +
-                pDomImage->getInit_from()->getValue().pathFile();
-            path = ReaderWriterDAE::ConvertColladaCompatibleURIToFilePath(path);
-            if (path.empty())
-            {
-                OSG_WARN << "Unable to get path from URI." << std::endl;
-                return std::string();
-            }
+            OSG_WARN << "Unable to get path from URI." << std::endl;
+            return std::string();
+        }
 #ifdef WIN32
-            // If the path has a drive specifier or a UNC name then strip the leading /
-            if (path.size() > 2 && (path[2] == ':' || (path[1] == '/' && path[2] == '/')))
-                return path.substr(1, std::string::npos);
+        // If the path has a drive specifier or a UNC name then strip the leading /
+        if (path.size() > 2 && (path[2] == ':' || (path[1] == '/' && path[2] == '/')))
+            return path.substr(1, std::string::npos);
 #endif
-            return path;
-        }
-        else
-        {
-            OSG_WARN << "Only images with a \"file\" scheme URI are supported in this version." << std::endl;
-        }
+        return path;
     }
     else
     {


### PR DESCRIPTION
This is an artificial limit, and prevents using custom virtual file system or relative paths in custom image read callbacks. Removing that enables using dae image paths like "textures/texture.png". Removing the check results in passing the filepaths directly to cdom::uriToNativePath.