### PR TITLE
Fix for #1013 - Texture2DArray fails to regenerate after a releaseGLO…

### DIFF
--- a/src/osg/Texture2DArray.cpp
+++ b/src/osg/Texture2DArray.cpp
@@ -400,11 +400,8 @@ void Texture2DArray::apply(State& state) const
             osg::Image* image = itr->get();
             if (image)
             {
-                if (getModifiedCount(n,contextID) != image->getModifiedCount())
-                {
-                    getModifiedCount(n,contextID) = image->getModifiedCount();
-                    applyTexImage2DArray_subload(state, image, n, _textureWidth, _textureHeight, image->r(), _internalFormat, _numMipmapLevels);
-                }
+                getModifiedCount(n,contextID) = image->getModifiedCount();
+                applyTexImage2DArray_subload(state, image, n, _textureWidth, _textureHeight, image->r(), _internalFormat, _numMipmapLevels);
                 n += image->r();
             }
         }


### PR DESCRIPTION
…bjects/dirtyTextureObject - remove the modified count condition on component images when subloading when there is no texture object