### PR TITLE
Setting numViews value in glFramebufferTextureMultiviewOVR call

### DIFF
--- a/src/osg/FrameBufferObject.cpp
+++ b/src/osg/FrameBufferObject.cpp
@@ -540,7 +540,7 @@ void FrameBufferAttachment::attach(State &state, GLenum target, GLenum attachmen
         {
             if (ext->glFramebufferTextureMultiviewOVR)
             {
-                ext->glFramebufferTextureMultiviewOVR(target, attachment_point, tobj->id(), _ximpl->level, 0, 2);
+                ext->glFramebufferTextureMultiviewOVR(target, attachment_point, tobj->id(), _ximpl->level, 0, _ximpl->textureTarget->getTextureDepth());
             }
         }
         else


### PR DESCRIPTION
Was just missed when you did the inital work I think.

One thing I think would be worth looking at is a way to set baseViewIndex and numViews manually. I can't think of a way though without adding new variables somewhere.

Users might have a situation where they want to render more views than the hardware is capable of in a single pass but they may also want to keep all the views in a single texture array. If they could set the baseViewIndex and numViews manually they could say render me from 0-3 in one pass then 4-7 in another pass.

Just a thought.