### PR TITLE
ShaderComposition mechanism on the osg::State fixed

### DIFF
--- a/src/osg/State.cpp
+++ b/src/osg/State.cpp
@@ -713,19 +713,19 @@ void State::apply(const StateSet* dstate)
 
         applyAttributeList(_attributeMap,dstate->getAttributeList());
 
-        if ((_lastAppliedProgramObject!=0) && (previousLastAppliedProgramObject==_lastAppliedProgramObject) && _defineMap.changed)
+        // Checking if there is no program on the stack or the program is not applied from the AttributeStack (StateSet core mechanism)
+        if (_shaderCompositionEnabled && (_lastAppliedProgramObject == 0 ||
+            (_lastAppliedProgramObject->getProgram() != _attributeMap[_lastAppliedProgramObject->getProgram()->getTypeMemberPair()].last_applied_attribute)))
         {
-            // OSG_NOTICE<<"State::apply(StateSet*) Program already applied ("<<(previousLastAppliedProgramObject==_lastAppliedProgramObject)<<") and _defineMap.changed= "<<_defineMap.changed<<std::endl;
-            _lastAppliedProgramObject->getProgram()->apply(*this);
+            // No program has been applied by the StateSet stack so assume shader composition is required
+            applyShaderComposition();
         }
 
-        if (_shaderCompositionEnabled)
+        if (_lastAppliedProgramObject != 0 && previousLastAppliedProgramObject == _lastAppliedProgramObject && _defineMap.changed)
         {
-            if (previousLastAppliedProgramObject == _lastAppliedProgramObject || _lastAppliedProgramObject==0)
-            {
-                // No program has been applied by the StateSet stack so assume shader composition is required
-                applyShaderComposition();
-            }
+            // Pragma(tic) mechanism must be applied after ShaderComposer
+            // OSG_NOTICE<<"State::apply(StateSet*) Program already applied ("<<(previousLastAppliedProgramObject==_lastAppliedProgramObject)<<") and _defineMap.changed= "<<_defineMap.changed<<std::endl;
+            _lastAppliedProgramObject->getProgram()->apply(*this);
         }
 
         if (dstate->getUniformList().empty())
@@ -784,17 +784,19 @@ void State::apply()
     // go through all active StateAttribute's, applying where appropriate.
     applyAttributeMap(_attributeMap);
 
-
-    if ((_lastAppliedProgramObject!=0) && (previousLastAppliedProgramObject==_lastAppliedProgramObject) && _defineMap.changed)
+    // Checking if there is no program on the stack or the program is not applied from the AttributeStack (StateSet core mechanism)
+    if (_shaderCompositionEnabled && (_lastAppliedProgramObject == 0 ||
+        (_lastAppliedProgramObject->getProgram() != _attributeMap[_lastAppliedProgramObject->getProgram()->getTypeMemberPair()].last_applied_attribute)))
     {
-        //OSG_NOTICE<<"State::apply() Program already applied ("<<(previousLastAppliedProgramObject==_lastAppliedProgramObject)<<") and _defineMap.changed= "<<_defineMap.changed<<std::endl;
-        if (_lastAppliedProgramObject) _lastAppliedProgramObject->getProgram()->apply(*this);
+        // No program has been applied by the StateSet stack so assume shader composition is required
+        applyShaderComposition();
     }
 
-
-    if (_shaderCompositionEnabled)
+    if ((_lastAppliedProgramObject != 0) && (previousLastAppliedProgramObject == _lastAppliedProgramObject) && _defineMap.changed)
     {
-        applyShaderComposition();
+        // Pragma(tic) mechanism must be applied after ShaderComposer
+        //OSG_NOTICE<<"State::apply() Program already applied ("<<(previousLastAppliedProgramObject==_lastAppliedProgramObject)<<") and _defineMap.changed= "<<_defineMap.changed<<std::endl;
+        _lastAppliedProgramObject->getProgram()->apply(*this);
     }
 
     if (_currentShaderCompositionUniformList.empty()) applyUniformMap(_uniformMap);
@@ -811,7 +813,7 @@ void State::applyShaderComposition()
         {
             // if (isNotifyEnabled(osg::INFO)) print(notify(osg::INFO));
 
-            // build lits of current ShaderComponents
+            // build list of current ShaderComponents
             ShaderComponents shaderComponents;
 
             // OSG_NOTICE<<"State::applyShaderComposition() : _attributeMap.size()=="<<_attributeMap.size()<<std::endl;
@@ -835,7 +837,8 @@ void State::applyShaderComposition()
         if (_currentShaderCompositionProgram)
         {
             Program::PerContextProgram* pcp = _currentShaderCompositionProgram->getPCP(*this);
-            if (_lastAppliedProgramObject != pcp) applyAttribute(_currentShaderCompositionProgram);
+            if (_lastAppliedProgramObject != pcp)
+                _currentShaderCompositionProgram->apply(*this);    // NOTE: AttributeStack should not be changed by ShaderComposer
         }
     }
 }

--- a/src/osg/State.cpp
+++ b/src/osg/State.cpp
@@ -715,7 +715,7 @@ void State::apply(const StateSet* dstate)
 
         // Checking if there is no program on the stack or the program is not applied from the AttributeStack (StateSet core mechanism)
         if (_shaderCompositionEnabled && (_lastAppliedProgramObject == 0 ||
-            (_lastAppliedProgramObject->getProgram() != _attributeMap[_lastAppliedProgramObject->getProgram()->getTypeMemberPair()].last_applied_attribute)))
+                                          (_lastAppliedProgramObject->getProgram() != getLastAppliedAttribute(osg::StateAttribute::PROGRAM))))
         {
             // No program has been applied by the StateSet stack so assume shader composition is required
             applyShaderComposition();
@@ -786,7 +786,7 @@ void State::apply()
 
     // Checking if there is no program on the stack or the program is not applied from the AttributeStack (StateSet core mechanism)
     if (_shaderCompositionEnabled && (_lastAppliedProgramObject == 0 ||
-        (_lastAppliedProgramObject->getProgram() != _attributeMap[_lastAppliedProgramObject->getProgram()->getTypeMemberPair()].last_applied_attribute)))
+                                      (_lastAppliedProgramObject->getProgram() != getLastAppliedAttribute(osg::StateAttribute::PROGRAM))))
     {
         // No program has been applied by the StateSet stack so assume shader composition is required
         applyShaderComposition();


### PR DESCRIPTION
This PR solves this bugs (_if osg::ShaderComposer used_) :
1) Multiple redundant glUseProgram(0) -> glUseProgram(program) calls
**This was wrong:**
a) AttributeStack should not be changed by ShaderComposer
b) Pragma(tic) mechanism must be applied after ShaderComposer

2) Using of Program via core StateSet mechanism while using ShaderComposer mechanism
**This condition was wrong**:
`if (previousLastAppliedProgramObject == _lastAppliedProgramObject || _lastAppliedProgramObject==0)`

PS
It's hard to understand the diff because the order of lines has been changed
