### PR TITLE
Fix VBO dispatching

### DIFF
--- a/include/osg/Drawable
+++ b/include/osg/Drawable
@@ -575,16 +575,20 @@ inline void Drawable::draw(RenderInfo& renderInfo) const
         return;
     }
 
+    bool usingVertexBufferObjects = state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects);
+
     // TODO, add check against whether VAO is active and supported
-    if (state.getCurrentVertexArrayState())
+    osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
+    if (vas)
     {
-        //OSG_NOTICE<<"state.getCurrentVertexArrayState()->getVertexArrayObject()="<< state.getCurrentVertexArrayState()->getVertexArrayObject()<<std::endl;
-        state.bindVertexArrayObject(state.getCurrentVertexArrayState());
+        //OSG_NOTICE<<"vas->getVertexArrayObject()="<< vas->getVertexArrayObject()<<std::endl;
+        vas->setVertexBufferObjectSupported(usingVertexBufferObjects);
+        vas->setRequiresSetArrays(true);
+        state.bindVertexArrayObject(vas);
     }
 
-
 #ifdef OSG_GL_DISPLAYLISTS_AVAILABLE
-    if (!state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects) && _useDisplayList)
+    if (!usingVertexBufferObjects && _useDisplayList)
     {
         // get the contextID (user defined ID of 0 upwards) for the
         // current OpenGL context.

--- a/src/osg/Drawable.cpp
+++ b/src/osg/Drawable.cpp
@@ -687,16 +687,20 @@ void Drawable::draw(RenderInfo& renderInfo) const
         return;
     }
 
+    bool usingVertexBufferObjects = state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects);
+
     // TODO, add check against whether VAO is active and supported
-    if (state.getCurrentVertexArrayState())
+    osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
+    if (vas)
     {
-        //OSG_NOTICE<<"state.getCurrentVertexArrayState()->getVertexArrayObject()="<< state.getCurrentVertexArrayState()->getVertexArrayObject()<<std::endl;
-        state.bindVertexArrayObject(state.getCurrentVertexArrayState());
+        //OSG_NOTICE<<"vas->getVertexArrayObject()="<< vas->getVertexArrayObject()<<std::endl;
+        vas->setVertexBufferObjectSupported(usingVertexBufferObjects);
+        vas->setRequiresSetArrays(true);
+        state.bindVertexArrayObject(vas);
     }
 
-
 #ifdef OSG_GL_DISPLAYLISTS_AVAILABLE
-    if (!state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects) && _useDisplayList)
+    if (!usingVertexBufferObjects && _useDisplayList)
     {
         // get the contextID (user defined ID of 0 upwards) for the
         // current OpenGL context.
@@ -735,7 +739,7 @@ void Drawable::draw(RenderInfo& renderInfo) const
 VertexArrayState* Drawable::createVertexArrayStateImplementation(RenderInfo& renderInfo) const
 {
     OSG_INFO<<"VertexArrayState* Drawable::createVertexArrayStateImplementation(RenderInfo& renderInfo) const "<<this<<std::endl;
-    VertexArrayState* vos = new osg::VertexArrayState(renderInfo.getState());
-    vos->assignAllDispatchers();
-    return vos;
+    VertexArrayState* vas = new osg::VertexArrayState(renderInfo.getState());
+    vas->assignAllDispatchers();
+    return vas;
 }

--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -896,15 +896,8 @@ void Geometry::drawImplementation(RenderInfo& renderInfo) const
 
     State& state = *renderInfo.getState();
 
-    bool usingVertexBufferObjects = state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects);
-    bool usingVertexArrayObjects = usingVertexBufferObjects && state.useVertexArrayObject(_useVertexArrayObject);
-
-    osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
-    vas->setVertexBufferObjectSupported(usingVertexBufferObjects);
-
     bool checkForGLErrors = state.getCheckForGLErrors()==osg::State::ONCE_PER_ATTRIBUTE;
     if (checkForGLErrors) state.checkGLErrors("start of Geometry::drawImplementation()");
-
 
     drawVertexArraysImplementation(renderInfo);
 
@@ -917,9 +910,10 @@ void Geometry::drawImplementation(RenderInfo& renderInfo) const
 
     drawPrimitivesImplementation(renderInfo);
 
-    if (usingVertexBufferObjects && !usingVertexArrayObjects)
+    if (!state.useVertexArrayObject(_useVertexArrayObject) && state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects))
     {
         // unbind the VBO's if any are used.
+        osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
         vas->unbindVertexBufferObject();
         vas->unbindElementBufferObject();
     }
@@ -953,10 +947,7 @@ void Geometry::drawVertexArraysImplementation(RenderInfo& renderInfo) const
     attributeDispatchers.activateSecondaryColorArray(_secondaryColorArray.get());
     attributeDispatchers.activateFogCoordArray(_fogCoordArray.get());
 
-    if (state.useVertexArrayObject(_useVertexArrayObject))
-    {
-        if (!vas->getRequiresSetArrays()) return;
-    }
+    if (!vas->getRequiresSetArrays()) return;
 
     vas->lazyDisablingOfVertexAttributes();
 

--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -910,13 +910,10 @@ void Geometry::drawImplementation(RenderInfo& renderInfo) const
 
     drawPrimitivesImplementation(renderInfo);
 
-    if (!state.useVertexArrayObject(_useVertexArrayObject) && state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects))
-    {
-        // unbind the VBO's if any are used.
-        osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
-        vas->unbindVertexBufferObject();
-        vas->unbindElementBufferObject();
-    }
+    osg::VertexArrayState *vas = state.getCurrentVertexArrayState();
+    // unbind the VBO's if any are used.
+    vas->unbindVertexBufferObject();
+    if (!state.useVertexArrayObject(_useVertexArrayObject)) vas->unbindElementBufferObject();
 
     if (checkForGLErrors) state.checkGLErrors("end of Geometry::drawImplementation().");
 }

--- a/src/osgTerrain/GeometryPool.cpp
+++ b/src/osgTerrain/GeometryPool.cpp
@@ -924,7 +924,9 @@ void SharedGeometry::drawImplementation(osg::RenderInfo& renderInfo) const
     attributeDispatchers.activateNormalArray(_normalArray.get());
     attributeDispatchers.activateColorArray(_colorArray.get());
 
-    if (!state.useVertexArrayObject(_useVertexArrayObject) || vas->getRequiresSetArrays())
+    bool requiresSetArrays = vas->getRequiresSetArrays();
+
+    if (requiresSetArrays)
     {
         // OSG_NOTICE<<"   sending vertex arrays vas->getRequiresSetArrays()="<<vas->getRequiresSetArrays()<<std::endl;
 
@@ -954,8 +956,6 @@ void SharedGeometry::drawImplementation(osg::RenderInfo& renderInfo) const
     //
     GLenum primitiveType = computeDiagonals ? GL_LINES_ADJACENCY : GL_QUADS;
 
-    bool request_bind_unbind = !state.useVertexArrayObject(_useVertexArrayObject) || state.getCurrentVertexArrayState()->getRequiresSetArrays();
-
     osg::GLBufferObject* ebo = _drawElements->getOrCreateGLBufferObject(state.getContextID());
 
     if (ebo)
@@ -972,7 +972,7 @@ void SharedGeometry::drawImplementation(osg::RenderInfo& renderInfo) const
     }
 
     // unbind the VBO's if any are used.
-    if (request_bind_unbind) state.unbindVertexBufferObject();
+    if (requiresSetArrays) state.unbindVertexBufferObject();
 
     if (checkForGLErrors) state.checkGLErrors("end of SharedGeometry::drawImplementation().");
 }

--- a/src/osgText/Text.cpp
+++ b/src/osgText/Text.cpp
@@ -1209,12 +1209,9 @@ void Text::drawImplementation(osg::State& state, const osg::Vec4& colorMultiplie
 
     state.haveAppliedAttribute(osg::StateAttribute::DEPTH);
 
-    if (!state.useVertexArrayObject(_useVertexArrayObject) && state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects))
-    {
-        // unbind the VBO's if any are used.
-        vas->unbindVertexBufferObject();
-        vas->unbindElementBufferObject();
-    }
+    // unbind the VBO's if any are used.
+    vas->unbindVertexBufferObject();
+    if (!state.useVertexArrayObject(_useVertexArrayObject)) vas->unbindElementBufferObject();
 
     if (needToApplyMatrix)
     {

--- a/src/osgText/Text.cpp
+++ b/src/osgText/Text.cpp
@@ -1101,8 +1101,7 @@ void Text::drawImplementationSinglePass(osg::State& state, const osg::Vec4& colo
 
     osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
     bool usingVertexBufferObjects = state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects);
-    bool usingVertexArrayObjects = usingVertexBufferObjects && state.useVertexArrayObject(_useVertexArrayObject);
-    bool requiresSetArrays = !usingVertexBufferObjects || !usingVertexArrayObjects || vas->getRequiresSetArrays();
+    bool requiresSetArrays = vas->getRequiresSetArrays();
 
     if ((_drawMode&(~TEXT))!=0 && !_decorationPrimitives.empty())
     {
@@ -1184,11 +1183,8 @@ void Text::drawImplementation(osg::State& state, const osg::Vec4& colorMultiplie
     state.Normal(_normal.x(), _normal.y(), _normal.z());
 
     osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
-    bool usingVertexBufferObjects = state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects);
-    bool usingVertexArrayObjects = usingVertexBufferObjects && state.useVertexArrayObject(_useVertexArrayObject);
-    bool requiresSetArrays = !usingVertexBufferObjects || !usingVertexArrayObjects || vas->getRequiresSetArrays();
 
-    if (requiresSetArrays)
+    if (vas->getRequiresSetArrays())
     {
         vas->lazyDisablingOfVertexAttributes();
         vas->setVertexArray(state, _coords.get());
@@ -1213,7 +1209,7 @@ void Text::drawImplementation(osg::State& state, const osg::Vec4& colorMultiplie
 
     state.haveAppliedAttribute(osg::StateAttribute::DEPTH);
 
-    if (usingVertexBufferObjects && !usingVertexArrayObjects)
+    if (!state.useVertexArrayObject(_useVertexArrayObject) && state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects))
     {
         // unbind the VBO's if any are used.
         vas->unbindVertexBufferObject();

--- a/src/osgText/Text3D.cpp
+++ b/src/osgText/Text3D.cpp
@@ -587,12 +587,9 @@ void Text3D::drawImplementation(osg::RenderInfo& renderInfo) const
         }
     }
 
-    if (usingVertexBufferObjects && !state.useVertexArrayObject(_useVertexArrayObject))
-    {
-        // unbind the VBO's if any are used.
-        vas->unbindVertexBufferObject();
-        vas->unbindElementBufferObject();
-    }
+    // unbind the VBO's if any are used.
+    vas->unbindVertexBufferObject();
+    if (!state.useVertexArrayObject(_useVertexArrayObject)) vas->unbindElementBufferObject();
 
     if (needToApplyMatrix)
     {

--- a/src/osgText/Text3D.cpp
+++ b/src/osgText/Text3D.cpp
@@ -520,17 +520,16 @@ void Text3D::drawImplementation(osg::RenderInfo& renderInfo) const
     }
 
     osg::VertexArrayState* vas = state.getCurrentVertexArrayState();
-    bool usingVertexBufferObjects = state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects);
-    bool usingVertexArrayObjects = usingVertexBufferObjects && state.useVertexArrayObject(_useVertexArrayObject);
-    bool requiresSetArrays = !usingVertexBufferObjects || !usingVertexArrayObjects || vas->getRequiresSetArrays();
 
-    if (requiresSetArrays)
+    if (vas->getRequiresSetArrays())
     {
         vas->lazyDisablingOfVertexAttributes();
         vas->setVertexArray(state, _coords.get());
         vas->setNormalArray(state, _normals.get());
         vas->applyDisablingOfVertexAttributes(state);
     }
+
+    bool usingVertexBufferObjects = state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects);
 
     if ((_drawMode&(~TEXT))!=0)
     {
@@ -588,7 +587,7 @@ void Text3D::drawImplementation(osg::RenderInfo& renderInfo) const
         }
     }
 
-    if (usingVertexBufferObjects && !usingVertexArrayObjects)
+    if (usingVertexBufferObjects && !state.useVertexArrayObject(_useVertexArrayObject))
     {
         // unbind the VBO's if any are used.
         vas->unbindVertexBufferObject();


### PR DESCRIPTION
Here are a few points to summarize my assumptions and understanding of the code.

* When VAOs are used, VBOs are used (if supported) regardless off the usingVertexBufferObjects setting.

This is status quo and seems reasonable. However, the usingVertexBufferObjects stetting still determines if EBOs are used.

So, if one sets up an Drawable

drawable->setUseVertexBufferObjects(false);
drawable->setUseVertexArrayObject(true);

one would get VAOs with VBOs, but not EBOs.

I don't know what is really intended and if such setup is practically used. (The compileGLObjects functions don't seem to handle it either.) I think it would make sense to also use EBOs, as it's a more efficient use of VAOs. To achieve this, one can simply replace in drawImplementations the line

bool usingVertexBufferObjects = state.useVertexBufferObject(_supportsVertexBufferObjects && _useVertexBufferObjects);

with this one:

bool usingVertexBufferObjects = vas->getVertexBufferObjectSupported();

Anyway, one should be aware that the variable usingVertexBufferObjects is somewhat misleading because it doesn't tell whether VBO are really used.



* When not using VAOs, the usingVertexBufferObjects setting determines if VBOs and EBOs are used.
 
 I added these lines to Drawable::draw:

  vas->setVertexBufferObjectSupported(usingVertexBufferObjects);
  vas->setRequiresSetArrays(true);

 The first fixes the missing setup so that the VBOs get properly dispatched, the latter helps setting up the vas object transparently for subclass drawImplementations.

It simplifies the condition

!usingVertexArrayObjects || vas->getRequiresSetArrays()

to  

vas->getRequiresSetArrays()



* I couldn't figure out why the VBO's are unbound at the end of each drawImplementation. Shouldn't the VertexArrayState and it's lazy update mechanism handle this?  I guess it is for compatibility with custom Drawables.

Actually I discovered a reason to unbind the VBO when VAOs are used. In OpenGL, the bound VBO is not part of the VAO state while in OSG it is modeled so. Not unbinding the VBO can cause it to not get bound in the next frame, if it is falsely assumed to not have changed. I will provide a detailed description and an example program in the issue report.

As simplification and workaround I replaced the lines

if  (usingVertexBufferObjects && !usingVertexArrayObject)
{
        // unbind the VBO's if any are used.
        vas->unbindVertexBufferObject();
        vas->unbindElementBufferObject();
 }

with these ones

   // unbind the VBO's if any are used.
    vas->unbindVertexBufferObject();
    if (!state.useVertexArrayObject(_useVertexArrayObject)) vas->unbindElementBufferObject();

Note that in case of using VAOs, the unbindVertexBufferObject function is a no-op, except for the case that one of the VBOs really got updated. This is even the case when the data variance is set to DYNAMIC.  So it shouldn't hurt performance or undermine the purpose of VAOs.

When not using VAOs, both buffer objects are unbound like it has been the case before.
