### PR TITLE
PR plugin opt 3.6

### DIFF
--- a/src/osgDB/InputStream.cpp
+++ b/src/osgDB/InputStream.cpp
@@ -815,7 +815,7 @@ osg::ref_ptr<osg::Image> InputStream::readImage(bool readFromExternal)
                     std::stringstream inputStream;
                     inputStream.write( data, size );
 
-                    osgDB::ReaderWriter::ReadResult rr = reader->readImage( inputStream );
+                    osgDB::ReaderWriter::ReadResult rr = reader->readImage( inputStream, _options.get());
                     if ( rr.validImage() )
                         image = rr.takeImage();
                     else

--- a/src/osgPlugins/glsl/ReaderWriterGLSL.cpp
+++ b/src/osgPlugins/glsl/ReaderWriterGLSL.cpp
@@ -229,7 +229,7 @@ class ReaderWriterGLSL : public osgDB::ReaderWriter
             return WriteResult::FILE_SAVED;
         }
 
-        virtual WriteResult writeShader(const osg::Shader &shader,const std::string& fileName, const osgDB::ReaderWriter::Options*) const
+        virtual WriteResult writeShader(const osg::Shader &shader,const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
         {
             std::string ext = osgDB::getFileExtension(fileName);
             if (!acceptsExtension(ext)) return WriteResult::FILE_NOT_HANDLED;
@@ -237,7 +237,7 @@ class ReaderWriterGLSL : public osgDB::ReaderWriter
             osgDB::ofstream fout(fileName.c_str(), std::ios::out | std::ios::binary);
             if(!fout) return WriteResult::ERROR_IN_WRITING_FILE;
 
-            return writeShader(shader, fout);
+            return writeShader(shader, fout, options);
         }
 };
 

--- a/src/osgPlugins/logo/ReaderWriterLOGO.cpp
+++ b/src/osgPlugins/logo/ReaderWriterLOGO.cpp
@@ -177,9 +177,9 @@ class Logos: public osg::Drawable
         #endif
         }
 
-        void addLogo( RelativePosition pos, std::string name )
+        void addLogo( RelativePosition pos, std::string name, const osgDB::ReaderWriter::Options* options)
         {
-            osg::ref_ptr<osg::Image> image = osgDB::readRefImageFile( name.c_str() );
+            osg::ref_ptr<osg::Image> image = osgDB::readRefImageFile( name.c_str(), options );
             if( image.valid())
             {
                 _logos[pos].push_back( image );
@@ -319,7 +319,7 @@ class LOGOReaderWriter : public osgDB::ReaderWriter
                 else
                 {
                     if( str.length() )
-                    ld->addLogo( pos, str );
+                    ld->addLogo( pos, str ,options);
                 }
             }
 

--- a/src/osgPlugins/lwo/ReaderWriterLWO.cpp
+++ b/src/osgPlugins/lwo/ReaderWriterLWO.cpp
@@ -167,7 +167,7 @@ struct GeometryCollection
 
 
 // read file and convert to OSG.
-osgDB::ReaderWriter::ReadResult ReaderWriterLWO::readNode_LWO1(const std::string& fileName, const osgDB::ReaderWriter::Options*) const
+osgDB::ReaderWriter::ReadResult ReaderWriterLWO::readNode_LWO1(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
 {
     lwObject* lw = lw_object_read(fileName.c_str(),osg::notify(osg::INFO));
     if (!lw)
@@ -224,7 +224,7 @@ osgDB::ReaderWriter::ReadResult ReaderWriterLWO::readNode_LWO1(const std::string
                 if (lw_material.ctex.flags && strlen(lw_material.ctex.name)!=0)
                 {
                     OSG_INFO << "ctex " << lw_material.ctex.name << std::endl;
-                    osg::ref_ptr<osg::Image> image = osgDB::readRefImageFile(lw_material.ctex.name);
+                    osg::ref_ptr<osg::Image> image = osgDB::readRefImageFile(lw_material.ctex.name, options);
                     if (image.valid())
                     {
                         // create state

--- a/src/osgPlugins/mdl/MDLReader.cpp
+++ b/src/osgPlugins/mdl/MDLReader.cpp
@@ -145,7 +145,7 @@ std::string MDLReader::getToken(std::string str, const char * /*delim*/, size_t 
 }
 
 
-ref_ptr<Texture> MDLReader::readTextureFile(std::string textureName)
+ref_ptr<Texture> MDLReader::readTextureFile(std::string textureName, const osgDB::ReaderWriter::Options* options)
 {
     // Find the texture's image file
     std::string texExtension = osgDB::getFileExtensionIncludingDot(textureName);
@@ -175,7 +175,7 @@ ref_ptr<Texture> MDLReader::readTextureFile(std::string textureName)
     // If we found the file, read it, otherwise bail
     if (!texPath.empty())
     {
-        osg::ref_ptr<Image> texImage = readRefImageFile(texPath);
+        osg::ref_ptr<Image> texImage = readRefImageFile(texPath, options);
 
         // If we got the image, create the texture attribute
         if (texImage.valid())
@@ -227,7 +227,7 @@ ref_ptr<Texture> MDLReader::readTextureFile(std::string textureName)
 }
 
 
-ref_ptr<StateSet> MDLReader::readMaterialFile(std::string materialName)
+ref_ptr<StateSet> MDLReader::readMaterialFile(std::string materialName, const osgDB::ReaderWriter::Options* options)
 {
     std::string              mtlFileName;
     std::string              mtlPath;
@@ -363,7 +363,7 @@ ref_ptr<StateSet> MDLReader::readMaterialFile(std::string materialName)
 
                 // Read the texture
                 if (!token.empty())
-                    texture = readTextureFile(token);
+                    texture = readTextureFile(token, options);
             }
             else if (equalCaseInsensitive(token, "$basetexture2"))
             {
@@ -372,7 +372,7 @@ ref_ptr<StateSet> MDLReader::readMaterialFile(std::string materialName)
 
                 // Read the texture
                 if (!token.empty())
-                    texture2 = readTextureFile(token);
+                    texture2 = readTextureFile(token, options);
             }
             else if ((equalCaseInsensitive(token, "$translucent")) ||
                      (equalCaseInsensitive(token, "$alphatest")))
@@ -586,7 +586,7 @@ Mesh * MDLReader::processMesh(std::istream * str, int offset)
 }
 
 
-bool MDLReader::readFile(const std::string & file)
+bool MDLReader::readFile(const std::string & file, const osgDB::ReaderWriter::Options* options)
 {
     std::string       baseName;
     std::string       fileName;
@@ -680,7 +680,7 @@ bool MDLReader::readFile(const std::string & file)
         while ((j < sizeof(texName)) && (texName[j-1] != 0));
 
         // Load this texture
-        stateSet = readMaterialFile(texName);
+        stateSet = readMaterialFile(texName, options);
 
         // Add it to our list
         state_sets.push_back(stateSet);

--- a/src/osgPlugins/mdl/MDLReader.h
+++ b/src/osgPlugins/mdl/MDLReader.h
@@ -170,8 +170,8 @@ protected:
    std::string    getToken(std::string str, const char * delim, size_t & index);
    std::string    findFileIgnoreCase(std::string filePath);
 
-   osg::ref_ptr<osg::Texture>     readTextureFile(std::string textureName);
-   osg::ref_ptr<osg::StateSet>    readMaterialFile(std::string mtlName);
+   osg::ref_ptr<osg::Texture>     readTextureFile(std::string textureName, const osgDB::ReaderWriter::Options* options);
+   osg::ref_ptr<osg::StateSet>    readMaterialFile(std::string mtlName, const osgDB::ReaderWriter::Options* options);
 
    BodyPart *    processBodyPart(std::istream * str, int offset);
    Model *       processModel(std::istream * str, int offset);
@@ -182,7 +182,7 @@ public:
    MDLReader();
    virtual ~MDLReader();
 
-   bool   readFile(const std::string & file);
+   bool   readFile(const std::string & file, const osgDB::ReaderWriter::Options* options);
 
    osg::ref_ptr<osg::Node>   getRootNode();
 };

--- a/src/osgPlugins/mdl/ReaderWriterMDL.cpp
+++ b/src/osgPlugins/mdl/ReaderWriterMDL.cpp
@@ -46,7 +46,7 @@ ReaderWriter::ReadResult ReaderWriterMDL::readNode(
     // allows us to also find the .vvd and .vtx files without the leading
     // path confusing things)
     mdlReader = new MDLReader();
-    if (mdlReader->readFile(file))
+    if (mdlReader->readFile(file, options))
     {
         // Get the results of our read
         result = mdlReader->getRootNode();

--- a/src/osgPlugins/normals/ReaderWriterNormals.cpp
+++ b/src/osgPlugins/normals/ReaderWriterNormals.cpp
@@ -77,7 +77,7 @@ class NormalsReader: public osgDB::ReaderWriter
             std::string nodeName = osgDB::getNameLessExtension( fileName );
             if( !nodeName.empty() )
             {
-                osg::ref_ptr<osg::Node> node = osgDB::readRefNodeFile( nodeName );
+                osg::ref_ptr<osg::Node> node = osgDB::readRefNodeFile( nodeName, options );
                 if( node.valid() )
                 {
                     osg::ref_ptr<osg::Group> group = new osg::Group;

--- a/src/osgPlugins/ply/ReaderWriterPLY.cpp
+++ b/src/osgPlugins/ply/ReaderWriterPLY.cpp
@@ -78,7 +78,7 @@ osgDB::ReaderWriter::ReadResult ReaderWriterPLY::readNode(const std::string& fil
 
     //Instance of vertex data which will read the ply file and convert in to osg::Node
     ply::VertexData vertexData;
-    osg::Node* node = vertexData.readPlyFile(fileName.c_str());
+    osg::Node* node = vertexData.readPlyFile(fileName.c_str(), options);
 
     if (node)
         return node;

--- a/src/osgPlugins/ply/vertexData.cpp
+++ b/src/osgPlugins/ply/vertexData.cpp
@@ -19,7 +19,6 @@
 #include <osg/io_utils>
 #include <osgUtil/SmoothingVisitor>
 #include <osg/TexEnv>
-#include <osgDB/ReaderWriter>
 #include <osgDB/FileNameUtils>
 #include <osgDB/ReadFile>
 #include <osg/Texture2D>
@@ -269,7 +268,7 @@ void VertexData::readTriangles( PlyFile* file, const int nFaces )
 
 
 /*  Open a PLY file and read vertex, color and index data. and returns the node  */
-osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColors )
+osg::Node* VertexData::readPlyFile( const char* filename, const osgDB::ReaderWriter::Options* options, const bool ignoreColors )
 {
     int     nPlyElems;
     char**  elemNames;
@@ -539,7 +538,7 @@ osg::Node* VertexData::readPlyFile( const char* filename, const bool ignoreColor
         geom->setUseVertexBufferObjects(true);
 
         osg::ref_ptr<osg::Image> image;
-        if (!textureFile.empty() && (image = osgDB::readRefImageFile(textureFile)) != NULL)
+        if (!textureFile.empty() && (image = osgDB::readRefImageFile(textureFile, options)) != NULL)
         {
             osg::Texture2D *texture = new osg::Texture2D;
             texture->setImage(image.get());

--- a/src/osgPlugins/ply/vertexData.h
+++ b/src/osgPlugins/ply/vertexData.h
@@ -15,6 +15,7 @@
 
 #include <osg/Node>
 #include <osg/PrimitiveSet>
+#include <osgDB/ReaderWriter>
 
 #include <vector>
 
@@ -39,7 +40,7 @@ namespace ply
 
 
         // Reads ply file and convert in to osg::Node and returns the same
-        osg::Node* readPlyFile( const char* file, const bool ignoreColors = false );
+        osg::Node* readPlyFile( const char* file, const osgDB::ReaderWriter::Options* options, const bool ignoreColors = false );
 
         // to set the flag for using inverted face
         void useInvertedFaces() { _invertFaces = true; }

--- a/src/osgWrappers/deprecated-dotosg/osgVolume/ImageLayer.cpp
+++ b/src/osgWrappers/deprecated-dotosg/osgVolume/ImageLayer.cpp
@@ -57,12 +57,12 @@ bool ImageLayer_readLocalData(osg::Object& obj, osgDB::Input &fr)
                 osg::ref_ptr<osg::Image> image;
                 if (fileType == osgDB::DIRECTORY)
                 {
-                    image = osgDB::readRefImageFile(filename+".dicom");
+                    image = osgDB::readRefImageFile(filename+".dicom", fr.getOptions());
 
                 }
                 else if (fileType == osgDB::REGULAR_FILE)
                 {
-                    image = osgDB::readRefImageFile( filename );
+                    image = osgDB::readRefImageFile( filename, fr.getOptions());
                 }
 
 


### PR DESCRIPTION
Hi Robert,
I noticed that a few of the plugins don't pass their options to dependent (image) loaders. Took me a while to understand that the readRef[Image/Node/Object] functions take their default from the registry options, while the objCache functions use NULL as default.
Laurens.