### PR TITLE
Terminate C string

### DIFF
--- a/src/osgPlugins/dae/daeReader.cpp
+++ b/src/osgPlugins/dae/daeReader.cpp
@@ -300,6 +300,7 @@ bool daeReader::convert( std::istream& fin )
     // use a vector as buffer and read from stream
     std::vector<char> buffer(length);
     fin.read(&buffer[0], length);
+    buffer.emplace_back('\0');
 
     domElement* loaded_element = _dae->openFromMemory(fileURI, &buffer[0]);
     _document = dynamic_cast<domCOLLADA*>(loaded_element);


### PR DESCRIPTION
Fix to issue https://github.com/openscenegraph/OpenSceneGraph/issues/994

Adds a null to the end of the C string. This has been tested to work project OpenMW.