### PR TITLE
Fix: Removed drawing from compileGLObjects method of text.

### DIFF
--- a/include/osgText/Text
+++ b/include/osgText/Text
@@ -185,6 +185,10 @@ public:
     /** Get the coordinates of the character corners in local coordinates. Use Text::getMatrix() or Text::computeMatrix(..) to get the transform into model coordinates (see TextBase header.) */
     bool getCharacterCorners(unsigned int index, osg::Vec3& bottomLeft, osg::Vec3& bottomRight, osg::Vec3& topLeft, osg::Vec3& topRight) const;
 
+    /** Immediately compile this \c Drawable into an OpenGL Display List/VertexBufferObjects.
+      * @note Operation is ignored if \c _useDisplayList is \c false or VertexBufferObjects are not used. */
+    virtual void compileGLObjects(osg::RenderInfo& renderInfo) const;
+
     /** Resize any per context GLObject buffers to specified size. */
     virtual void resizeGLObjectBuffers(unsigned int maxSize);
 

--- a/include/osgText/Text3D
+++ b/include/osgText/Text3D
@@ -91,6 +91,10 @@ class OSGTEXT_EXPORT Text3D : public osgText::TextBase
         /** accept a PrimtiveFunctor and call its methods to tell it about the internal primtives that this Drawable has.*/
         virtual void accept(osg::PrimitiveFunctor& pf) const;
 
+        /** Immediately compile this \c Drawable into an OpenGL Display List/VertexBufferObjects.
+          * @note Operation is ignored if \c _useDisplayList is \c false or VertexBufferObjects are not used. */
+        virtual void compileGLObjects(osg::RenderInfo& renderInfo) const;
+
         /** Resize any per context GLObject buffers to specified size. */
         virtual void resizeGLObjectBuffers(unsigned int maxSize);
 


### PR DESCRIPTION
At the moment, in compileGLObjects method of text, not only the preparation of glBuffers takes place, but also the rendering itself. This leads to text rendering in those moments when it should not be.