### PR TITLE
Back-port (cherry-pick) warnings fixes into 3.6

### DIFF
--- a/include/osg/BoundingSphere
+++ b/include/osg/BoundingSphere
@@ -63,6 +63,13 @@ class BoundingSphereImpl
           * otherwise. */
         inline bool valid() const { return _radius>=0.0; }
 
+        inline BoundingSphereImpl& operator = (const BoundingSphereImpl& rhs)
+        {
+            _center = rhs._center;
+            _radius = rhs._radius;
+            return *this;
+        }
+
         inline bool operator == (const BoundingSphereImpl& rhs) const { return _center==rhs._center && _radius==rhs._radius; }
         inline bool operator != (const BoundingSphereImpl& rhs) const { return _center!=rhs._center || _radius!=rhs._radius; }
 

--- a/include/osg/GLExtensions
+++ b/include/osg/GLExtensions
@@ -149,6 +149,15 @@ class VertexAttribAlias
             _osgName(osgName),
             _declaration(declaration) {}
 
+        VertexAttribAlias& operator = (const VertexAttribAlias& rhs)
+        {
+            _location = rhs._location;
+            _glName = rhs._glName;
+            _osgName = rhs._osgName;
+            _declaration = rhs._declaration;
+            return *this;
+        }
+
         GLuint      _location;
         std::string _glName;
         std::string _osgName;

--- a/include/osg/Quat
+++ b/include/osg/Quat
@@ -53,6 +53,14 @@ class OSG_EXPORT Quat
             _v[3]=w;
         }
 
+        inline Quat( const Quat& rhs )
+        {
+            _v[0]=rhs._v[0];
+            _v[1]=rhs._v[1];
+            _v[2]=rhs._v[2];
+            _v[3]=rhs._v[3];
+        }
+
         inline Quat( const Vec4f& v )
         {
             _v[0]=v.x();

--- a/src/osg/glu/libtess/tess.cpp
+++ b/src/osg/glu/libtess/tess.cpp
@@ -213,7 +213,7 @@ osg::gluTessProperty( GLUtesselator *tess, GLenum which, GLdouble value )
       tess->windingRule = windingRule;
       return;
     default:
-      break;
+      return;
     }
 
   case GLU_TESS_BOUNDARY_ONLY:

--- a/src/osgPlugins/dds/ReaderWriterDDS.cpp
+++ b/src/osgPlugins/dds/ReaderWriterDDS.cpp
@@ -1079,15 +1079,12 @@ bool WriteDDSFile(const osg::Image *img, std::ostream& fout, bool autoFlipDDSWri
 
     // Initialize ddsd structure and its members
     DDSURFACEDESC2 ddsd;
-    memset( &ddsd, 0, sizeof( ddsd ) );
     DDPIXELFORMAT  ddpf;
-    memset( &ddpf, 0, sizeof( ddpf ) );
     //DDCOLORKEY     ddckCKDestOverlay;
     //DDCOLORKEY     ddckCKDestBlt;
     //DDCOLORKEY     ddckCKSrcOverlay;
     //DDCOLORKEY     ddckCKSrcBlt;
     DDSCAPS2       ddsCaps;
-    memset( &ddsCaps, 0, sizeof( ddsCaps ) );
 
     ddsd.dwSize = sizeof(ddsd);
     ddpf.dwSize = sizeof(ddpf);

--- a/src/osgPlugins/gles/IndexMeshVisitor.cpp
+++ b/src/osgPlugins/gles/IndexMeshVisitor.cpp
@@ -55,7 +55,6 @@ void IndexMeshVisitor::process(osg::Geometry& geom) {
     new_primitives.reserve(primitives.size());
 
     // compute duplicate vertices
-    typedef std::vector<unsigned int> IndexList;
     unsigned int numVertices = geom.getVertexArray()->getNumElements();
     IndexList indices(numVertices);
     unsigned int i, j;

--- a/src/osgPlugins/gles/glesUtil
+++ b/src/osgPlugins/gles/glesUtil
@@ -222,9 +222,6 @@ namespace glesUtil {
         virtual void apply(osg::Vec2ubArray& array) { remap(array); }
 
         virtual void apply(osg::MatrixfArray& array) { remap(array); }
-
-    protected:
-        RemapArray& operator= (const RemapArray&) { return *this; }
     };
 
 
@@ -252,9 +249,6 @@ namespace glesUtil {
             }
             return 0;
         }
-
-        protected:
-            VertexAttribComparitor& operator= (const VertexAttribComparitor&) { return *this; }
     };
 
     // Move the values in an array to new positions, based on the

--- a/src/osgPlugins/ive/DataInputStream.cpp
+++ b/src/osgPlugins/ive/DataInputStream.cpp
@@ -287,7 +287,7 @@ bool DataInputStream::uncompress(std::istream& fin, std::string& destination) co
     return ret == Z_STREAM_END ? true : false;
 }
 #else
-bool DataInputStream::uncompress(std::istream& fin, std::string& destination) const
+bool DataInputStream::uncompress(std::istream& /*fin*/, std::string& /*destination*/) const
 {
     return false;
 }

--- a/src/osgPlugins/ive/DataOutputStream.cpp
+++ b/src/osgPlugins/ive/DataOutputStream.cpp
@@ -320,7 +320,7 @@ bool DataOutputStream::compress(std::ostream& fout, const std::string& source) c
     return true;
 }
 #else
-bool DataOutputStream::compress(std::ostream& fout, const std::string& source) const
+bool DataOutputStream::compress(std::ostream& /*fout*/, const std::string& /*source*/) const
 {
     return false;
 }

--- a/src/osgPlugins/osc/OscReceivingDevice.cpp
+++ b/src/osgPlugins/osc/OscReceivingDevice.cpp
@@ -309,7 +309,7 @@ public:
 
             return true;
         }
-        catch(osc::Exception e) {
+        catch(osc::Exception& e) {
             handleException(e);
         }
 
@@ -342,7 +342,7 @@ public:
 
             return true;
         }
-        catch(osc::Exception e) {
+        catch(osc::Exception& e) {
             handleException(e);
         }
 
@@ -378,7 +378,7 @@ public:
 
             return true;
         }
-        catch(osc::Exception e) {
+        catch(osc::Exception& e) {
             handleException(e);
         }
 
@@ -413,7 +413,7 @@ public:
 
             return true;
         }
-        catch(osc::Exception e) {
+        catch(osc::Exception& e) {
             handleException(e);
         }
 
@@ -449,7 +449,7 @@ public:
 
             return true;
         }
-        catch (osc::Exception e) {
+        catch (osc::Exception& e) {
             handleException(e);
         }
         return false;
@@ -491,7 +491,7 @@ public:
 
             return true;
         }
-        catch (osc::Exception e) {
+        catch (osc::Exception& e) {
             handleException(e);
         }
         return false;
@@ -529,7 +529,7 @@ public:
 
             return true;
         }
-        catch (osc::Exception e) {
+        catch (osc::Exception& e) {
             handleException(e);
         }
         return false;
@@ -588,7 +588,7 @@ public:
 
             return true;
         }
-        catch (osc::Exception e) {
+        catch (osc::Exception& e) {
             handleException(e);
         }
         return false;
@@ -630,7 +630,7 @@ public:
 
             return true;
         }
-        catch (osc::Exception e) {
+        catch (osc::Exception& e) {
             handleException(e);
         }
         return false;
@@ -662,7 +662,7 @@ public:
 
             return true;
         }
-        catch (osc::Exception e) {
+        catch (osc::Exception& e) {
             handleException(e);
         }
         return false;
@@ -695,7 +695,7 @@ public:
 
             return true;
         }
-        catch (osc::Exception e) {
+        catch (osc::Exception& e) {
             handleException(e);
         }
         return false;

--- a/src/osgUtil/MeshOptimizers.cpp
+++ b/src/osgUtil/MeshOptimizers.cpp
@@ -109,6 +109,11 @@ struct VertexAttribComparitor : public GeometryArrayGatherer
     {
     }
 
+    VertexAttribComparitor(const VertexAttribComparitor& rhs)
+        : GeometryArrayGatherer(rhs)
+    {
+    }
+
     bool operator() (unsigned int lhs, unsigned int rhs) const
     {
         for(ArrayList::const_iterator itr=_arrayList.begin();


### PR DESCRIPTION
Cherry-picked https://github.com/openscenegraph/OpenSceneGraph/commit/e0d5e4b0ffa382ea0cf1d3290937722950a9ed80

Identical except for the changes to `MatrixTemplate`, which does not exist in 3.6