### PR TITLE
Add support for showing environment variables provided by osg plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ PROJECT(OpenSceneGraph)
 SET(OPENSCENEGRAPH_MAJOR_VERSION 3)
 SET(OPENSCENEGRAPH_MINOR_VERSION 4)
 SET(OPENSCENEGRAPH_PATCH_VERSION 2)
-SET(OPENSCENEGRAPH_SOVERSION 132)
+SET(OPENSCENEGRAPH_SOVERSION 133)
 
 # set to 0 when not a release candidate, non zero means that any generated
 # git tags will be treated as release candidates of given number

--- a/include/osgDB/PluginQuery
+++ b/include/osgDB/PluginQuery
@@ -39,6 +39,7 @@ class ReaderWriterInfo : public osg::Referenced
         ReaderWriter::FormatDescriptionMap  protocols;
         ReaderWriter::FormatDescriptionMap  extensions;
         ReaderWriter::FormatDescriptionMap  options;
+        ReaderWriter::FormatDescriptionMap  environment;
         ReaderWriter::Features              features;
 
     protected:

--- a/include/osgDB/ReaderWriter
+++ b/include/osgDB/ReaderWriter
@@ -63,6 +63,9 @@ class OSGDB_EXPORT ReaderWriter : public osg::Object
         /** Return which list of file extensions supported by ReaderWriter. */
         virtual const FormatDescriptionMap& supportedOptions() const { return _supportedOptions; }
 
+        /** Return which list of file environment variables supported by ReaderWriter. */
+        virtual const FormatDescriptionMap& supportedEnvironment() const { return _supportedEnvironment; }
+
         /** Return true if ReaderWriter accepts specified file extension.*/
         virtual bool acceptsExtension(const std::string& /*extension*/) const;
 
@@ -276,11 +279,15 @@ class OSGDB_EXPORT ReaderWriter : public osg::Object
           * Please note, this should usually only be used internally by subclasses of ReaderWriter. */
         void supportsOption(const std::string& opt, const std::string& description);
 
+        /** Specify env string as a supported environment string. */
+        void supportsEnvironment(const std::string& opt, const std::string& description);
+
     protected:
 
         FormatDescriptionMap _supportedProtocols;
         FormatDescriptionMap _supportedExtensions;
         FormatDescriptionMap _supportedOptions;
+        FormatDescriptionMap _supportedEnvironment;
 };
 
 }

--- a/src/osgDB/PluginQuery.cpp
+++ b/src/osgDB/PluginQuery.cpp
@@ -80,6 +80,7 @@ bool osgDB::queryPlugin(const std::string& fileName, ReaderWriterInfoList& infoL
                 rwi->protocols = rw->supportedProtocols();
                 rwi->extensions = rw->supportedExtensions();
                 rwi->options = rw->supportedOptions();
+                rwi->environment = rw->supportedEnvironment();
                 rwi->features = rw->supportedFeatures();
 
                 infoList.push_back(rwi.get());
@@ -151,6 +152,13 @@ bool osgDB::outputPluginDetails(std::ostream& out, const std::string& fileName)
                 if (fdm_itr->first.length()>longestOptionLength) longestOptionLength = fdm_itr->first.length();
             }
 
+            for(fdm_itr = info.environment.begin();
+                fdm_itr != info.environment.end();
+                ++fdm_itr)
+            {
+                if (fdm_itr->first.length()>longestOptionLength) longestOptionLength = fdm_itr->first.length();
+            }
+
             unsigned int padLength = longestOptionLength+4;
 
             for(fdm_itr = info.protocols.begin();
@@ -172,6 +180,13 @@ bool osgDB::outputPluginDetails(std::ostream& out, const std::string& fileName)
                 ++fdm_itr)
             {
                 out<<"        options    : "<<padwithspaces(fdm_itr->first, padLength)<<fdm_itr->second<<std::endl;
+            }
+
+            for(fdm_itr = info.environment.begin();
+                fdm_itr != info.environment.end();
+                ++fdm_itr)
+            {
+                out<<"        environment: "<<padwithspaces(fdm_itr->first, padLength)<<fdm_itr->second<<std::endl;
             }
             out<<"    }"<<std::endl;
         }

--- a/src/osgDB/ReaderWriter.cpp
+++ b/src/osgDB/ReaderWriter.cpp
@@ -68,6 +68,11 @@ void ReaderWriter::supportsOption(const std::string& fmt, const std::string& des
     _supportedOptions[fmt] = description;
 }
 
+void ReaderWriter::supportsEnvironment(const std::string& fmt, const std::string& description)
+{
+    _supportedEnvironment[fmt] = description;
+}
+
 ReaderWriter::Features ReaderWriter::supportedFeatures() const
 {
     int features = FEATURE_NONE;

--- a/src/osgPlugins/curl/ReaderWriterCURL.cpp
+++ b/src/osgPlugins/curl/ReaderWriterCURL.cpp
@@ -381,10 +381,11 @@ ReaderWriterCURL::ReaderWriterCURL()
     
     supportsExtension("curl","Pseudo file extension, used to select curl plugin.");
     supportsExtension("*","Passes all read files to other plugins to handle actual model loading.");
-    supportsOption("OSG_CURL_PROXY","Specify the http proxy.");
-    supportsOption("OSG_CURL_PROXYPORT","Specify the http proxy port.");
-    supportsOption("OSG_CURL_CONNECTTIMEOUT","Specify the connection timeout duration in seconds [default = 0 = not set].");
-    supportsOption("OSG_CURL_TIMEOUT","Specify the timeout duration of the whole transfer in seconds [default = 0 = not set].");
+
+    supportsEnvironment("OSG_CURL_PROXY","Specify the http proxy.");
+    supportsEnvironment("OSG_CURL_PROXYPORT","Specify the http proxy port.");
+    supportsEnvironment("OSG_CURL_CONNECTTIMEOUT","Specify the connection timeout duration in seconds [default = 0 = not set].");
+    supportsEnvironment("OSG_CURL_TIMEOUT","Specify the timeout duration of the whole transfer in seconds [default = 0 = not set].");
 }
 
 ReaderWriterCURL::~ReaderWriterCURL()

--- a/src/osgPlugins/txp/ReaderWriterTXP.h
+++ b/src/osgPlugins/txp/ReaderWriterTXP.h
@@ -57,6 +57,7 @@ public:
     ReaderWriterTXP()
     {
         supportsExtension("txp","Terrapage txp format");
+        supportsEnvironment("OSG_TXP_DEFAULT_MAX_ANISOTROPY", "default value to use when setting up textures");
     }
 
     virtual const char* className() const

--- a/src/osgPlugins/xine/ReaderWriterXine.cpp
+++ b/src/osgPlugins/xine/ReaderWriterXine.cpp
@@ -306,6 +306,8 @@ class ReaderWriterXine : public osgDB::ReaderWriter
             supportsExtension("wmv","");
             supportsExtension("xine","Xine plugin Pseduo plugin");
 
+            supportsEnvironment("OSG_XINE_AUDIO_DRIVER", "name of default audio driver to use");
+
             _xine = xine_new();
 
             const char* user_home = xine_get_homedir();


### PR DESCRIPTION
With this pull request osgconv shows which environment variables are supported by plugins for example:

```
Plugin /usr/lib64/osgPlugins-3.4.2/osgdb_curl.so
{
    ReaderWriter : HTTP Protocol Model Reader
    {
        features   : readObject readImage readHeightField readNode writeObject writeImage writeHeightField writeNode 
        protocol   : ftp                        Read from ftp port using libcurl.
        protocol   : ftps                       Read from ftps port using libcurl.
        protocol   : http                       Read from http port using libcurl.
        protocol   : https                      Read from https port using libcurl.
        extensions : .*                         Passes all read files to other plugins to handle actual model loading.
        extensions : .curl                      Pseudo file extension, used to select curl plugin.
        environment: OSG_CURL_CONNECTTIMEOUT    Specify the connection timeout duration in seconds [default = 0 = not set].
        environment: OSG_CURL_PROXY             Specify the http proxy.
        environment: OSG_CURL_PROXYPORT         Specify the http proxy port.
        environment: OSG_CURL_TIMEOUT           Specify the timeout duration of the whole transfer in seconds [default = 0 = not set].
    }
}
```