### PR TITLE
Check GL_NV_framebuffer_multisample_coverage

### DIFF
--- a/examples/osgfpdepth/osgfpdepth.cpp
+++ b/examples/osgfpdepth/osgfpdepth.cpp
@@ -138,9 +138,7 @@ void getPossibleConfigs(GraphicsContext* gc, BufferConfigList& colorConfigs,
         return;
     if (ext->isMultisampleSupported)
         glGetIntegerv(GL_MAX_SAMPLES_EXT, &maxSamples);
-    // isMultisampleCoverageSupported
-    if (isGLExtensionSupported(contextID,
-                               "GL_NV_framebuffer_multisample_coverage"))
+    if (ext->isRenderbufferMultisampleCoverageSupported())
     {
         glGetIntegerv(GL_MAX_MULTISAMPLE_COVERAGE_MODES_NV,
                       &coverageSampleConfigs);

--- a/src/osg/GLExtensions.cpp
+++ b/src/osg/GLExtensions.cpp
@@ -1094,7 +1094,10 @@ GLExtensions::GLExtensions(unsigned int in_contextID):
     setGLExtensionFuncPtr(glGenRenderbuffers, "glGenRenderbuffers", "glGenRenderbuffersEXT", "glGenRenderbuffersOES", validContext);
     setGLExtensionFuncPtr(glRenderbufferStorage, "glRenderbufferStorage", "glRenderbufferStorageEXT", "glRenderbufferStorageOES", validContext);
     setGLExtensionFuncPtr(glRenderbufferStorageMultisample, "glRenderbufferStorageMultisample", "glRenderbufferStorageMultisampleEXT", "glRenderbufferStorageMultisampleOES", validContext);
-    setGLExtensionFuncPtr(glRenderbufferStorageMultisampleCoverageNV, "glRenderbufferStorageMultisampleCoverageNV", validContext);
+    if (isGLExtensionSupported(contextID, "GL_NV_framebuffer_multisample_coverage"))
+        setGLExtensionFuncPtr(glRenderbufferStorageMultisampleCoverageNV, "glRenderbufferStorageMultisampleCoverageNV", validContext);
+    else
+        glRenderbufferStorageMultisampleCoverageNV = NULL;
     setGLExtensionFuncPtr(glBindFramebuffer, "glBindFramebuffer", "glBindFramebufferEXT", "glBindFramebufferOES", validContext);
     setGLExtensionFuncPtr(glDeleteFramebuffers, "glDeleteFramebuffers", "glDeleteFramebuffersEXT", "glDeleteFramebuffersOES", validContext);
     setGLExtensionFuncPtr(glGenFramebuffers, "glGenFramebuffers", "glGenFramebuffersEXT", "glGenFramebuffersOES", validContext);


### PR DESCRIPTION
`isRenderbufferMultisampleCoverageSupported()` should not return true if the extension is not supported.

Fixes #1028