### PR TITLE
osg::Viewport's constructor with no arguments should create an invali…

### DIFF
--- a/src/osg/Viewport.cpp
+++ b/src/osg/Viewport.cpp
@@ -18,8 +18,8 @@ Viewport::Viewport()
 {
     _x = 0;
     _y = 0;
-    _width = 800;
-    _height = 600;
+    _width = 0;
+    _height = 0;
 }
 
 
@@ -29,6 +29,9 @@ Viewport::~Viewport()
 
 void Viewport::apply(State&) const
 {
+    if (!valid())
+        return;
+
     glViewport( static_cast<GLint>(_x),static_cast<GLint>(_y),
                 static_cast<GLsizei>(_width),static_cast<GLsizei>(_height) );
 }


### PR DESCRIPTION
…d Viewport: this will reduce OpenGL calls


I've found many unnecessary
`glViewport(x = 0, y = 0, width = 800, height = 600)`
calls while apitracing.

NOTE:
This comes from "StateAttribute mechanism" on the osg::State.
`global_default_attribute = new osg::Viewport()` in two words

PS
I don't see the reason why the default Viewport must be 800x600
