### PR TITLE
Fix typos in src/ sub-directory

### DIFF
--- a/src/OpenThreads/win32/Win32Mutex.cpp
+++ b/src/OpenThreads/win32/Win32Mutex.cpp
@@ -15,7 +15,7 @@
 //
 // Win32Mutex.c++ - C++ Mutex class .
 // The idea for it is borrowed from SGI STL
-// It looks like it's hard to use win32 CRITICALL_SECTIONS withour introducing race 
+// It looks like it's hard to use win32 CRITICALL_SECTIONS without introducing race 
 // conditions on InitializeCriticalSection() . So we use spin mutex here.
 // ~~~~~~~~~~~~~~~~
 //

--- a/src/OpenThreads/win32/Win32Thread.cpp
+++ b/src/OpenThreads/win32/Win32Thread.cpp
@@ -424,7 +424,7 @@ int Thread::cancel()
         SetEvent(pd->cancelEvent.get());
 
         // cancelMode == 1 (asynch)-> kill em
-        // cancelMode == 0 (deffered) -> wait a little then kill em
+        // cancelMode == 0 (deferred) -> wait a little then kill em
 
     //    if( (pd->cancelMode == 1) || (WaitForSingleObject(pd->tid,INFINITE)!=WAIT_OBJECT_0) )
         if( pd->cancelMode == 1 )

--- a/src/OpenThreads/win32/Win32ThreadPrivateData.h
+++ b/src/OpenThreads/win32/Win32ThreadPrivateData.h
@@ -44,7 +44,7 @@ private:
 
     Block threadStartedBlock;
 
-    int  cancelMode; // 0 - deffered (default) 1-asynch 2-disabled
+    int  cancelMode; // 0 - deferred (default) 1-asynch 2-disabled
 
     bool detached;
 

--- a/src/osg/BufferObject.cpp
+++ b/src/osg/BufferObject.cpp
@@ -186,7 +186,7 @@ void GLBufferObject::compileBuffer()
 
     if (i<_bufferEntries.size())
     {
-        // triming end of bufferEntries as the source data is has less entries than the originally held.
+        // trimming end of bufferEntries as the source data is has less entries than the originally held.
         _bufferEntries.erase(_bufferEntries.begin()+i, _bufferEntries.end());
     }
 
@@ -864,7 +864,7 @@ void GLBufferObjectSet::orphan(GLBufferObject* to)
     // handled in the handlePendingOrphandedGLBufferObjects() where the TO's
     // will be removed from the active list, and then placed in the orhpanGLBufferObject
     // list.  This double buffered approach to handling orphaned TO's is used
-    // to avoid having to mutex the process of appling active TO's.
+    // to avoid having to mutex the process of applying active TO's.
     _pendingOrphanedGLBufferObjects.push_back(to);
 }
 

--- a/src/osg/CullingSet.cpp
+++ b/src/osg/CullingSet.cpp
@@ -36,7 +36,7 @@ void CullingSet::disableAndPushOccludersCurrentMask(NodePath& nodePath)
         {
             //std::cout<<"  ++ disabling occluder "<<itr<<std::endl;
             // we have trapped for the case an occlude potentially occluding itself,
-            // to prevent this we disable the results mask so that no subsequnt
+            // to prevent this we disable the results mask so that no subsequent
             // when the next pushCurrentMask calls happens this occluder is switched off.
             itr->disableResultMasks();
             itr->pushCurrentMask();

--- a/src/osg/DisplaySettings.cpp
+++ b/src/osg/DisplaySettings.cpp
@@ -324,7 +324,7 @@ static ApplicationUsageProxy DisplaySetting_e9(ApplicationUsage::ENVIRONMENTAL_V
         "LEFT_EYE_TOP_VIEWPORT | LEFT_EYE_BOTTOM_VIEWPORT");
 static ApplicationUsageProxy DisplaySetting_e10(ApplicationUsage::ENVIRONMENTAL_VARIABLE,
         "OSG_SPLIT_STEREO_AUTO_ADJUST_ASPECT_RATIO <mode>",
-        "OFF | ON  Default to OFF to compenstate for the compression of the aspect ratio when viewing in split screen stereo.  Note, if you are setting fovx and fovy explicityly OFF should be used.");
+        "OFF | ON  Default to OFF to compenstate for the compression of the aspect ratio when viewing in split screen stereo.  Note, if you are setting fovx and fovy explicitly OFF should be used.");
 static ApplicationUsageProxy DisplaySetting_e11(ApplicationUsage::ENVIRONMENTAL_VARIABLE,
         "OSG_SPLIT_STEREO_VERTICAL_SEPARATION <float>",
         "Number of pixels between viewports.");

--- a/src/osg/Geometry.cpp
+++ b/src/osg/Geometry.cpp
@@ -1686,7 +1686,7 @@ void Geometry::fixDeprecatedData()
             default:            primLength=0; break; // compute later when =0.
         }
 
-        // copy the vertex data across to the new arays
+        // copy the vertex data across to the new arrays
         switch(primitiveset->getType())
         {
             case(PrimitiveSet::DrawArraysPrimitiveType):

--- a/src/osg/Program.cpp
+++ b/src/osg/Program.cpp
@@ -769,7 +769,7 @@ void Program::PerContextProgram::linkProgram(osg::State& state)
         }
 
         // set any explicit vertex attribute bindings that are set up via osg::State, such as the vertex arrays
-        //  that have been aliase to vertex attrib arrays
+        //  that have been aliased to vertex attrib arrays
         if (state.getUseVertexAttributeAliasing())
         {
             const AttribBindingList& stateBindlist = state.getAttributeBindingList();

--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -982,7 +982,7 @@ void TextureObjectSet::orphan(Texture::TextureObject* to)
     // handled in the handlePendingOrphandedTextureObjects() where the TO's
     // will be removed from the active list, and then placed in the orhpanTextureObject
     // list.  This double buffered approach to handling orphaned TO's is used
-    // to avoid having to mutex the process of appling active TO's.
+    // to avoid having to mutex the process of applying active TO's.
     _pendingOrphanedTextureObjects.push_back(to);
 
 #if 0

--- a/src/osg/Texture1D.cpp
+++ b/src/osg/Texture1D.cpp
@@ -477,7 +477,7 @@ void Texture1D::copyTexSubImage1D(State& state, int xoffset, int x, int y, int w
     }
     else
     {
-        // no texture object already exsits for this context so need to
+        // no texture object already exists for this context so need to
         // create it upfront - simply call copyTexImage1D.
         copyTexImage1D(state,x,y,width);
     }

--- a/src/osg/Texture2D.cpp
+++ b/src/osg/Texture2D.cpp
@@ -470,7 +470,7 @@ void Texture2D::copyTexSubImage2D(State& state, int xoffset, int yoffset, int x,
     }
     else
     {
-        // no texture object already exsits for this context so need to
+        // no texture object already exists for this context so need to
         // create it upfront - simply call copyTexImage2D.
         copyTexImage2D(state,x,y,width,height);
     }

--- a/src/osg/TextureCubeMap.cpp
+++ b/src/osg/TextureCubeMap.cpp
@@ -411,7 +411,7 @@ void TextureCubeMap::copyTexSubImageCubeMap(State& state, int face, int xoffset,
         if (!textureObject)
         {
             // failed to create texture object
-            OSG_NOTICE<<"Warning : failed to create TextureCubeMap texture obeject, copyTexSubImageCubeMap abandoned."<<std::endl;
+            OSG_NOTICE<<"Warning : failed to create TextureCubeMap texture object, copyTexSubImageCubeMap abandoned."<<std::endl;
             return;
         }
 

--- a/src/osg/TextureRectangle.cpp
+++ b/src/osg/TextureRectangle.cpp
@@ -559,7 +559,7 @@ void TextureRectangle::copyTexSubImage2D(State& state, int xoffset, int yoffset,
     }
     else
     {
-        // no texture object already exsits for this context so need to
+        // no texture object already exists for this context so need to
         // create it upfront - simply call copyTexImage2D.
         copyTexImage2D(state,x,y,width,height);
     }

--- a/src/osg/glu/libtess/README
+++ b/src/osg/glu/libtess/README
@@ -208,7 +208,7 @@ The interface
 	  GLU_TESS_WINDING_NEGATIVE
 	  GLU_TESS_WINDING_ABS_GEQ_TWO
 
-      The input contours parition the plane into regions.  A winding
+      The input contours partition the plane into regions.  A winding
       rule determines which of these regions are inside the polygon.
       
       For a single contour C, the winding number of a point x is simply

--- a/src/osg/glu/libtess/sweep.cpp
+++ b/src/osg/glu/libtess/sweep.cpp
@@ -438,7 +438,7 @@ static void CallCombine( GLUtesselator *tess, GLUvertex *isect,
 static void SpliceMergeVertices( GLUtesselator *tess, GLUhalfEdge *e1,
 				 GLUhalfEdge *e2 )
 /*
- * Two vertices with idential coordinates are combined into one.
+ * Two vertices with identical coordinates are combined into one.
  * e1->Org is kept, while e2->Org is discarded.
  */
 {
@@ -941,7 +941,7 @@ static void ConnectRightVertex( GLUtesselator *tess, ActiveRegion *regUp,
 static void ConnectLeftDegenerate( GLUtesselator *tess,
 				   ActiveRegion *regUp, GLUvertex *vEvent )
 /*
- * The event vertex lies exacty on an already-processed edge or vertex.
+ * The event vertex lies exactly on an already-processed edge or vertex.
  * Adding the new vertex involves splicing it into the already-processed
  * part of the mesh.
  */

--- a/src/osgManipulator/Dragger.cpp
+++ b/src/osgManipulator/Dragger.cpp
@@ -235,7 +235,7 @@ void Dragger::setHandleEvents(bool flag)
 
 void Dragger::addConstraint(Constraint* constraint)
 {
-    // check to make sure constaint hasn't already been attached.
+    // check to make sure constraint hasn't already been attached.
     for(Constraints::iterator itr = _constraints.begin();
         itr != _constraints.end();
         ++itr)

--- a/src/osgParticle/ParticleSystem.cpp
+++ b/src/osgParticle/ParticleSystem.cpp
@@ -140,7 +140,7 @@ void osgParticle::ParticleSystem::update(double dt, osg::NodeVisitor& nv)
         // Update shader uniforms
         // This slightly reduces the consumption of traversing the particle vector, because we
         // don't compute tile and angle attributes that are useleff for shaders.
-        // At present, our lcoal shader implementation will ignore these particle props:
+        // At present, our local shader implementation will ignore these particle props:
         //     _cur_tile, _s_coord, _t_coord, _prev_pos, _prev_angle and _angle
         osg::StateSet* stateset = getOrCreateStateSet();
 

--- a/src/osgPlugins/3ds/WriterNodeVisitor.cpp
+++ b/src/osgPlugins/3ds/WriterNodeVisitor.cpp
@@ -907,7 +907,7 @@ WriterNodeVisitor::buildFaces(osg::Geode        & geo,
                               bool                texcoords)
 {
     unsigned int nbTrianglesRemaining = listTriangles.size();
-    unsigned int nbVerticesRemaining  = calcVertices(geo);        // May set _succeded to false
+    unsigned int nbVerticesRemaining  = calcVertices(geo);        // May set _succeeded to false
     if (!succeeded()) return;
 
     std::string name( getUniqueName(geo.getName().empty() ? geo.className() : geo.getName(), true, "geo") );
@@ -942,7 +942,7 @@ WriterNodeVisitor::buildFaces(osg::Geode        & geo,
             // Finnish mesh
             lib3ds_mesh_resize_faces   (mesh, numFace);
             //lib3ds_mesh_resize_vertices() will be called in buildMesh()
-            buildMesh(geo, mat, index_vert, texcoords, mesh);        // May set _succeded to false
+            buildMesh(geo, mat, index_vert, texcoords, mesh);        // May set _succeeded to false
             if (!succeeded())
             {
                 lib3ds_mesh_free(mesh);
@@ -973,7 +973,7 @@ WriterNodeVisitor::buildFaces(osg::Geode        & geo,
         face.material = it->first.material;
     }
 
-    buildMesh(geo, mat, index_vert, texcoords, mesh);        // May set _succeded to false
+    buildMesh(geo, mat, index_vert, texcoords, mesh);        // May set _succeeded to false
     if (!succeeded())
     {
         lib3ds_mesh_free(mesh);
@@ -1027,7 +1027,7 @@ void WriterNodeVisitor::apply( osg::Geode &node )
         if ( g != NULL )
         {
             pushStateSet(g->getStateSet());
-            createListTriangle(g, listTriangles, texcoords, i);        // May set _succeded to false
+            createListTriangle(g, listTriangles, texcoords, i);        // May set _succeeded to false
             popStateSet(g->getStateSet());
             if (!succeeded()) break;
         }
@@ -1036,9 +1036,9 @@ void WriterNodeVisitor::apply( osg::Geode &node )
     {
 #if DISABLE_3DS_ANIMATION
         osg::Matrix mat( osg::computeLocalToWorld(getNodePath()) );
-        buildFaces(node, mat, listTriangles, texcoords);        // May set _succeded to false
+        buildFaces(node, mat, listTriangles, texcoords);        // May set _succeeded to false
 #else
-        buildFaces(node, osg::Matrix(), listTriangles, texcoords);        // May set _succeded to false
+        buildFaces(node, osg::Matrix(), listTriangles, texcoords);        // May set _succeeded to false
 #endif
     }
     popStateSet(node.getStateSet());
@@ -1071,17 +1071,17 @@ void WriterNodeVisitor::apply( osg::Billboard &node )
 
             pushStateSet(g->getStateSet());
             createListTriangle(g, listTriangles, texcoords, i);
-            popStateSet(g->getStateSet());        // May set _succeded to false
+            popStateSet(g->getStateSet());        // May set _succeeded to false
             if (!succeeded()) break;
 
             osg::Matrix pointLocalMat(osg::Matrix::translate(node.getPosition(i)));        // TODO handle rotation
 #if DISABLE_3DS_ANIMATION
             osg::Matrix currentBillboardWorldMat(pointLocalMat * m);
             apply3DSMatrixNode(node, &pointLocalMat, "bil");                            // Add a 3DS matrix node (with local matrix)
-            buildFaces(node, currentBillboardWorldMat, listTriangles, texcoords);        // May set _succeded to false
+            buildFaces(node, currentBillboardWorldMat, listTriangles, texcoords);        // May set _succeeded to false
 #else
             apply3DSMatrixNode(node, &pointLocalMat, "bil");                            // Add a 3DS matrix node (with local matrix)
-            buildFaces(node, osg::Matrix(), listTriangles, texcoords);                    // May set _succeded to false
+            buildFaces(node, osg::Matrix(), listTriangles, texcoords);                    // May set _succeeded to false
 #endif
             if (!succeeded()) break;
         }

--- a/src/osgPlugins/CMakeLists.txt
+++ b/src/osgPlugins/CMakeLists.txt
@@ -54,7 +54,7 @@ endmacro()
 
 ############################################################
 #
-#  NodeKit/Psudo loader plugins
+#  NodeKit/Pseudo loader plugins
 #
 ADD_PLUGIN_DIRECTORY(osga)
 ADD_PLUGIN_DIRECTORY(rot)

--- a/src/osgPlugins/Inventor/ConvertFromInventor.cpp
+++ b/src/osgPlugins/Inventor/ConvertFromInventor.cpp
@@ -1760,7 +1760,7 @@ ConvertFromInventor::getStateSet(SoCallbackAction* action)
         case SoDrawStyle::FILLED:
         {
 #if 0
-// OSG defaults to filled draw style, so no need to set redundent state.
+// OSG defaults to filled draw style, so no need to set redundant state.
             osg::PolygonMode *polygonMode = new osg::PolygonMode;
             polygonMode->setMode(osg::PolygonMode::FRONT_AND_BACK,
                                  osg::PolygonMode::FILL);

--- a/src/osgPlugins/Inventor/ConvertToInventor.cpp
+++ b/src/osgPlugins/Inventor/ConvertToInventor.cpp
@@ -832,7 +832,7 @@ ConvertToInventor::InventorState* ConvertToInventor::createInventorState(const o
 
           if (ccw)
             // Warn if culling the lit faces while rendering unlit faces.
-            // Inventor does not support this setup and it lits the unculled faces only.
+            // Inventor does not support this setup and it lights the unculled faces only.
             OSG_WARN << "IvWriter: Culling was set in a way that one-sided lighting will lit the culled sides of faces. "
                                       "Using lighting on correct faces." << std::endl;
 

--- a/src/osgPlugins/Inventor/ReaderWriterIV.cpp
+++ b/src/osgPlugins/Inventor/ReaderWriterIV.cpp
@@ -117,7 +117,7 @@ ReaderWriterIV::readNodeFromSoInput(SoInput &input,
     // Create the inventor scenegraph by reading from SoInput
     SoSeparator* rootIVNode = SoDB::readAll(&input);
 
-    // Remove recently appened search paths
+    // Remove recently appended search paths
     if (options)
         removeSearchPaths(searchPaths);
 

--- a/src/osgPlugins/OpenCASCADE/ReaderWriterOpenCASCADE.cpp
+++ b/src/osgPlugins/OpenCASCADE/ReaderWriterOpenCASCADE.cpp
@@ -373,7 +373,7 @@ osg::ref_ptr<osg::Geode> ReaderWritterOpenCASCADE::OCCTKReader::igesToOSGGeode(c
 void ReaderWritterOpenCASCADE::OCCTKReader::_traverse(const TDF_Label &shapeTree, gp_Trsf& transformation)
 {
     TDF_Label referredShape;
-    /// find if current shape referes some shape. if it does then traverse that
+    /// find if current shape referred some shape. if it does then traverse that
     /// else it is a simple shape and do visualize that simple shape
     if(_assembly->GetReferredShape(shapeTree, referredShape))
     {

--- a/src/osgPlugins/QTKit/ReaderWriterQTKit.mm
+++ b/src/osgPlugins/QTKit/ReaderWriterQTKit.mm
@@ -700,7 +700,7 @@ class ReaderWriterQTKit : public osgDB::ReaderWriter
             if (ext=="QTKit")
             {
                 fileName = osgDB::findDataFile( osgDB::getNameLessExtension(file), options);
-                OSG_INFO<<"QTKit stipped filename = "<<fileName<<std::endl;
+                OSG_INFO<<"QTKit stripped filename = "<<fileName<<std::endl;
             }
             else
             {

--- a/src/osgPlugins/cfg/Camera.cpp
+++ b/src/osgPlugins/cfg/Camera.cpp
@@ -649,13 +649,13 @@ void Camera::run( void )
 
         if (_done) break;
 
-        // printf("   Camera::run before sycn block\n");
+        // printf("   Camera::run before sync block\n");
 
         _syncBarrier->block();
 
         if (_done) break;
 
-        // printf("   Camera::run after sycn block\n");
+        // printf("   Camera::run after sync block\n");
 
         advance();
     }

--- a/src/osgPlugins/cfg/Camera.h
+++ b/src/osgPlugins/cfg/Camera.h
@@ -34,7 +34,7 @@ class RenderSurface;
 
     The Camera contains a Lens class and has a RenderSurface.  Methods
     are provided to give the programmer control over the OpenGL PROJECTION
-    matrix throught the Lens and over the initial MODELVIEW matrix through
+    matrix through the Lens and over the initial MODELVIEW matrix through
     the camera's position and attitude.
 
     The programmer must provide a class derived from Camera::SceneHandler

--- a/src/osgPlugins/directshow/DirectShowTexture.cpp
+++ b/src/osgPlugins/directshow/DirectShowTexture.cpp
@@ -910,7 +910,7 @@ struct ListDeviceAvailable
                 }
             }
 
-            // covert to std::string
+            // convert to std::string
             _bstr_t bstr_t(varName.bstrVal);
             std::string deviceName(bstr_t);
             std::string deviceGUID;

--- a/src/osgPlugins/dxf/DXFWriterNodeVisitor.h
+++ b/src/osgPlugins/dxf/DXFWriterNodeVisitor.h
@@ -129,7 +129,7 @@ protected:
         // aci index format is
         // last digit odd = 50% sat, even=100%
         // last digit 0,1 = 100% value, 2,3=80%, 4,5=60% 6,7=50%, 8,9=30%
-        //  first two sigits are hue angle /1.5 but count starts at 10, first 9 values are dummy named colours
+        //  first two digits are hue angle /1.5 but count starts at 10, first 9 values are dummy named colours
         int aci=10 + (int)(h/1.5);
         aci -= (aci%10); // ensure last digit is zero
 

--- a/src/osgPlugins/fbx/WriterNodeVisitor.cpp
+++ b/src/osgPlugins/fbx/WriterNodeVisitor.cpp
@@ -361,7 +361,7 @@ WriterNodeVisitor::Material::Material(WriterNodeVisitor& writerNodeVisitor,
             _fbxMaterial = FbxSurfacePhong::Create(pSdkManager, relativePath.c_str());
         }
         // Connect texture to material's diffuse
-        // Note there should be no reason FbxSurfacePhong::Create() would return NULL, but as previous code made this secirity test, here we keep the same way.
+        // Note there should be no reason FbxSurfacePhong::Create() would return NULL, but as previous code made this security test, here we keep the same way.
         if (_fbxMaterial)
         {
             _fbxMaterial->Diffuse.ConnectSrcObject(_fbxTexture);

--- a/src/osgPlugins/freetype/FreeTypeLibrary.h
+++ b/src/osgPlugins/freetype/FreeTypeLibrary.h
@@ -28,7 +28,7 @@ class FreeTypeLibrary : public osg::Referenced
 {
 public:
 
-    /** protected destrcutor to prevent inappropriate deletion.*/
+    /** protected destructor to prevent inappropriate deletion.*/
     virtual ~FreeTypeLibrary();
 
     /** get the singleton instance.*/

--- a/src/osgPlugins/gles/MostInfluencedGeometryByBone
+++ b/src/osgPlugins/gles/MostInfluencedGeometryByBone
@@ -211,7 +211,7 @@ protected:
 
     struct sort_influences {
         //We sort influences by number of influenced vertex first and then by normalized weight (number_of_vertex_influence / accumulated_weight)
-        //i.e we choose to keep geometries with many vertex insted of geometries with high normalized weight, it makes more sense for geometry
+        //i.e we choose to keep geometries with many vertex instead of geometries with high normalized weight, it makes more sense for geometry
         //selection via bone influence box @see AABBonBoneVisitor class
         bool operator()(const BoneInfluence &a, const BoneInfluence &b) {
             return (a.second.getNumInfluencedVertex() > b.second.getNumInfluencedVertex()) ||

--- a/src/osgPlugins/hdr/hdrwriter.h
+++ b/src/osgPlugins/hdr/hdrwriter.h
@@ -8,7 +8,7 @@
     developed by Greg Ward.  It handles the conversions between rgbe and
     pixels consisting of floats.  The data is assumed to be an array of floats.
     By default there are three floats per pixel in the order red, green, blue.
-    (RGBE_DATA_??? values control this.)  Only the mimimal header reading and
+    (RGBE_DATA_??? values control this.)  Only the minimal header reading and
     writing is implemented.  Each routine does error checking and will return
     a status value as defined below.  This code is intended as a skeleton so
     feel free to modify it to suit your needs.

--- a/src/osgPlugins/imageio/ReaderWriterImageIO.cpp
+++ b/src/osgPlugins/imageio/ReaderWriterImageIO.cpp
@@ -1143,7 +1143,7 @@ public:
         ReadResult read_result = readImageFile(full_file_name);
 #else
         // Only here to help test istream backend. The file version is better because
-        // the filenname.extension could potentially be used by ImageIO to hint what the format type is.
+        // the filename.extension could potentially be used by ImageIO to hint what the format type is.
         osgDB::ifstream istream(full_file_name.c_str(), std::ios::in | std::ios::binary);
         if(!istream) return ReadResult::FILE_NOT_HANDLED;
         ReadResult read_result = readImage(istream);
@@ -1252,7 +1252,7 @@ public:
         return writeImageFile(osg_image, full_file_name, the_options);
 #else
         // Only here to help test ostream backend. The file version is better because
-        // the filenname.extension could potentially be used by ImageIO to hint what the format type is.
+        // the filename.extension could potentially be used by ImageIO to hint what the format type is.
         osgDB::ofstream fout(file_name.c_str(), std::ios::out | std::ios::binary);
         if(!fout) return WriteResult::ERROR_IN_WRITING_FILE;
         return writeImage(osg_image, fout, the_options);

--- a/src/osgPlugins/ive/DataOutputStream.cpp
+++ b/src/osgPlugins/ive/DataOutputStream.cpp
@@ -1828,7 +1828,7 @@ void DataOutputStream::writeVolumeProperty(const osgVolume::Property* property)
         // write the id.
         writeInt(id);
 
-        // write the propery
+        // write the property
          if (dynamic_cast<const osgVolume::SwitchProperty*>(property))
         {
             ((ive::VolumeSwitchProperty*)(property))->write(this);

--- a/src/osgPlugins/ive/Exception.cpp
+++ b/src/osgPlugins/ive/Exception.cpp
@@ -2,7 +2,7 @@
  *
  *    FILE:            Exception.cpp
  *
- *    DESCRIPTION:    Exception throwed when error occur.
+ *    DESCRIPTION:    Exception thrown when error occur.
  *
  *    CREATED BY:        Rune Schmidt Jensen
  *

--- a/src/osgPlugins/p3d/ReaderWriterP3D.cpp
+++ b/src/osgPlugins/p3d/ReaderWriterP3D.cpp
@@ -3160,7 +3160,7 @@ osg::Node* ReaderWriterP3DXML::parseXmlGraph(osgDB::XmlNode* root, bool readOnly
         {
             std::string newpath = expandEnvVarsInFileName(cur->contents);
 
-            // now check if an absolue or http path
+            // now check if an absolute or http path
             std::string::size_type colonPos = newpath.find_first_of(':');
             std::string::size_type backslashPos = newpath.find_first_of('/');
             std::string::size_type forwardslashPos = newpath.find_first_of('\\');

--- a/src/osgPlugins/quicktime/QTImportExport.h
+++ b/src/osgPlugins/quicktime/QTImportExport.h
@@ -22,7 +22,7 @@ class QuicktimeImportExport {
         /** readFromString tries to read a chunk of bytes and interpret it as an image.
          *  @param istream the input stream
          *  @param fileTypeHint you can speed up the conversion by providing a filename with extension, so quicktime has not to guess the image's type
-         *  @param sizeHint useful, if you are streaming data, if you provide a sizeHint ony sizeHint bytes are read from the stream
+         *  @param sizeHint useful, if you are streaming data, if you provide a sizeHint only sizeHint bytes are read from the stream
          */
         osg::Image* readFromStream(std::istream & inStream, const std::string& fileTypeHint, long sizeHint = 0);
 

--- a/src/osgPlugins/quicktime/QTLiveUtils.cpp
+++ b/src/osgPlugins/quicktime/QTLiveUtils.cpp
@@ -235,7 +235,7 @@ void print_video_component_capability(VideoDigitizerComponent aComponent)
         long pref_width, pref_height;
         vid_err = VDGetPreferredImageDimensions(aComponent, &pref_width, &pref_height);
         if (vid_err) { OSG_NOTICE << "VDGetPreferredImageDimensions(aComponent, &pref_width, &pref_height) - ERROR" << std::endl; }
-        else         { OSG_NOTICE << "Preferrred width,height :  " << pref_width << "  " << pref_height << std::endl; }
+        else         { OSG_NOTICE << "Preferred width,height :  " << pref_width << "  " << pref_height << std::endl; }
 
         // Inputs
         short inputs;

--- a/src/osgPlugins/quicktime/QuicktimeLiveImageStream.cpp
+++ b/src/osgPlugins/quicktime/QuicktimeLiveImageStream.cpp
@@ -85,7 +85,7 @@ void QuicktimeLiveImageStream::quit(bool wiatForThreadToExit)
 
 // Use the Sequence Grabber or the raw Video Digitizer
 // If using SG then use it in Preview or Record option
-// Thre options - VD Play Through, SG Preview or SG Record
+// Three options - VD Play Through, SG Preview, or SG Record
 static bool g_s_use_sg        = true ; // 1a
 static bool g_s_use_sg_record = false; // 1b
 

--- a/src/osgPlugins/shp/ESRIShapeReaderWriter.cpp
+++ b/src/osgPlugins/shp/ESRIShapeReaderWriter.cpp
@@ -66,7 +66,7 @@ class ESRIShapeReaderWriter : public osgDB::ReaderWriter
             {
                 if (sp.getGeode()->getNumDrawables() != xbp.getAttributeList().size())
                 {
-                    OSG_WARN << "ESRIShape loader : .dbf file containe different record number that .shp file." << std::endl
+                    OSG_WARN << "ESRIShape loader : .dbf file contained different record number that .shp file." << std::endl
                                            << "                   .dbf record skipped." << std::endl;
                 }
                 else

--- a/src/osgPlugins/txp/trpage_geom.h
+++ b/src/osgPlugins/txp/trpage_geom.h
@@ -1288,7 +1288,7 @@ public:
 
     /* This tells you the number of tiles this texture is used in.  You can
        use this to do texture paging (if you can support it).  It's a pretty
-       general meachanism and will work for large scale geospecific terrain textures
+       general mechanism and will work for large scale geospecific terrain textures
        as well as things like specific building pictures.
        When GetImageMode returns Global, expect this value to always be 1.  For
        Template texture, it will be set to the total number of uses of the template
@@ -1620,7 +1620,7 @@ public:
     ~trpgModelTable(void);
 
     /* Set the total number of models in the table.  Use this in conjunction
-       with SetModel.  If you can, use AddModel isntead of either of these.
+       with SetModel.  If you can, use AddModel instead of either of these.
     */
     void    SetNumModels(int);
     /* Add the given model to the table.  Makes a copy of the model you pass in
@@ -1693,7 +1693,7 @@ public:
     // Set the total number of LODs
     // For version 2.1 only lod 0 is stored in the table
     void    SetNumLod(int numLod);
-    // Set the number of tiles in each dimenion for each terrain LOD
+    // Set the number of tiles in each dimension for each terrain LOD
     // This must agree with trpgHeader
     void    SetNumTiles(int numX,int numY,int lod);
     // Set the external address of a given tile as well as its Z value
@@ -2156,7 +2156,7 @@ public:
     void    SetNormals(int num,BindType bind,const float64 *);
     /* This method is used to add normals one by one of the given type.
        You would use this if you were adding geometry one vertex at a time
-       in conjuntion with AddVertex().
+       in conjunction with AddVertex().
     */
     void    AddNormal(DataType type,trpg3dPoint &);
     /* This constant is used to select the type of a color array

--- a/src/osgPlugins/txp/trpage_readbuf.cpp
+++ b/src/osgPlugins/txp/trpage_readbuf.cpp
@@ -416,7 +416,7 @@ bool trpgMemReadBuffer::GetData(char *ret,int rlen)
 }
 
 // Get Reference to Data
-// Protected method that retrieves a reference to the given amoutn of data
+// Protected method that retrieves a reference to the given amount of data
 bool trpgMemReadBuffer::GetDataRef(char **ret,int rlen)
 {
     if (rlen < 0)  return false;

--- a/src/osgPlugins/txp/trpage_warchive.cpp
+++ b/src/osgPlugins/txp/trpage_warchive.cpp
@@ -1543,7 +1543,7 @@ bool trpgwImageHelper::Flush()
 }
 
 /* Designate Texture File
-   Close the curren texture file (if any) and open one with the given
+   Close the current texture file (if any) and open one with the given
    base name.
 */
 bool trpgwImageHelper::DesignateTextureFile(int id)

--- a/src/osgPlugins/zip/unzip.cpp
+++ b/src/osgPlugins/zip/unzip.cpp
@@ -3160,7 +3160,7 @@ unzFile unzOpenInternal(LUFILE *fin)
   uLong number_disk=0;          // number of the current dist, used for spanning ZIP, unsupported, always 0
   if (err==UNZ_OK && unzlocal_getShort(fin,&number_disk)!=UNZ_OK) err=UNZ_ERRNO;
   // number of the disk with the start of the central directory
-  uLong number_disk_with_CD=0;  // number the disk with central dir, used for spaning ZIP, unsupported, always 0
+  uLong number_disk_with_CD=0;  // number the disk with central dir, used for spanning ZIP, unsupported, always 0
   if (err==UNZ_OK && unzlocal_getShort(fin,&number_disk_with_CD)!=UNZ_OK) err=UNZ_ERRNO;
   // total number of entries in the central dir on this disk
   if (err==UNZ_OK && unzlocal_getShort(fin,&us.gi.number_entry)!=UNZ_OK) err=UNZ_ERRNO;

--- a/src/osgPresentation/SlideEventHandler.cpp
+++ b/src/osgPresentation/SlideEventHandler.cpp
@@ -1328,7 +1328,7 @@ bool SlideEventHandler::selectSlide(int slideNum,int layerNum)
 
     _tickAtLastSlideOrLayerChange = tick;
 
-    // dectivate movies etc on current active slide.
+    // deactivate movies etc on current active slide.
     bool newSlide = _activeSlide!=slideNum;
     if (newSlide)
     {
@@ -1682,7 +1682,7 @@ void SlideEventHandler::dispatchEvent(const KeyPosition& keyPosition)
         return;
     }
 
-    // reset the time of the last key press to ensure that the event is disgarded as a key repeat.
+    // reset the time of the last key press to ensure that the event is discarded as a key repeat.
     _timeLastKeyPresses = -1.0;
 
     if (keyPosition._x!=FLT_MAX)

--- a/src/osgShadow/ShadowMap.cpp
+++ b/src/osgShadow/ShadowMap.cpp
@@ -500,7 +500,7 @@ void ShadowMap::cull(osgUtil::CullVisitor& cv)
 #if IMPROVE_TEXGEN_PRECISION
         // compute the matrix which takes a vertex from local coords into tex coords
         // We actually use two matrices one used to define texgen
-        // and second that will be used as modelview when appling to OpenGL
+        // and second that will be used as modelview when applying to OpenGL
         _texgen->setPlanesFromMatrix( _camera->getProjectionMatrix() *
                                       osg::Matrix::translate(1.0,1.0,1.0) *
                                       osg::Matrix::scale(0.5f,0.5f,0.5f) );

--- a/src/osgShadow/StandardShadowMap.cpp
+++ b/src/osgShadow/StandardShadowMap.cpp
@@ -46,7 +46,7 @@ StandardShadowMap::StandardShadowMap():
 #if FRAGMENT_SHADERS_ONLY
     _mainFragmentShader = new osg::Shader( osg::Shader::FRAGMENT,
         " // following expressions are auto modified - do not change them:       \n"
-        " // gl_TexCoord[0]  0 - can be subsituted with other index              \n"
+        " // gl_TexCoord[0]  0 - can be substituted with other index              \n"
         "                                                                        \n"
         "float DynamicShadow( );                                                 \n"
         "                                                                        \n"
@@ -73,7 +73,7 @@ StandardShadowMap::StandardShadowMap():
 
     _shadowFragmentShader = new osg::Shader( osg::Shader::FRAGMENT,
         " // following expressions are auto modified - do not change them:      \n"
-        " // gl_TexCoord[1]  1 - can be subsituted with other index             \n"
+        " // gl_TexCoord[1]  1 - can be substituted with other index             \n"
         "                                                                       \n"
         "uniform sampler2DShadow shadowTexture;                                 \n"
         "                                                                       \n"
@@ -89,7 +89,7 @@ StandardShadowMap::StandardShadowMap():
 #else
     _mainFragmentShader = new osg::Shader( osg::Shader::FRAGMENT,
         " // following expressions are auto modified - do not change them:       \n"
-        " // gl_TexCoord[0]  0 - can be subsituted with other index              \n"
+        " // gl_TexCoord[0]  0 - can be substituted with other index              \n"
         "                                                                        \n"
         "float DynamicShadow( );                                                 \n"
         "                                                                        \n"
@@ -116,7 +116,7 @@ StandardShadowMap::StandardShadowMap():
 
     _shadowFragmentShader = new osg::Shader( osg::Shader::FRAGMENT,
         " // following expressions are auto modified - do not change them:      \n"
-        " // gl_TexCoord[1]  1 - can be subsituted with other index             \n"
+        " // gl_TexCoord[1]  1 - can be substituted with other index             \n"
         "                                                                       \n"
         "uniform sampler2DShadow shadowTexture;                                 \n"
         "                                                                       \n"
@@ -129,11 +129,11 @@ StandardShadowMap::StandardShadowMap():
 
     _shadowVertexShader = new osg::Shader( osg::Shader::VERTEX,
         " // following expressions are auto modified - do not change them:      \n"
-        " // gl_TexCoord[1]  1 - can be subsituted with other index             \n"
-        " // gl_EyePlaneS[1] 1 - can be subsituted with other index             \n"
-        " // gl_EyePlaneT[1] 1 - can be subsituted with other index             \n"
-        " // gl_EyePlaneR[1] 1 - can be subsituted with other index             \n"
-        " // gl_EyePlaneQ[1] 1 - can be subsituted with other index             \n"
+        " // gl_TexCoord[1]  1 - can be substituted with other index             \n"
+        " // gl_EyePlaneS[1] 1 - can be substituted with other index             \n"
+        " // gl_EyePlaneT[1] 1 - can be substituted with other index             \n"
+        " // gl_EyePlaneR[1] 1 - can be substituted with other index             \n"
+        " // gl_EyePlaneQ[1] 1 - can be substituted with other index             \n"
         "                                                                       \n"
         "void DynamicShadow( in vec4 ecPosition )                               \n"
         "{                                                                      \n"
@@ -146,9 +146,9 @@ StandardShadowMap::StandardShadowMap():
 
     _mainVertexShader = new osg::Shader( osg::Shader::VERTEX,
         " // following expressions are auto modified - do not change them:      \n"
-        " // gl_TexCoord[0]      0 - can be subsituted with other index         \n"
-        " // gl_TextureMatrix[0] 0 - can be subsituted with other index         \n"
-        " // gl_MultiTexCoord0   0 - can be subsituted with other index         \n"
+        " // gl_TexCoord[0]      0 - can be substituted with other index         \n"
+        " // gl_TextureMatrix[0] 0 - can be substituted with other index         \n"
+        " // gl_MultiTexCoord0   0 - can be substituted with other index         \n"
         "                                                                       \n"
         "const int NumEnabledLights = 1;                                        \n"
         "                                                                       \n"
@@ -476,7 +476,7 @@ void StandardShadowMap::ViewData::cull()
     // find the light casting our shadows
     osg::Vec4 lightPos;
     osg::Vec3 lightDir;
-    osg::Vec3 lightUp( 0,0,0 ); // force computing most approprate dir
+    osg::Vec3 lightUp( 0,0,0 ); // force computing most appropriate dir
     const osg::Light *light = selectLight( lightPos, lightDir );
 
     if ( !light )

--- a/src/osgShadow/ViewDependentShadowMap.cpp
+++ b/src/osgShadow/ViewDependentShadowMap.cpp
@@ -2287,7 +2287,7 @@ bool ViewDependentShadowMap::assignTexGenSettings(osgUtil::CullVisitor* cv, osg:
 
     // compute the matrix which takes a vertex from local coords into tex coords
     // We actually use two matrices one used to define texgen
-    // and second that will be used as modelview when appling to OpenGL
+    // and second that will be used as modelview when applying to OpenGL
     texgen->setPlanesFromMatrix( camera->getProjectionMatrix() *
                                  osg::Matrix::translate(1.0,1.0,1.0) *
                                  osg::Matrix::scale(0.5,0.5,0.5) );

--- a/src/osgSim/Impostor.cpp
+++ b/src/osgSim/Impostor.cpp
@@ -18,7 +18,7 @@ using namespace osg;
 using namespace osgSim;
 
 // use this cull callback to allow the camera to traverse the Impostor's children without
-// actuall having them assigned as children to the camea itself.  This make the camera a
+// actually having them assigned as children to the camea itself.  This make the camera a
 // decorator without ever directly being assigned to it.
 class ImpostorTraverseNodeCallback : public osg::NodeCallback
 {
@@ -216,7 +216,7 @@ ImpostorSprite* Impostor::createImpostorSprite(osgUtil::CullVisitor* cv)
      }
 
 
-    // default to true right now, will dertermine if perspective from the
+    // default to true right now, will determine if perspective from the
     // projection matrix...
     bool isPerspectiveProjection = true;
 

--- a/src/osgSim/ImpostorSprite.cpp
+++ b/src/osgSim/ImpostorSprite.cpp
@@ -95,7 +95,7 @@ void ImpostorSprite::dirty()
 
 float ImpostorSprite::calcPixelError(const osg::Matrix& MVPW) const
 {
-    // find the maximum screen space pixel error between the control coords and the quad coners.
+    // find the maximum screen space pixel error between the control coords and the quad corners.
     float max_error_sqrd = 0.0f;
 
     for(int i=0;i<4;++i)

--- a/src/osgSim/SphereSegment.cpp
+++ b/src/osgSim/SphereSegment.cpp
@@ -2446,7 +2446,7 @@ void SphereSegment::updatePositions()
 
     unsigned int pos = 0;
 
-    // assigne center vertex
+    // assign center vertex
     (*_vertices)[pos] = _centre;
     (*_normals)[pos].set(0.0f,0.0f,1.0f);
     pos++;

--- a/src/osgText/TextBase.cpp
+++ b/src/osgText/TextBase.cpp
@@ -694,7 +694,7 @@ void TextBase::positionCursor(const osg::Vec2 & endOfLine_coords, osg::Vec2 & cu
             switch (_alignment)
             {
                 // TODO: current behaviour top baselines lined up in both cases - need to implement
-                //       top of characters aligment - Question is this necessary?
+                //       top of characters alignment - Question is this necessary?
                 // ... otherwise, nothing to be done for these 6 cases
                 //case LEFT_TOP:
                 //case CENTER_TOP:

--- a/src/osgUtil/CullVisitor.cpp
+++ b/src/osgUtil/CullVisitor.cpp
@@ -128,7 +128,7 @@ void CullVisitor::reset()
         (*itr)->reset();
     }
 
-    // reset the resuse lists.
+    // reset the reuse lists.
     _currentReuseRenderLeafIndex = 0;
 
     _nearPlaneCandidateMap.clear();
@@ -169,7 +169,7 @@ void CullVisitor::computeNearPlane()
 #if 0
         osg::Timer_t start_t = osg::Timer::instance()->tick();
 #endif
-        // update near from defferred list of drawables
+        // update near from deferred list of drawables
         unsigned int numTests = 0;
         for(DistanceMatrixDrawableMap::iterator itr=_nearPlaneCandidateMap.begin();
             itr!=_nearPlaneCandidateMap.end() && itr->first<_computed_znear;
@@ -199,7 +199,7 @@ void CullVisitor::computeNearPlane()
 
         //osg::Timer_t start_t = osg::Timer::instance()->tick();
 
-        // update near from defferred list of drawables
+        // update near from deferred list of drawables
         unsigned int numTests = 0;
         for(DistanceMatrixDrawableMap::reverse_iterator itr=_farPlaneCandidateMap.rbegin();
             itr!=_farPlaneCandidateMap.rend() && itr->first>_computed_zfar;
@@ -765,7 +765,7 @@ bool CullVisitor::updateCalculatedNearFar(const osg::Matrix& matrix,const osg::D
                 MatrixPlanesDrawables mpd;
                 if (isBillboard)
                 {
-                    // OSG_WARN<<"Adding billboard into deffered list"<<std::endl;
+                    // OSG_WARN<<"Adding billboard into deferred list"<<std::endl;
                     osg::Polytope transformed_frustum;
                     transformed_frustum.setAndTransformProvidingInverse(getProjectionCullingStack().back().getFrustum(),matrix);
                     mpd.set(matrix,&drawable,transformed_frustum);

--- a/src/osgUtil/Optimizer.cpp
+++ b/src/osgUtil/Optimizer.cpp
@@ -1083,7 +1083,7 @@ bool CollectLowestTransformsVisitor::removeTransforms(osg::Node* nodeWeCannotRem
                     else
                     {
                         OSG_WARN<<"Warning:: during Optimize::CollectLowestTransformsVisitor::removeTransforms(Node*)"<<std::endl;
-                        OSG_WARN<<"          unhandled of setting of indentity matrix on "<< titr->first->className()<<std::endl;
+                        OSG_WARN<<"          unhandled of setting of identity matrix on "<< titr->first->className()<<std::endl;
                         OSG_WARN<<"          model will appear in the incorrect position."<<std::endl;
                     }
                 }
@@ -1816,7 +1816,7 @@ bool Optimizer::MergeGeometryVisitor::mergeGroup(osg::Group& group)
         // first try to group geometries with the same properties
         // (i.e. array types) to avoid loss of data during merging
         MergeList mergeListChecked;        // List of drawables just before merging, grouped by "compatibility" and vertex limit
-        MergeList mergeList;            // Intermediate list of drawables, grouped ony by "compatibility"
+        MergeList mergeList;            // Intermediate list of drawables, grouped only by "compatibility"
         for(GeometryDuplicateMap::iterator itr=geometryDuplicateMap.begin();
             itr!=geometryDuplicateMap.end();
             ++itr)

--- a/src/osgUtil/PlaneIntersector.cpp
+++ b/src/osgUtil/PlaneIntersector.cpp
@@ -659,7 +659,7 @@ void PlaneIntersector::intersect(osgUtil::IntersectionVisitor& iv, osg::Drawable
     if ( _plane.intersect( drawable->getBoundingBox() )!=0 ) return;
     if ( !_polytope.contains( drawable->getBoundingBox() ) ) return;
 
-    // OSG_NOTICE<<"Succed PlaneIntersector::intersect(osgUtil::IntersectionVisitor& iv, osg::Drawable* drawable)"<<std::endl;
+    // OSG_NOTICE<<"Succeed PlaneIntersector::intersect(osgUtil::IntersectionVisitor& iv, osg::Drawable* drawable)"<<std::endl;
 
     osg::TriangleFunctor<PlaneIntersectorUtils::TriangleIntersector> ti;
     ti.set(_plane, _polytope, iv.getModelMatrix(), _recordHeightsAsAttributes, _em.get());

--- a/src/osgUtil/RenderStage.cpp
+++ b/src/osgUtil/RenderStage.cpp
@@ -321,7 +321,7 @@ void RenderStage::runCameraSetUp(osg::RenderInfo& renderInfo)
             {
                 if (texture3D->getTextureWidth()==0 || texture3D->getTextureHeight()==0 || texture3D->getTextureDepth()==0 )
                 {
-                    // note we dont' have the depth here, so we'll heave to assume that height and depth are the same..
+                    // note we don't have the depth here, so we'll have to assume that height and depth are the same..
                     texture3D->setTextureSize(width,height,height);
                 }
             }

--- a/src/osgViewer/GraphicsWindowCocoa.mm
+++ b/src/osgViewer/GraphicsWindowCocoa.mm
@@ -457,7 +457,7 @@ static NSRect convertToQuartzCoordinates(const NSRect& rect)
     DEBUG_OUT("Mouse down");
     // Because many Mac users have only a 1-button mouse, we should provide ways
     // to access the button 2 and 3 actions of osgViewer.
-    // I will use the Ctrl modifer to represent right-clicking
+    // I will use the Ctrl modifier to represent right-clicking
     // and Option modifier to represent middle clicking.
     if([theEvent modifierFlags] & NSControlKeyMask)
     {
@@ -505,7 +505,7 @@ static NSRect convertToQuartzCoordinates(const NSRect& rect)
 
     // Because many Mac users have only a 1-button mouse, we should provide ways
     // to access the button 2 and 3 actions of osgViewer.
-    // I will use the Ctrl modifer to represent right-clicking
+    // I will use the Ctrl modifier to represent right-clicking
     // and Option modifier to represent middle clicking.
     if([self isUsingCtrlClick] == YES)
     {

--- a/src/osgViewer/GraphicsWindowWin32.cpp
+++ b/src/osgViewer/GraphicsWindowWin32.cpp
@@ -1827,7 +1827,7 @@ HGLRC GraphicsWindowWin32::createContextImplementation()
         }
     }
 
-    // TBD insert GL ES 2 suppurt, if required for Win32.
+    // TBD insert GL ES 2 support, if required for Win32.
 
     // If platform context creation fails for any reason,
     // we'll create a standard context. This means you could

--- a/src/osgViewer/GraphicsWindowX11.cpp
+++ b/src/osgViewer/GraphicsWindowX11.cpp
@@ -531,7 +531,7 @@ bool GraphicsWindowX11::setWindowDecorationImplementation(bool flag)
             wmHints.inputMode = 0;
             wmHints.status = 0;
 
-            // if traits says not resize we want to set the functions to exlude MWM_FUNC_RESIZE,
+            // if traits says not resize we want to set the functions to exclude MWM_FUNC_RESIZE,
             // but this bitmask needs to be set if the MWM_FUNC_ALL bit is already set in order to toggle it off.
             if (_traits.valid() && !_traits->supportsResize) wmHints.functions = wmHints.functions | MWM_FUNC_RESIZE;
 

--- a/src/osgViewer/IOSUtils.h
+++ b/src/osgViewer/IOSUtils.h
@@ -70,7 +70,7 @@ public:
 protected:
 
     /** implementation of setScreenResolution */
-    //IPad can have extenal screens which we can request a res for
+    //IPad can have external screens which we can request a res for
     //the main screen screenNum 0 can not currently have its res changed
     //as it only has one mode (might change though and this should still handle it)
     bool setScreenResolutionImpl(const osg::GraphicsContext::ScreenIdentifier& screenIdentifier, unsigned int width, unsigned int height);

--- a/src/osgViewer/IOSUtils.mm
+++ b/src/osgViewer/IOSUtils.mm
@@ -174,7 +174,7 @@ bool IOSWindowingSystemInterface::setScreenSettings(const osg::GraphicsContext::
 
 
 /** implementation of setScreenResolution */
-//IPad can have extenal screens which we can request a res for
+//IPad can have external screens which we can request a res for
 //the main screen screenNum 0 can not currently have its res changed
 //as it only has one mode (might change though and this should still handle it)
 //

--- a/src/osgWidget/Box.cpp
+++ b/src/osgWidget/Box.cpp
@@ -164,7 +164,7 @@ Window::Sizes Box::_getWidthImplementation() const {
         );
     }
 
-    // If we're a vertical Box, our width is the width of the larget Widget in the group.
+    // If we're a vertical Box, our width is the width of the largest Widget in the group.
     // Our minWidth is the largest minWidth of the Widgets in the group.
     else return Sizes(
         _getMaxWidgetWidthTotal(),


### PR DESCRIPTION
Found via `codespell -q 3 -S ./ChangeLog,./NEWS.txt -L aci,alph,ba,blok,childrens,childs,compiletime,currenty,doubleclick,dum,enew,inout,interaktive,lod,ontop,parm,propmt,prset,ro,seh,stil,supercedes,te,tesselation,tesselator,useg,valu,vas,widthout,xwindows`