### PR TITLE
Generalize EGL support on windows

### DIFF
--- a/include/osgViewer/api/Win32/Win32GWUtils
+++ b/include/osgViewer/api/Win32/Win32GWUtils
@@ -19,7 +19,9 @@
 //#define _WIN32_WINNT    0x0501 // Windows Server 2003, Windows XP
 #define _WIN32_WINNT    0x0500 // Windows NT
 #endif
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 
 #include <osg/GraphicsContext>

--- a/src/osgViewer/GraphicsWindowWin32.cpp
+++ b/src/osgViewer/GraphicsWindowWin32.cpp
@@ -1474,30 +1474,24 @@ const ContextInfo GraphicsWindowWin32::createContextImplementation()
 {
 	ContextInfo context;
 
-	if(OSG_GLES3_FEATURES) {
-		OSG_NOTIFY(osg::INFO) << "GLES3: Attempting to create GLES3 context." << std::endl;
-		OSG_NOTIFY(osg::INFO) << "GLES3: version: " << _traits->glContextVersion << std::endl;
-		OSG_NOTIFY(osg::INFO) << "GLES3: context flags: " << _traits->glContextFlags << std::endl;
-		OpenGLContext openGLContext;
-		if(!Win32WindowingSystem::getInterface()->getSampleOpenGLContext(openGLContext, _hdc, _screenOriginX, _screenOriginY))
-		{
-			reportErrorForScreen("GLES3: Can't create context.",
-				_traits->screenNum, ::GetLastError());
-		}
-		else
-		{
-			context.eglDisplay = openGLContext.contextInfo().eglDisplay;
-			context.eglContext = createContext(openGLContext.contextInfo().eglDisplay, openGLContext.getConfig());
-
-			EGLint surfaceAttributes[] = { EGL_NONE, EGL_NONE };
-			context.eglSurface = eglCreateWindowSurface(openGLContext.contextInfo().eglDisplay, openGLContext.getConfig(), _hwnd, surfaceAttributes);
-
-			OSG_NOTIFY(osg::INFO) << "GLES3: context created successfully." << std::endl;
-		}
-	}
-	else {
-		reportErrorForScreen("Can't create context.",
+	OSG_NOTIFY(osg::INFO) << "GLES: Attempting to create GLES context." << std::endl;
+	OSG_NOTIFY(osg::INFO) << "GLES: version: " << _traits->glContextVersion << std::endl;
+	OSG_NOTIFY(osg::INFO) << "GLES: context flags: " << _traits->glContextFlags << std::endl;
+	OpenGLContext openGLContext;
+	if(!Win32WindowingSystem::getInterface()->getSampleOpenGLContext(openGLContext, _hdc, _screenOriginX, _screenOriginY))
+	{
+		reportErrorForScreen("GLES: Can't create context.",
 			_traits->screenNum, ::GetLastError());
+	}
+	else
+	{
+		context.eglDisplay = openGLContext.contextInfo().eglDisplay;
+		context.eglContext = createContext(openGLContext.contextInfo().eglDisplay, openGLContext.getConfig());
+
+		EGLint surfaceAttributes[] = { EGL_NONE, EGL_NONE };
+		context.eglSurface = eglCreateWindowSurface(openGLContext.contextInfo().eglDisplay, openGLContext.getConfig(), _hwnd, surfaceAttributes);
+
+		OSG_NOTIFY(osg::INFO) << "GLES: context created successfully." << std::endl;
 	}
 	return context;
 }
@@ -1843,7 +1837,7 @@ HGLRC GraphicsWindowWin32::createContextImplementation()
 
     return( context );
 }
-#endif !OSG_USE_EGL 
+#endif
 
 bool GraphicsWindowWin32::setWindowDecorationImplementation( bool decorated )
 {

--- a/src/osgViewer/Win32GWUtils.cpp
+++ b/src/osgViewer/Win32GWUtils.cpp
@@ -16,8 +16,8 @@ namespace EGL {
 	EGLint eglOpenglBit = EGL_OPENGL_ES3_BIT, eglContextClientVersion = 3;
 	EGLenum eglApi = EGL_OPENGL_ES_API;
 #endif
-#if defined(OSG_GLES2_AVAILABLE)
-	EGLint eglOpenglBit = 0, eglContextClientVersion = 2;
+#if defined(OSG_GLES2_AVAILABLE) && !defined(OSG_GLES3_AVAILABLE)
+	EGLint eglOpenglBit = EGL_OPENGL_ES2_BIT, eglContextClientVersion = 2;
 	EGLenum eglApi = EGL_OPENGL_ES_API;
 #endif
 

--- a/src/osgViewer/Win32GWUtils.cpp
+++ b/src/osgViewer/Win32GWUtils.cpp
@@ -136,6 +136,8 @@ bool ContextInfo::isEmpty() {
 
 EGLDisplay createAndInitializeEGLDisplay(HDC hdc = 0L)
 {
+	EGLDisplay eglDisplay;
+	#ifdef EGL_ANGLE_platform_angle
 	/* possible types:
 	EGL_PLATFORM_ANGLE_TYPE_DEFAULT_ANGLE
 	EGL_PLATFORM_ANGLE_TYPE_D3D9_ANGLE
@@ -158,9 +160,6 @@ EGLDisplay createAndInitializeEGLDisplay(HDC hdc = 0L)
 	displayAttributes.push_back(EGL_PLATFORM_ANGLE_DEVICE_TYPE_HARDWARE_ANGLE);
 	displayAttributes.push_back(EGL_NONE);
 
-	EGLint major, minor;
-	EGLDisplay eglDisplay;
-	
 	if (hdc) {
 		eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
 			reinterpret_cast<void *>(hdc),
@@ -169,7 +168,16 @@ EGLDisplay createAndInitializeEGLDisplay(HDC hdc = 0L)
 	else {
 		eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, reinterpret_cast<void *>(EGL_DEFAULT_DISPLAY), displayAttributes.data());
 	}
+	#else
+	if (hdc) {
+		eglDisplay = eglGetDisplay(hdc);
+	}
+	else {
+		eglDisplay = eglGetDisplay((EGLNativeDisplayType)EGL_DEFAULT_DISPLAY);
+	}
+	#endif
 
+	EGLint major, minor;
 	eglInitialize(eglDisplay, &major, &minor);
 
 	OSG_NOTIFY(osg::INFO) << "EGL Version: \"" << eglQueryString(eglDisplay, EGL_VERSION) << "\"" << std::endl;
@@ -235,13 +243,13 @@ EGLContext createContext(EGLDisplay eglDisplay, const EGLConfig& config)
 
 void destroyContext(ContextInfo& c)
 {
-	if (!::eglMakeCurrent(c.eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)) {
+	if (c.eglDisplay != EGL_NO_DISPLAY && !::eglMakeCurrent(c.eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)) {
 		reportError("Win32GWUtils.destroyContext() - Unable to set current EGL rendering context", ::eglGetError());
 	}
-	if (!::eglDestroySurface(c.eglDisplay, c.eglSurface)) {
+	if (c.eglSurface != EGL_NO_SURFACE && !::eglDestroySurface(c.eglDisplay, c.eglSurface)) {
 		reportError("Win32GWUtils.destroyContext() - Unable to destroy current EGL Surface context", ::eglGetError());
 	}
-	if (!::eglDestroyContext(c.eglDisplay, c.eglContext)) {
+	if (c.eglContext != EGL_NO_CONTEXT && !::eglDestroyContext(c.eglDisplay, c.eglContext)) {
 		reportError("Win32GWUtils.destroyContext() - Unable to destroy current EGL rendering context", ::eglGetError());
 	}
 	c.clear();


### PR DESCRIPTION
Currently the EGL support on Windows expects the EGL/Angle platform, however there are other EGL implementations available like Imagination Technologies' PVRVFrame. This change adds a compile-time check for EGL/Angle, if unavailable a more generic way for getting the EGL display handle is chosen.

This PR also contains a fix for the GraphicsWindowWin32 OpenGL context creation when using EGL which only worked if GLES3 was available.