### PR TITLE
Fix _shaderHint bug in DisplaySettings::setDisplaySettings

### DIFF
--- a/src/osg/DisplaySettings.cpp
+++ b/src/osg/DisplaySettings.cpp
@@ -120,7 +120,7 @@ void DisplaySettings::setDisplaySettings(const DisplaySettings& vs)
 
     _vertexBufferHint = vs._vertexBufferHint;
 
-    setShaderHint(_shaderHint);
+    setShaderHint(vs._shaderHint);
 
     _keystoneHint = vs._keystoneHint;
     _keystoneFileNames = vs._keystoneFileNames;


### PR DESCRIPTION
DisplaySettings::setDisplaySettings sets _shaderHint from itself (potentially uninitialized)