### PR TITLE
Bring auto-generated includes into target_include_directories

### DIFF
--- a/CMakeModules/OsgMacroUtils.cmake
+++ b/CMakeModules/OsgMacroUtils.cmake
@@ -227,6 +227,7 @@ MACRO(SETUP_LIBRARY LIB_NAME)
         TARGET_INCLUDE_DIRECTORIES(${LIB_NAME}
             PUBLIC
                 $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
                 $<INSTALL_INTERFACE:${INSTALL_INCDIR}>
         )
 


### PR DESCRIPTION
osg cannot be built/linked against within a larger CMake build (e.g.,
when brought in as add_subdirectory(OpenSceneGraph)) because
target_include_directories(osg ...) does not include a build-time
path to auto-generated includes; e.g. osg/Config

This commit fixes that.