### PR TITLE
Fix C++17 MSVC compilation error

### DIFF
--- a/src/osg/DisplaySettings.cpp
+++ b/src/osg/DisplaySettings.cpp
@@ -22,15 +22,15 @@
 #include <algorithm>
 #include <string.h>
 
-using namespace osg;
-using namespace std;
-
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #include<windows.h>
 extern "C" { OSG_EXPORT DWORD NvOptimusEnablement=0x00000001; }
 #else
 extern "C" { int NvOptimusEnablement=0x00000001; }
 #endif
+
+using namespace osg;
+using namespace std;
 
 void DisplaySettings::setNvOptimusEnablement(int value)
 {

--- a/src/osgPlugins/cfg/ConfigParser.cpp
+++ b/src/osgPlugins/cfg/ConfigParser.cpp
@@ -235,7 +235,6 @@
 #include "CameraConfig.h"
 
 
-using namespace std;
 using namespace osgProducer;
 
 static void ConfigParser_error( const char * );

--- a/src/osgPlugins/cfg/ConfigParser.y
+++ b/src/osgPlugins/cfg/ConfigParser.y
@@ -34,7 +34,6 @@
 #include <Producer/CameraConfig>
 
 
-using namespace std;
 using namespace Producer;
 
 static void ConfigParser_error( const char * );


### PR DESCRIPTION
With C++17, Windows headers must not be included after `using namespace std;`.

Windows headers define a `byte` type internally and `using namespace std`
causes it to conflict with `std::byte`:

    error C2872: 'byte': ambiguous symbol

MSVC thread: https://developercommunity.visualstudio.com/t/error-c2872-byte-ambiguous-symbol/93889