### PR TITLE
Do not delete GlobalReferencedMutex on exit

### DIFF
--- a/src/osg/Referenced.cpp
+++ b/src/osg/Referenced.cpp
@@ -79,12 +79,11 @@ struct ResetPointer
 };
 
 typedef ResetPointer<DeleteHandler> DeleteHandlerPointer;
-typedef ResetPointer<OpenThreads::Mutex> GlobalMutexPointer;
 
 OpenThreads::Mutex* Referenced::getGlobalReferencedMutex()
 {
-    static GlobalMutexPointer s_ReferencedGlobalMutext = new OpenThreads::Mutex;
-    return s_ReferencedGlobalMutext.get();
+    static OpenThreads::Mutex* s_ReferencedGlobalMutext = new OpenThreads::Mutex;
+    return s_ReferencedGlobalMutext;
 }
 
 // helper class for forcing the global mutex to be constructed when the library is loaded.


### PR DESCRIPTION
Static (de)initialization order caused this mutex to be deleted before
the objects that depended on it, causing a crash on exit.

With this change, OSG no longer deletes the mutex on exit. This is OK
because it is deleted by the OS on exit anyway.

Fixes #1048

---

Please also cherry-pick into 3.6 (applies cleanly)