### PR TITLE
Ensure global Mutex is initialized before Registry

### DIFF
--- a/include/osgDB/Registry
+++ b/include/osgDB/Registry
@@ -50,7 +50,8 @@ namespace osgDB {
     The RegisterReaderWriterProxy can be used to automatically
     register at runtime a reader/writer with the Registry.
 */
-class OSGDB_EXPORT Registry : public osg::Referenced
+class OSGDB_EXPORT Registry : osg::depends_on<OpenThreads::Mutex*, osg::Referenced::getGlobalReferencedMutex>,
+                              public osg::Referenced
 {
     public:
 


### PR DESCRIPTION
A Registry instance may be accessed before the global mutex, e.g. via `osgText::Font::getDefaultFont()`  here:

https://github.com/openscenegraph/OpenSceneGraph/blob/e77f50371ce6ab05ee0c523fc7a4604ad639e047/src/osgText/Font.cpp#L49

This leads to the Mutex being destroyed before the Registry is destroyed.

This causes a crash at exit, as described in #1048.

Fixes #1048.

---

Please also merge into 3.6 (applies cleanly)