### PR TITLE
State's popAllStateSets fixed: should not reset _lastAppliedProgramOb…

### DIFF
--- a/src/osg/State.cpp
+++ b/src/osg/State.cpp
@@ -541,8 +541,6 @@ void State::popAllStateSets()
 
     applyProjectionMatrix(0);
     applyModelViewMatrix(0);
-
-    _lastAppliedProgramObject = 0;
 }
 
 void State::popStateSet()


### PR DESCRIPTION
…ject to zero. As result: osg::State synced with OpenGL state => no unnecessary (redundant) glUseProgram calls