### PR TITLE
Find zlib on Android

### DIFF
--- a/CMakeModules/OsgAndroidMacroUtils.cmake
+++ b/CMakeModules/OsgAndroidMacroUtils.cmake
@@ -126,18 +126,18 @@ MACRO(ANDROID_3RD_PARTY)
     ################################################
     #ZLIB
     ################################################
-    #FIND_PATH(ZLIB_INCLUDE_DIR Android.mk
-    #    ${CMAKE_SOURCE_DIR}/3rdparty/zlib
-    #)
+    FIND_PATH(ZLIB_INCLUDE_DIR Android.mk
+       ${CMAKE_SOURCE_DIR}/3rdparty/zlib NO_CMAKE_FIND_ROOT_PATH
+    )
     #set(ENV{AND_OSG_LIB_NAMES} "$ENV{AND_OSG_LIB_NAMES} zlib")
     #set(ENV{AND_OSG_LIB_PATHS} "$ENV{AND_OSG_LIB_PATHS}include ${ZLIB_INCLUDE_DIR}/Android.mk \n")
-    #if(ZLIB_INCLUDE_DIR)
-    #    message(STATUS "ZLIB found ${ZLIB_INCLUDE_DIR}" )
-    #    set(ZLIB_FOUND "Yes")
-    #    install(DIRECTORY 3rdparty/build/libjpeg/ DESTINATION ./ )
-    #else(ZLIB_INCLUDE_DIR)
-    #    message(STATUS "ZLIB missing" )
-    #endif()
+    if(ZLIB_INCLUDE_DIR)
+       message(STATUS "ZLIB found ${ZLIB_INCLUDE_DIR}" )
+       set(ZLIB_FOUND "Yes")
+       install(DIRECTORY 3rdparty/build/zlib/ DESTINATION ./ )
+    else(ZLIB_INCLUDE_DIR)
+       message(STATUS "ZLIB missing" )
+    endif()
     ################################################
     #CURL
     ################################################


### PR DESCRIPTION
Otherwise png plugin for Android is not compiled because it [requires](https://github.com/openscenegraph/OpenSceneGraph/blob/8437550c2566a6b00a6963eb725377c36bb3f07c/src/osgPlugins/CMakeLists.txt#L114) zlib.