### PR TITLE
Rare segfault in Text::drawImplementationSinglePass fixed: _textureGl…

### DIFF
--- a/include/osgText/Text
+++ b/include/osgText/Text
@@ -212,7 +212,7 @@ public:
     BackdropImplementation getBackdropImplementation() const { return DELAYED_DEPTH_WRITES; }
 
     // internal structures, variable and methods used for rendering of characters.
-    struct OSGTEXT_EXPORT GlyphQuads
+    struct OSGTEXT_EXPORT GlyphQuads : public osg::Referenced
     {
         typedef std::vector<Glyph*> Glyphs;
 
@@ -222,8 +222,6 @@ public:
         GlyphQuads();
         GlyphQuads(const GlyphQuads& gq);
 
-        void setupPrimitives(Text::BackdropType backdropType);
-
         Glyphs& getGlyphs() { return _glyphs; }
         const Glyphs& getGlyphs() const { return _glyphs; }
 
@@ -231,7 +229,7 @@ public:
         void resizeGLObjectBuffers(unsigned int maxSize);
 
         /** If State is non-zero, this function releases OpenGL objects for
-        * the specified graphics context. Otherwise, releases OpenGL objexts
+        * the specified graphics context. Otherwise, releases OpenGL objects
         * for all graphics contexts. */
         void releaseGLObjects(osg::State* state=0) const;
 
@@ -240,7 +238,7 @@ public:
         GlyphQuads& operator = (const GlyphQuads&) { return *this; }
     };
 
-    typedef std::map<osg::ref_ptr<GlyphTexture>,GlyphQuads> TextureGlyphQuadMap;
+    typedef std::map< osg::ref_ptr<GlyphTexture>, osg::ref_ptr<GlyphQuads> > TextureGlyphQuadMap;
 
     /** Direct Access to GlyphQuads */
     const GlyphQuads* getGlyphQuads(GlyphTexture* texture) const
@@ -248,7 +246,7 @@ public:
         TextureGlyphQuadMap::const_iterator itGlyphQuad = _textureGlyphQuadMap.find(texture);
         if (itGlyphQuad == _textureGlyphQuadMap.end()) return NULL;
 
-        return &itGlyphQuad->second;
+        return itGlyphQuad->second.get();
     }
 
     const TextureGlyphQuadMap& getTextureGlyphQuadMap() const

--- a/src/osgWidget/Input.cpp
+++ b/src/osgWidget/Input.cpp
@@ -120,7 +120,7 @@ void Input::_calculateCursorOffsets() {
     std::vector<osgText::Glyph*>    glyphs;
     for ( ; tgqmi != tgqm.end(); tgqmi++ )
     {
-        const osgText::Text::GlyphQuads& gq = tgqmi->second;
+        const osgText::Text::GlyphQuads& gq = *(tgqmi->second);
 
         //coords.insert(coords.end(),gq.getTransformedCoords(0).begin(),gq.getTransformedCoords(0).end());
         for (unsigned int i=0; i<gq.getGlyphs().size(); ++i)


### PR DESCRIPTION
…yphQuadMap[glyphTexture] can exist but it's _primitive can be invalid.

GlyphQuads's interface need to be changed (osg::Referenced now, setupPrimitives() method without definition deleted); TextureGlyphQuadMap changed.
Intersection with Text improved (no dynamic_casts, less code)