### PR TITLE
removes invalid glReadBuffer calls

### DIFF
--- a/src/osgUtil/RenderStage.cpp
+++ b/src/osgUtil/RenderStage.cpp
@@ -519,9 +519,7 @@ void RenderStage::runCameraSetUp(osg::RenderInfo& renderInfo)
             {
             #if !defined(OSG_GLES1_AVAILABLE) && !defined(OSG_GLES2_AVAILABLE) && !defined(OSG_GLES3_AVAILABLE)
                 setDrawBuffer( GL_NONE, true );
-                setReadBuffer( GL_NONE, true );
                 state.glDrawBuffer( GL_NONE );
-                state.glReadBuffer( GL_NONE );
             #endif
             }
 


### PR DESCRIPTION
While investigating reports of Open GL errors in Open MW, we found osg makes such invalid calls during the setup of framebuffer objects that do not use color attachments. The Open GL specification indicates GL_NONE is not an acceptable value for glReadBuffer.