### PR TITLE
Add one more path to find collada-dom

### DIFF
--- a/CMakeModules/FindCOLLADA.cmake
+++ b/CMakeModules/FindCOLLADA.cmake
@@ -65,6 +65,7 @@ FIND_PATH(COLLADA_INCLUDE_DIR dae.h
     ${COLLADA_DOM_ROOT}/include
     $ENV{COLLADA_DIR}/include
     $ENV{COLLADA_DIR}
+    $ENV{COLLADA_DIR}/include/collada-dom2.5
     ~/Library/Frameworks
     /Library/Frameworks
     /opt/local/Library/Frameworks #macports


### PR DESCRIPTION
This is a default path when collada-dom is built as following:
```
cmake -D CMAKE_INSTALL_PREFIX=install .
cmake --build .
cmake --install .
```