### PR TITLE
Fix bounds for empty text nodes

### DIFF
--- a/src/osgText/TextBase.cpp
+++ b/src/osgText/TextBase.cpp
@@ -484,6 +484,14 @@ void TextBase::computePositions()
 
 void TextBase::computePositionsImplementation()
 {
+    _normal = osg::Vec3(0.0f,0.0f,1.0f);
+
+    if (_text.empty())
+    {
+        _offset = Vec3();
+        return;
+    }
+
     switch(_alignment)
     {
         case LEFT_TOP:      _offset.set(_textBB.xMin(),_textBB.yMax(),_textBB.zMin()); break;
@@ -506,8 +514,6 @@ void TextBase::computePositionsImplementation()
         case CENTER_BOTTOM_BASE_LINE:  _offset.set((_textBB.xMax()+_textBB.xMin())*0.5f,-_characterHeight*(1.0 + _lineSpacing)*(_lineCount-1),0.0f); break;
         case RIGHT_BOTTOM_BASE_LINE:  _offset.set(_textBB.xMax(),-_characterHeight*(1.0 + _lineSpacing)*(_lineCount-1),0.0f); break;
     }
-
-    _normal = osg::Vec3(0.0f,0.0f,1.0f);
 }
 
 bool TextBase::computeMatrix(osg::Matrix& matrix, osg::State* state) const


### PR DESCRIPTION
_lineCount can be 0 if the TextBase has no text, so we get underflow if the alignment is one of the *_BOTTOM_BASE_LINE. Empty text nodes seem to come up in some of the .dxf files our users are importing.

I've worked around the bug in our code for now by deleting the empty text nodes on load. 