### PR TITLE
daeReader::convert( std::istream& ) fixes

### DIFF
--- a/src/osgPlugins/dae/daeReader.cpp
+++ b/src/osgPlugins/dae/daeReader.cpp
@@ -13,8 +13,6 @@
 
 #include "daeReader.h"
 
-#include <cstddef>
-
 #include <dae.h>
 #include <dae/domAny.h>
 #include <dom/domCOLLADA.h>


### PR DESCRIPTION
1. Pass a \0-terminated C-string to `_dae->openFromMemory` (fixes #994)
2. Use a heap array instead of a vector. This avoids unnecessary filling of the buffer with zeroes (which vector always does).
3. Correctly get the input stream size by subtracting the position of the beginning of the stream.
4. Handle stream error.

Please cherry-pick this into 3.6 when merging