### PR TITLE
Make sure GUIActionAdapter has a single vtable

### DIFF
--- a/include/osgGA/GUIActionAdapter
+++ b/include/osgGA/GUIActionAdapter
@@ -58,10 +58,10 @@ then you then respond the flag being set in your own leisure.
 
 class GUIEventAdapter;
 
-class GUIActionAdapter
+class OSGGA_EXPORT GUIActionAdapter
 {
 public:
-        virtual ~GUIActionAdapter() {}
+        virtual ~GUIActionAdapter();
 
         /** Provide a mechanism for getting the osg::View associated with this GUIActionAdapter.
           * One would use this to case view to osgViewer::View(er) if supported by the subclass.*/
@@ -101,4 +101,3 @@ public:
 }
 
 #endif
-

--- a/src/osgGA/CMakeLists.txt
+++ b/src/osgGA/CMakeLists.txt
@@ -47,6 +47,7 @@ SET(TARGET_SRC
     EventVisitor.cpp
     FirstPersonManipulator.cpp
     FlightManipulator.cpp
+    GUIActionAdapter.cpp
     GUIEventAdapter.cpp
     GUIEventHandler.cpp
     KeySwitchMatrixManipulator.cpp
@@ -76,4 +77,3 @@ SET(TARGET_LIBRARIES
 SET(COMPONENT_PKGCONFIG_DESCRIPTION "GUI event library for Openscenegraph")
 
 SETUP_LIBRARY(${LIB_NAME})
-

--- a/src/osgGA/GUIActionAdapter.cpp
+++ b/src/osgGA/GUIActionAdapter.cpp
@@ -1,0 +1,18 @@
+/* -*-c++-*- OpenSceneGraph - Copyright (C) 1998-2006 Robert Osfield
+ *
+ * This library is open source and may be redistributed and/or modified under
+ * the terms of the OpenSceneGraph Public License (OSGPL) version 0.0 or
+ * (at your option) any later version.  The full license is in LICENSE file
+ * included with this distribution, and on the openscenegraph.org website.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * OpenSceneGraph Public License for more details.
+*/
+
+#include <osgGA/GUIActionAdapter>
+
+using namespace osgGA;
+
+GUIActionAdapter::~GUIActionAdapter() = default;


### PR DESCRIPTION
With clang 10, a simple `dynamic_cast<osgViewer::Viewer*>(&aa)` with aa of
type `osgGA::GUIActionAdapter` but actually referencing a `osgViewer::Viewer`
was returning `nullptr`.

This is due to the fact that the compiler didn't know where to put the vtable
implementation. By the way, clang has a nice warning for that:
Class has no out-of-line virtual method definitions; its vtable will be
emitted in every translation unit [-Wweak-vtables]

Since the Viewer was instanciated in the code of the lib, I guess it used a
different vtable than the dynamic_cast in my binary, making dynamic_cast think
it was a different class and thus returning a nullptr.

I've made the GUIActionAdapter class visible, since it's used as base class
of other visible classes.