### PR TITLE
Fix RigTransformSoftware copy

### DIFF
--- a/src/osgAnimation/RigTransformSoftware.cpp
+++ b/src/osgAnimation/RigTransformSoftware.cpp
@@ -30,7 +30,7 @@ RigTransformSoftware::RigTransformSoftware()
 
 RigTransformSoftware::RigTransformSoftware(const RigTransformSoftware& rts,const osg::CopyOp& copyop):
     RigTransform(rts, copyop),
-    _needInit(rts._needInit),
+    _needInit(true),
     _invalidInfluence(rts._invalidInfluence)
 {
 


### PR DESCRIPTION
* Force init for new copy as _uniqVertexGroupList is not copied

The problem can occur if you deep copy a scene with a RigTransformSoftware in it after it has already been displayed. We were copying a pedestrian model and trying to use a different animation on it, but the second animation fails to apply as the copied RigTransformSoftware never gets inited. 