### PR TITLE
Fix for Optimizer handling of Switch nodes

### DIFF
--- a/include/osgUtil/Optimizer
+++ b/include/osgUtil/Optimizer
@@ -17,6 +17,7 @@
 #include <osg/NodeVisitor>
 #include <osg/Matrix>
 #include <osg/Geometry>
+#include <osg/Switch>
 #include <osg/Transform>
 #include <osg/Texture2D>
 
@@ -534,6 +535,10 @@ class OSGUTIL_EXPORT Optimizer
 
                 virtual void apply(osg::Group& group) { mergeGroup(group); traverse(group); }
                 virtual void apply(osg::Billboard&) { /* don't do anything*/ }
+                virtual void apply(osg::Switch& group) {
+                    /* don't merge immediate children */
+                    traverse(group);
+                }
 
                 bool mergeGroup(osg::Group& group);
 


### PR DESCRIPTION
If Geometry nodes are directly attached to a Switch node (without using Geodes) then the Optimizer MergeGeometryVisitor incorrectly merges them all together.  Simple fix to not merge directly attached Geometry nodes, but still traverse other child types.
