### PR TITLE
[cmake] Fix cross-build failure

### DIFF
--- a/CMakeModules/CheckAtomicOps.cmake
+++ b/CMakeModules/CheckAtomicOps.cmake
@@ -26,6 +26,14 @@ ELSE()
        SET(_OPENTHREADS_ATOMIC_USE_BSD_ATOMIC 1)
 
     ELSE()
+       set( _OPENTHREADS_ATOMIC_USE_WIN32_INTERLOCKED_EXITCODE
+           "PLEASE_FILL_OUT-FAILED_TO_RUN"
+           CACHE STRING "Result from try_run" FORCE)
+
+       set( _OPENTHREADS_ATOMIC_USE_WIN32_INTERLOCKED_EXITCODE__TRYRUN_OUTPUT
+           "PLEASE_FILL_OUT-NOTFOUND"
+           CACHE STRING "Output from try_run" FORCE)
+
        INCLUDE(CheckCXXSourceRuns)
 
        # Do step by step checking,


### PR DESCRIPTION
When I cross-build osg for `arm64-windows` with `x64-windows`, I got the following cmake error message:
```
CMake Error: try_run() invoked in cross-compiling mode, please set the following cache variables appropriately:
   _OPENTHREADS_ATOMIC_USE_WIN32_INTERLOCKED_EXITCODE (advanced)
   _OPENTHREADS_ATOMIC_USE_WIN32_INTERLOCKED_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see D:/buildtrees/osg/arm64-windows-rel/TryRunResults.cmake
```
According to the cmake code generated by cmake automaticly, add the same code before call `CHECK_CXX_SOURCE_RUNS`.

cmake version: 3.24
osg version: 3.6.5
OS version: Windows 10
compiler version: Visual Studio 2017