### PR TITLE
CMakeLists.txt: OSG_FIND_3RD_PARTY_DEPS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,7 +753,9 @@ OPTION(BUILD_OSG_PLUGINS "Build OSG Plugins - Disable for compile testing exampl
 mark_as_advanced(BUILD_OSG_PLUGINS)
 ################################################################################
 # 3rd Party Dependency Stuff
-IF(WIN32 AND NOT ANDROID)
+OPTION(OSG_FIND_3RD_PARTY_DEPS "Enable to search for Android or Windows dependencies in ./3rdparty" ON)
+
+IF(WIN32 AND NOT ANDROID AND OSG_FIND_3RD_PARTY_DEPS)
     INCLUDE(Find3rdPartyDependencies)
 ENDIF()
 
@@ -764,7 +766,7 @@ OPTION(OSG_USE_LOCAL_LUA_SOURCE "Enable to use local Lua source when building th
 # you can use the following style of command line option when invoking Cmake (here illustrating ignoring PythonLibs) :
 # cmake -DCMAKE_DISABLE_FIND_PACKAGE_PythonLibs=1 .
 #
-IF(ANDROID)
+IF(ANDROID AND OSG_FIND_3RD_PARTY_DEPS)
     ANDROID_3RD_PARTY()
 ELSE()
 # Common to all platforms except android:
@@ -840,7 +842,7 @@ ENDIF()
 
 # Image readers/writers depend on 3rd party libraries except for OS X which
 # can use Quicktime.
-IF(NOT ANDROID)
+IF(NOT (ANDROID AND OSG_FIND_3RD_PARTY_DEPS))
     IF(NOT APPLE)
         FIND_PACKAGE(GIFLIB)
         FIND_PACKAGE(JPEG)


### PR DESCRIPTION
Android-specific macros aren't needed in some cases, e.g. a much easier way to find packages is to simply specify the correct `CMAKE_FIND_ROOT_PATH`.

The `ANDROID_3RD_PARTY` macro interferes with this. Adds an option to disable it.

WIN32 build is in a similar situation, the new option affects it also.

---

Please also cherry-pick into 3.6 when merging (confirmed that this cherry-picks cleanly and works)