### PR TITLE
Silence OpenGL deprecation warnings on macOS; we know.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,9 @@ ENDIF()
 IF(NOT ANDROID)
 IF(APPLE)
 
+    # Silence OpenGL deprecation warnings on macOS; we know. 
+    ADD_COMPILE_DEFINITIONS(GL_SILENCE_DEPRECATION=1)
+
     IF(OSG_BUILD_PLATFORM_IPHONE)
 
         # set the sdk path as our sysroot, if we set this before the project is defined cmake fails to build its test program


### PR DESCRIPTION
Once Apple finally decides to drop OpenGL support then OSG can also then remove support for Apple products.

This cuts down on the amount of spam, 8 lines per call to OpenGL on macOS. Reduces compile time in addition to making actual errors easier to track down.

If merged, can this be cherry-picked to OpenSceneGraph-3.6 ?

Example of spam to be silenced:

```
In file included from /Users/gitlab/builds/OpenMW/openmw-dep/macos/source/openscenegraph/src/osg/PrimitiveRestartIndex.cpp:15:
/Users/gitlab/builds/OpenMW/openmw-dep/macos/source/openscenegraph/include/osg/State:1149:30: warning: 'glEnable' is deprecated: first deprecated in macOS 10.14 - OpenGL API deprecated. (Define GL_SILENCE_DEPRECATION to silence these warnings) [-Wdeprecated-declarations]
                if (enabled) glEnable(mode);
                             ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/System/Library/Frameworks/OpenGL.framework/Headers/gl.h:2472:13: note: 'glEnable' has been explicitly marked deprecated here
extern void glEnable (GLenum cap) OPENGL_DEPRECATED(10.0, 10.14);
            ^
In file included from /Users/gitlab/builds/OpenMW/openmw-dep/macos/source/openscenegraph/src/osg/PrimitiveRestartIndex.cpp:15:
/Users/gitlab/builds/OpenMW/openmw-dep/macos/source/openscenegraph/include/osg/State:1150:22: warning: 'glDisable' is deprecated: first deprecated in macOS 10.14 - OpenGL API deprecated. (Define GL_SILENCE_DEPRECATION to silence these warnings) [-Wdeprecated-declarations]
                else glDisable(mode);
                     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/System/Library/Frameworks/OpenGL.framework/Headers/gl.h:2462:13: note: 'glDisable' has been explicitly marked deprecated here
extern void glDisable (GLenum cap) OPENGL_DEPRECATED(10.0, 10.14);
            ^
```