### PR TITLE
Add move constructor and move assignment operator to ref_ptr

### DIFF
--- a/include/osg/ref_ptr
+++ b/include/osg/ref_ptr
@@ -22,6 +22,10 @@
 #include <string>
 #endif
 
+#if __cplusplus >= 201103L
+#include <utility>
+#endif
+
 namespace osg {
 
 template<typename T> class observer_ptr;
@@ -36,6 +40,9 @@ class ref_ptr
         ref_ptr() : _ptr(0) {}
         ref_ptr(T* ptr) : _ptr(ptr) { if (_ptr) _ptr->ref(); }
         ref_ptr(const ref_ptr& rp) : _ptr(rp._ptr) { if (_ptr) _ptr->ref(); }
+#if __cplusplus >= 201103L
+        ref_ptr(ref_ptr&& rp) noexcept : _ptr(rp._ptr) { rp._ptr = 0; }
+#endif
         template<class Other> ref_ptr(const ref_ptr<Other>& rp) : _ptr(rp._ptr) { if (_ptr) _ptr->ref(); }
         ref_ptr(observer_ptr<T>& optr) : _ptr(0) { optr.lock(*this); }
         ~ref_ptr() { if (_ptr) _ptr->unref();  _ptr = 0; }
@@ -51,6 +58,17 @@ class ref_ptr
             assign(rp);
             return *this;
         }
+
+#if __cplusplus >= 201103L
+        template<class Other> ref_ptr& operator = (ref_ptr<Other>&& rp)
+        {
+            if (_ptr == rp._ptr) return *this;
+            if (_ptr != nullptr) _ptr->unref();
+            _ptr = rp._ptr;
+            rp._ptr = nullptr;
+            return *this;
+        }
+#endif
 
         inline ref_ptr& operator = (T* ptr)
         {


### PR DESCRIPTION
Use conditional compilation to make it work only with C++11 support.

This gives a performance boost for inserting and erasing from a middle of a `std::vector<osg::ref_ptr>` because no reference counting is done while elements are shifted. Insert example is `Group::insertChild` function [here](https://github.com/openscenegraph/OpenSceneGraph/blob/d64ad2e654001a4323a7fb39fa3d937ae71f1646/src/osg/Group.cpp#L98) and erase example is `Group::removeChildren` function [here](https://github.com/openscenegraph/OpenSceneGraph/blob/d64ad2e654001a4323a7fb39fa3d937ae71f1646/src/osg/Group.cpp#L199).

In the specific OpenMW location loading case total cost of `Group::insertChild` is reduced by 11 times and `Group::removeChildren` by 13 times. Overall this reduces specific location loading by half. For more details see profiling [before](https://gitlab.com/OpenMW/openmw/-/issues/5992#note_563104417) the change and [after](https://gitlab.com/OpenMW/openmw/-/issues/5992#note_563130087) the change. It might be questionable if we are actually doing the right thing in OpenMW by inserting and erasing so many elements. Still this change should make performance improvement even for a single insert or erase.