### PR TITLE
Convert osg::Geode to osg::Group in dae-plugin

### DIFF
--- a/src/osgPlugins/dae/daeRMaterials.cpp
+++ b/src/osgPlugins/dae/daeRMaterials.cpp
@@ -119,7 +119,7 @@ bool daeReader::findInvertTransparency(daeDatabase* database) const
 //        id
 //        name
 //        type
-void daeReader::processBindMaterial( domBind_material *bm, domGeometry *geom, osg::Geode *geode, osg::Geode *cachedGeode )
+void daeReader::processBindMaterial( domBind_material *bm, domGeometry *geom, osg::Group *geometryGroup, osg::Group *cachedGeometryGroup )
 {
     if (bm->getTechnique_common() == NULL )
     {
@@ -127,11 +127,11 @@ void daeReader::processBindMaterial( domBind_material *bm, domGeometry *geom, os
         return;
     }
 
-    for (size_t i =0; i < geode->getNumDrawables(); i++)
+    for (size_t i =0; i < geometryGroup->getNumChildren(); i++)
     {
-        osg::Drawable* drawable = geode->getDrawable(i);
+        osg::Drawable* drawable = geometryGroup->getChild(i)->asGeometry();
         std::string materialName = drawable->getName();
-        osg::Geometry *cachedGeometry = dynamic_cast<osg::Geometry*>(cachedGeode->getDrawable(i)->asGeometry());
+        osg::Geometry *cachedGeometry = dynamic_cast<osg::Geometry*>(cachedGeometryGroup->getChild(i)->asGeometry());
 
         domInstance_material_Array &ima = bm->getTechnique_common()->getInstance_material_array();
         std::string symbol;

--- a/src/osgPlugins/dae/daeRSceneObjects.cpp
+++ b/src/osgPlugins/dae/daeRSceneObjects.cpp
@@ -18,7 +18,6 @@
 
 #include <osg/Switch>
 #include <osg/LightSource>
-#include <osg/Geode>
 #include <osg/ShapeDrawable>
 #include <osg/LOD>
 #include <osg/Billboard>

--- a/src/osgPlugins/dae/daeReader.cpp
+++ b/src/osgPlugins/dae/daeReader.cpp
@@ -280,7 +280,7 @@ bool daeReader::processDocument( const std::string& fileURI)
 
 void daeReader::clearCaches ()
 {
-    _geometryMap.clear();
+    _geometryGroupMap.clear();
     _materialMap.clear();
     _materialMap2.clear();
 }

--- a/src/osgPlugins/dae/daeReader.h
+++ b/src/osgPlugins/dae/daeReader.h
@@ -248,7 +248,7 @@ public:
         InterpolationType interpolation;
     };
 
-    typedef std::map<domGeometry*, osg::ref_ptr<osg::Geode> >    domGeometryGeodeMap;
+    typedef std::map<domGeometry*, osg::ref_ptr<osg::Group> >    domGeometryGroupMap;
     typedef std::map<domMaterial*, osg::ref_ptr<osg::StateSet> > domMaterialStateSetMap;
     typedef std::map<std::string, osg::ref_ptr<osg::StateSet> >    MaterialStateSetMap;
     typedef std::multimap< daeElement*, domChannel*> daeElementDomChannelMap;
@@ -312,15 +312,15 @@ private:
     osg::Group* processOsgSequence(domTechnique* teq);
 
     // geometry processing
-    osg::Geode* getOrCreateGeometry(domGeometry *geom, domBind_material* pDomBindMaterial, const osg::Geode** ppOriginalGeode = NULL);
+    osg::Group* getOrCreateGeometry(domGeometry *geom, domBind_material* pDomBindMaterial, const osg::Group** ppOriginalGeometry = NULL);
     osgAnimation::Bone* getOrCreateBone(domNode *pDomNode);
     osgAnimation::Skeleton* getOrCreateSkeleton(domNode *pDomNode);
-    osg::Geode* processInstanceGeometry( domInstance_geometry *ig );
+    osg::Group* processInstanceGeometry( domInstance_geometry *ig );
 
-    osg::Geode* processMesh(domMesh* pDomMesh);
-    osg::Geode* processConvexMesh(domConvex_mesh* pDomConvexMesh);
-    osg::Geode* processSpline(domSpline* pDomSpline);
-    osg::Geode* processGeometry(domGeometry *pDomGeometry);
+    osg::Group* processMesh(domMesh* pDomMesh);
+    osg::Group* processConvexMesh(domConvex_mesh* pDomConvexMesh);
+    osg::Group* processSpline(domSpline* pDomSpline);
+    osg::Group* processGeometryGroup(domGeometry *pDomGeometry);
 
     typedef std::vector<domInstance_controller*> domInstance_controllerList;
 
@@ -332,15 +332,15 @@ private:
     osg::Node* processInstanceController( domInstance_controller *ictrl );
 
     template< typename T >
-    void processSinglePPrimitive(osg::Geode* geode, const domMesh* pDomMesh, const T* group, SourceMap& sources, GLenum mode);
+    void processSinglePPrimitive(osg::Group* geometryGroup, const domMesh* pDomMesh, const T* group, SourceMap& sources, GLenum mode);
 
     template< typename T >
-    void processMultiPPrimitive(osg::Geode* geode, const domMesh* pDomMesh, const T* group, SourceMap& sources, GLenum mode);
+    void processMultiPPrimitive(osg::Group* geometryGroup, const domMesh* pDomMesh, const T* group, SourceMap& sources, GLenum mode);
 
-    void processPolylist(osg::Geode* geode, const domMesh* pDomMesh, const domPolylist *group, SourceMap &sources, TessellateMode tessellateMode);
+    void processPolylist(osg::Group* geometryGroup, const domMesh* pDomMesh, const domPolylist *group, SourceMap &sources, TessellateMode tessellateMode);
 
     template< typename T >
-    void processPolygons(osg::Geode* geode, const domMesh* pDomMesh, const T *group, SourceMap &sources, GLenum mode, TessellateMode tessellateMode);
+    void processPolygons(osg::Group* geometryGroup, const domMesh* pDomMesh, const T *group, SourceMap &sources, GLenum mode, TessellateMode tessellateMode);
 
     void resolveMeshArrays(const domP_Array&,
         const domInputLocalOffset_Array& inputs, const domMesh* pDomMesh,
@@ -348,7 +348,7 @@ private:
         std::vector<std::vector<GLuint> >& vertexLists);
 
     //material/effect processing
-    void processBindMaterial( domBind_material *bm, domGeometry *geom, osg::Geode *geode, osg::Geode *cachedGeode );
+    void processBindMaterial( domBind_material *bm, domGeometry *geom, osg::Group *geometryGroup, osg::Group *cachedGeometryGroup );
     void processMaterial(osg::StateSet *ss, domMaterial *mat );
     void processEffect(osg::StateSet *ss, domEffect *effect );
     void processProfileCOMMON(osg::StateSet *ss, domProfile_COMMON *pc );
@@ -406,8 +406,8 @@ private:
     daeElementDomChannelMap _daeElementDomChannelMap;
     /// Maps a domchannel to an animationupdatecallback
     domChannelOsgAnimationUpdateCallbackMap _domChannelOsgAnimationUpdateCallbackMap;
-    /// Maps geometry to a Geode
-    domGeometryGeodeMap _geometryMap;
+    /// Maps domGeometry to a osg::Group
+    domGeometryGroupMap _geometryGroupMap;
     /// All nodes in the document that are used as joints.
     std::set<const domNode*> _jointSet;
     /// Maps a node (of type joint) to a osgAnimation::Bone


### PR DESCRIPTION
This is more of a suggestion/idea than direct pull request, and may require further work. I hope for feedback, and suggest reviewing the code before merging, and considering whether this kind of change is helpful.

What it does: Converts osg::Geode, used by the Collada plugin, to osg::Group. I've understood that Geode is deprecated, so this should be a step forward. It does fix a few Collada-related problems with project OpenMW, particulary the ability to pick objects with mouse click (collision related?), and I haven't at least yet encountered any regressions.

However, I have limited knowledge of how the scenegraph should actually be handled, and if this is a decent way to do it.

