### PR TITLE
Support more ways to build with dependency to collada-dom library (Debian/Ubuntu/Others)

### DIFF
--- a/CMakeModules/FindCOLLADA.cmake
+++ b/CMakeModules/FindCOLLADA.cmake
@@ -64,6 +64,7 @@ FIND_PATH(COLLADA_INCLUDE_DIR dae.h
     ${COLLADA_DOM_ROOT}/include
     $ENV{COLLADA_DIR}/include
     $ENV{COLLADA_DIR}
+    $ENV{COLLADA_DIR}/include/collada-dom2.5
     ~/Library/Frameworks
     /Library/Frameworks
     /opt/local/Library/Frameworks #macports
@@ -185,8 +186,7 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
     ${ACTUAL_3DPARTY_DIR}/lib
 )
 
-    # find extra libraries that the static linking requires
-
+IF (COLLADA_STATIC_LIBRARY)
     FIND_PACKAGE(LibXml2)
     IF (LIBXML2_FOUND)
         SET(COLLADA_LIBXML_LIBRARY "${LIBXML2_LIBRARIES}" CACHE FILEPATH "" FORCE)
@@ -309,7 +309,7 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
         ${COLLADA_DOM_ROOT}/external-libs/boost/lib/mingw
         ${ACTUAL_3DPARTY_DIR}/lib
     )
-
+ENDIF()
 
 SET(COLLADA_FOUND "NO")
 IF(COLLADA_DYNAMIC_LIBRARY OR COLLADA_STATIC_LIBRARY)


### PR DESCRIPTION
1. Add more paths to find collada library. Existing onces ignore the default install location defined [here](https://github.com/rdiankov/collada-dom/blob/c1e20b7d6ff806237030fe82f126cb86d661f063/CMakeLists.txt#L141).
2. Find collada dependencies only when found static library. If it's only dynamic library, all dependencies are linked to it and there is no need to find them. Attempt to do so may fail because of locations mismatch. `CMakeModules/FindCOLLADA.cmake` supports only very specific locations for them.

A similar one is done here: [pull request](https://github.com/openscenegraph/OpenSceneGraph/pull/1138) for OpenSceneGraph but it's being ignored.

Note: I've already been carrying these fixes on Debian and Ubuntu as well in our static builds for OpenMW. Others also make use of the patch to work around the issue of how the collada-dom is included. It would be great to have this in OpenSceneGraph-3.6