### PR TITLE
ProxyNode Failed to load child node

### DIFF
--- a/src/osgWrappers/serializers/osg/ProxyNode.cpp
+++ b/src/osgWrappers/serializers/osg/ProxyNode.cpp
@@ -109,16 +109,20 @@ struct ProxyNodeFinishedObjectReadCallback : public osgDB::FinishedObjectReadCal
     {
         osg::ProxyNode& proxyNode = static_cast<osg::ProxyNode&>(obj);
 
+        if (proxyNode.getDatabasePath().empty())
+        {
+            osgDB::FilePathList& fpl = ((osgDB::ReaderWriter::Options*)is.getOptions())->getDatabasePathList();
+            if (!fpl.empty())
+                proxyNode.setDatabaseOptions((osgDB::ReaderWriter::Options*)is.getOptions());
+        }
+
         if (proxyNode.getLoadingExternalReferenceMode() == osg::ProxyNode::LOAD_IMMEDIATELY)
         {
             for(unsigned int i=0; i<proxyNode.getNumFileNames(); i++)
             {
                 if(i >= proxyNode.getNumChildren() && !proxyNode.getFileName(i).empty())
                 {
-                    osgDB::FilePathList& fpl = ((osgDB::ReaderWriter::Options*)is.getOptions())->getDatabasePathList();
-                    fpl.push_front( fpl.empty() ? osgDB::getFilePath(proxyNode.getFileName(i)) : fpl.front()+'/'+ osgDB::getFilePath(proxyNode.getFileName(i)));
                     osg::ref_ptr<osg::Node> node = osgDB::readRefNodeFile(proxyNode.getFileName(i), is.getOptions());
-                    fpl.pop_front();
                     if(node)
                         proxyNode.insertChild(i, node);
                 }


### PR DESCRIPTION
When the LoadingExternalReferenceMode value of ProxyNode is not LOAD_IMMEDIATELY, if children's filename is a relative path, then when it calls getDatabaseRequestHandler()->requestNodeFile to load, unless osgDB::Registry::instance()->setDataFilePathList is set, it will not be able to The relative path is converted to the correct absolute path, the loading will fail.