### PR TITLE
nodePath contains bad pointer, since pagedlod might be deleted during the intersection

### DIFF
--- a/include/osgUtil/LineSegmentIntersector
+++ b/include/osgUtil/LineSegmentIntersector
@@ -15,6 +15,7 @@
 #define OSGUTIL_LINESEGMENTINTERSECTOR 1
 
 #include <osgUtil/IntersectionVisitor>
+#include <osg/ObserverNodePath>
 
 namespace osgUtil
 {
@@ -50,7 +51,7 @@ class OSGUTIL_EXPORT LineSegmentIntersector : public Intersector
             typedef std::vector<double>         RatioList;
 
             double                          ratio;
-            osg::NodePath                   nodePath;
+            osg::ObserverNodePath           nodePath;
             osg::ref_ptr<osg::Drawable>     drawable;
             osg::ref_ptr<osg::RefMatrix>    matrix;
             osg::Vec3d                      localIntersectionPoint;

--- a/include/osgUtil/RayIntersector
+++ b/include/osgUtil/RayIntersector
@@ -15,6 +15,7 @@
 #define OSGUTIL_RAYINTERSECTOR 1
 
 #include <osgUtil/IntersectionVisitor>
+#include <osg/ObserverNodePath>
 
 namespace osgUtil
 {
@@ -62,7 +63,7 @@ class OSGUTIL_EXPORT RayIntersector : public Intersector
             typedef std::vector<double>         RatioList;
 
             double                          distance;
-            osg::NodePath                   nodePath;
+            osg::ObserverNodePath           nodePath;
             osg::ref_ptr<osg::Drawable>     drawable;
             osg::ref_ptr<osg::RefMatrix>    matrix;
             osg::Vec3d                      localIntersectionPoint;

--- a/src/osgManipulator/Dragger.cpp
+++ b/src/osgManipulator/Dragger.cpp
@@ -398,7 +398,9 @@ bool Dragger::handle(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& 
                         hitr != intersections.end();
                         ++hitr)
                     {
-                        _pointer.addIntersection(hitr->nodePath, hitr->getLocalIntersectPoint());
+						osg::NodePath np;
+						hitr->nodePath.getNodePath(np);
+						_pointer.addIntersection(np, hitr->getLocalIntersectPoint());
                     }
                     for (osg::NodePath::iterator itr = _pointer._hitList.front().first.begin();
                             itr != _pointer._hitList.front().first.end();

--- a/src/osgPresentation/PickEventHandler.cpp
+++ b/src/osgPresentation/PickEventHandler.cpp
@@ -113,7 +113,10 @@ bool PickEventHandler::handle(const osgGA::GUIEventAdapter& ea,osgGA::GUIActionA
                         const osg::BoundingBox bb(hitr->drawable->getBoundingBox());
 
                         osg::Camera* camera = viewer->getCamera();
-                        osg::Matrix matrix = osg::computeLocalToWorld(hitr->nodePath, false) * camera->getViewMatrix() * camera->getProjectionMatrix();
+
+						osg::NodePath np;
+						hitr->nodePath.getNodePath(np);
+						osg::Matrix matrix = osg::computeLocalToWorld(np, false) * camera->getViewMatrix() * camera->getProjectionMatrix();
                         matrix.postMult(camera->getViewport()->computeWindowMatrix());
 
                         osg::Matrixd inverse;

--- a/src/osgUI/TabWidget.cpp
+++ b/src/osgUI/TabWidget.cpp
@@ -67,8 +67,12 @@ bool TabWidget::handleImplementation(osgGA::EventVisitor* ev, osgGA::Event* even
         if (aa->computeIntersections(*ea, nodePath, intersections))
         {
             const osgUtil::LineSegmentIntersector::Intersection& Intersection = *intersections.begin();
-            for(osg::NodePath::const_iterator itr = Intersection.nodePath.begin();
-                itr != Intersection.nodePath.end();
+
+			osg::NodePath np;
+			Intersection.nodePath.getNodePath(np);
+
+			for (osg::NodePath::const_iterator itr = np.begin();
+				itr != np.end();
                 ++itr)
             {
                 if ((*itr)->getUserValue("index",tabHeaderContainsPointer)) break;

--- a/src/osgUI/Widget.cpp
+++ b/src/osgUI/Widget.cpp
@@ -378,8 +378,13 @@ struct SortTraversalOrder
         if (lhs->ratio > (rhs->ratio+epsilon)) return true;
         if (lhs->ratio < (rhs->ratio-epsilon)) return false;
 
-        const osg::NodePath& np_lhs = lhs->nodePath;
-        const osg::NodePath& np_rhs = rhs->nodePath;
+		osg::NodePath npLhs;
+		lhs->nodePath.getNodePath(npLhs);
+		const osg::NodePath &np_lhs = npLhs;
+
+		osg::NodePath npRhs;
+		rhs->nodePath.getNodePath(npRhs);
+		const osg::NodePath &np_rhs = npRhs;
 
         osg::NodePath::const_iterator itr_lhs = np_lhs.begin();
         osg::NodePath::const_iterator end_lhs = np_lhs.end();

--- a/src/osgUtil/LineSegmentIntersector.cpp
+++ b/src/osgUtil/LineSegmentIntersector.cpp
@@ -797,26 +797,31 @@ osg::Texture* LineSegmentIntersector::Intersection::getTextureLookUp(osg::Vec3& 
             if (texture) activeTexture = texture;
         }
 
-        for(osg::NodePath::const_reverse_iterator itr = nodePath.rbegin();
-            itr != nodePath.rend() && (!activeTexMat || !activeTexture);
-            ++itr)
-        {
-            const osg::Node* node = *itr;
-            if (node->getStateSet())
-            {
-                if (!activeTexMat)
-                {
-                    const osg::TexMat* texMat = dynamic_cast<const osg::TexMat*>(node->getStateSet()->getTextureAttribute(0,osg::StateAttribute::TEXMAT));
-                    if (texMat) activeTexMat = texMat;
-                }
+		osg::NodePath np;
 
-                if (!activeTexture)
-                {
-                    const osg::Texture* texture = dynamic_cast<const osg::Texture*>(node->getStateSet()->getTextureAttribute(0,osg::StateAttribute::TEXTURE));
-                    if (texture) activeTexture = texture;
-                }
-            }
-        }
+		if (nodePath.getNodePath(np))
+		{
+			for (osg::NodePath::const_reverse_iterator itr = np.rbegin();
+				itr != np.rend() && (!activeTexMat || !activeTexture);
+				++itr)
+			{
+				const osg::Node* node = *itr;
+				if (node->getStateSet())
+				{
+					if (!activeTexMat)
+					{
+						const osg::TexMat* texMat = dynamic_cast<const osg::TexMat*>(node->getStateSet()->getTextureAttribute(0, osg::StateAttribute::TEXMAT));
+						if (texMat) activeTexMat = texMat;
+					}
+
+					if (!activeTexture)
+					{
+						const osg::Texture* texture = dynamic_cast<const osg::Texture*>(node->getStateSet()->getTextureAttribute(0, osg::StateAttribute::TEXTURE));
+						if (texture) activeTexture = texture;
+					}
+				}
+			}
+		}
 
         if (activeTexMat)
         {

--- a/src/osgUtil/RayIntersector.cpp
+++ b/src/osgUtil/RayIntersector.cpp
@@ -322,43 +322,48 @@ Texture* RayIntersector::Intersection::getTextureLookUp(Vec3& tc) const
             if (texture) activeTexture = texture;
         }
 
-        for(NodePath::const_reverse_iterator itr = nodePath.rbegin();
-            itr != nodePath.rend() && (!activeTexMat || !activeTexture);
-            ++itr)
-            {
-                const Node* node = *itr;
-                if (node->getStateSet())
-                {
-                    if (!activeTexMat)
-                    {
-                        const TexMat* texMat = dynamic_cast<const TexMat*>(node->getStateSet()->getTextureAttribute(0,StateAttribute::TEXMAT));
-                        if (texMat) activeTexMat = texMat;
-                    }
+		osg::NodePath np;
 
-                    if (!activeTexture)
-                    {
-                        const Texture* texture = dynamic_cast<const Texture*>(node->getStateSet()->getTextureAttribute(0,StateAttribute::TEXTURE));
-                        if (texture) activeTexture = texture;
-                    }
-                }
-            }
+		if (nodePath.getNodePath(np))
+		{
+			for (NodePath::const_reverse_iterator itr = np.rbegin();
+				itr != np.rend() && (!activeTexMat || !activeTexture);
+				++itr)
+			{
+				const Node* node = *itr;
+				if (node->getStateSet())
+				{
+					if (!activeTexMat)
+					{
+						const TexMat* texMat = dynamic_cast<const TexMat*>(node->getStateSet()->getTextureAttribute(0, StateAttribute::TEXMAT));
+						if (texMat) activeTexMat = texMat;
+					}
 
-            if (activeTexMat)
-            {
-                Vec4 tc_transformed = Vec4(tc.x(), tc.y(), tc.z() ,0.0f) * activeTexMat->getMatrix();
-                tc.x() = tc_transformed.x();
-                tc.y() = tc_transformed.y();
-                tc.z() = tc_transformed.z();
+					if (!activeTexture)
+					{
+						const Texture* texture = dynamic_cast<const Texture*>(node->getStateSet()->getTextureAttribute(0, StateAttribute::TEXTURE));
+						if (texture) activeTexture = texture;
+					}
+				}
+			}
 
-                if (activeTexture && activeTexMat->getScaleByTextureRectangleSize())
-                {
-                    tc.x() *= static_cast<float>(activeTexture->getTextureWidth());
-                    tc.y() *= static_cast<float>(activeTexture->getTextureHeight());
-                    tc.z() *= static_cast<float>(activeTexture->getTextureDepth());
-                }
-            }
+			if (activeTexMat)
+			{
+				Vec4 tc_transformed = Vec4(tc.x(), tc.y(), tc.z(), 0.0f) * activeTexMat->getMatrix();
+				tc.x() = tc_transformed.x();
+				tc.y() = tc_transformed.y();
+				tc.z() = tc_transformed.z();
 
-            return const_cast<Texture*>(activeTexture);
+				if (activeTexture && activeTexMat->getScaleByTextureRectangleSize())
+				{
+					tc.x() *= static_cast<float>(activeTexture->getTextureWidth());
+					tc.y() *= static_cast<float>(activeTexture->getTextureHeight());
+					tc.z() *= static_cast<float>(activeTexture->getTextureDepth());
+				}
+			}
+
+			return const_cast<Texture*>(activeTexture);
+		}
 
     }
     return 0;

--- a/src/osgWidget/WindowManager.cpp
+++ b/src/osgWidget/WindowManager.cpp
@@ -317,7 +317,9 @@ bool WindowManager::pickAtXY(float x, float y, WidgetList& wl)
         // Iterate over every picked result and create a list of Widgets that belong
         // to that Window.
         for(Intersections::iterator i = intr.begin(); i != intr.end(); i++) {
-            Window* win = dynamic_cast<Window*>(i->nodePath.back()->getParent(0));
+			osg::NodePath np;
+			i->nodePath.getNodePath(np);
+			Window* win = dynamic_cast<Window*>(np.back()->getParent(0));
 
             // Make sure that our window is valid, and that our pick is within the
             // "visible area" of the Window.


### PR DESCRIPTION
The node path contians pagedlod pointer, if the pagedlod pointer is released during the intersection. That might happen if the read   callback is set to the intersection visitor. For example, databaseCacheReadCallback is set to the intersection visitor. The databaseCacheReadCallback will release the pagedlod when the cache is full.