### PR TITLE
Fix issue with VertexArrayState current VBO/EBO pointers being set after it is no longer current

### DIFF
--- a/include/osg/Drawable
+++ b/include/osg/Drawable
@@ -571,6 +571,7 @@ inline void Drawable::draw(RenderInfo& renderInfo) const
         drawInner(renderInfo);
 
         vas->setRequiresSetArrays(getDataVariance()==osg::Object::DYNAMIC);
+        vas->resetBufferObjectPointers();
 
         return;
     }

--- a/src/osg/Drawable.cpp
+++ b/src/osg/Drawable.cpp
@@ -683,6 +683,7 @@ void Drawable::draw(RenderInfo& renderInfo) const
         drawInner(renderInfo);
 
         vas->setRequiresSetArrays(getDataVariance()==osg::Object::DYNAMIC);
+        vas->resetBufferObjectPointers();
 
         return;
     }


### PR DESCRIPTION
My understanding is that `osg::VertexArrayState` keeps `_currentVBO`/`_currentEBO` to avoid re-binding buffers unnecessarily.
However when `osg::Drawable` finishes drawing, it keeps those pointers set.
So the following can happen:
1. During `draw()` Drawable A binds VBO1 and sets its `_currentVBO` to point to VBO1.
1. During `draw()` Drawable B binds VBO2 and sets its `_currentVBO` to point to VBO2.
1. Next time Drawable A decides to bind VBO1 it will see that `_currentVBO` to points to VBO1, so it will do nothing.
1. Drawable A will now dispatch an attribute stored in VBO1, but since it didn't bind VBO1, its VAO will be now bound with VBO2.

I have noticed this issue with multiple `osg::Geometry` objects that share some attributes and use a shared VBO for those, and have some individual attributes in their individual VBOs.

This PR will reset `_currentVBO`/`_currentEBO` pointers when drawing is complete.