### PR TITLE
VertexAttribDivisor functionality in Array

### DIFF
--- a/include/osg/Array
+++ b/include/osg/Array
@@ -140,6 +140,7 @@ class OSG_EXPORT Array : public BufferData
             _dataSize(dataSize),
             _dataType(dataType),
             _binding(binding),
+            _divisor(0),
             _normalize(false),
             _preserveDataType(false) {}
 
@@ -149,6 +150,7 @@ class OSG_EXPORT Array : public BufferData
             _dataSize(array._dataSize),
             _dataType(array._dataType),
             _binding(array._binding),
+            _divisor(array._divisor),
             _normalize(array._normalize),
             _preserveDataType(array._preserveDataType) {}
 
@@ -191,6 +193,11 @@ class OSG_EXPORT Array : public BufferData
         /** Get how this array should be passed to OpenGL.*/
         Binding getBinding() const { return _binding; }
 
+        /** Specify the rate at which generic vertex attributes advance during instanced rendering.*/
+        void setDivisor(GLuint divisor) { _divisor = divisor; }
+
+        /** Get the rate at which generic vertex attributes advance during instanced rendering.*/
+        GLuint getDivisor() const { return _divisor; }
 
         /** Specify whether the array data should be normalized by OpenGL.*/
         void setNormalize(bool normalize) { _normalize = normalize; }
@@ -226,6 +233,7 @@ class OSG_EXPORT Array : public BufferData
         GLint   _dataSize;
         GLenum  _dataType;
         Binding _binding;
+        GLuint  _divisor;
         bool    _normalize;
         bool    _preserveDataType;
 };

--- a/src/osg/VertexArrayState.cpp
+++ b/src/osg/VertexArrayState.cpp
@@ -467,6 +467,11 @@ struct VertexAttribArrayDispatch : public VertexArrayState::ArrayDispatch
         {
             ext->glVertexAttribPointer(static_cast<GLuint>(unit), new_array->getDataSize(), new_array->getDataType(), new_array->getNormalize(), 0, ptr);
         }
+
+        if (ext->glVertexAttribDivisor && new_array->getDivisor() > 0)
+        {
+            ext->glVertexAttribDivisor(static_cast<GLuint>(unit), new_array->getDivisor());
+        }
     }
 
     virtual void enable_and_dispatch(osg::State& state, const osg::Array* new_array)

--- a/src/osgWrappers/serializers/osg/Array.cpp
+++ b/src/osgWrappers/serializers/osg/Array.cpp
@@ -107,6 +107,11 @@ REGISTER_OBJECT_WRAPPER( Array,
         ADD_ENUM_VALUE( BIND_PER_VERTEX );
     END_ENUM_SERIALIZER();
 
+    {
+        UPDATE_TO_VERSION_SCOPED( 162 )
+        ADD_UINT_SERIALIZER_NO_SET( Divisor, 0);
+    }
+
     ADD_BOOL_SERIALIZER(Normalize, false);
     ADD_BOOL_SERIALIZER(PreserveDataType, false);
 


### PR DESCRIPTION
There was no possibilities to use VertexAttribDivisor with VertexArrayObject(ed) geometry.
This PR gives such possibility.
You can still use osg::VertexAttribDivisor for not VAOed geometries.
Array->setDivisor can be used for any configuration.

I've compiled OSG with/without `OSG_GL_VERTEX_ARRAY_FUNCS_AVAILABLE`
I've tested it mostly for OpenGL Core profile (with/without VAO + with/widthout VBO)
