### PR TITLE
Fix: Changes to make the non-const get method thread-safe.

### DIFF
--- a/include/osg/ContextData
+++ b/include/osg/ContextData
@@ -33,15 +33,25 @@ class OSG_EXPORT ContextData : public GraphicsObjectManager
         osg::GraphicsContext* getCompileContext() { return _compileContext.get(); }
 
         /** Get a specific GL extensions object or GraphicsObjectManager, initialize if not already present.
-          * Note, must only be called from a the graphics context thread associated with this osg::State. */
+          * Note, safe to call outwith a the graphics context thread associated with this osg::State. */
         template<typename T>
         T* get()
         {
             const std::type_info* id(&typeid(T));
-            osg::ref_ptr<osg::Referenced>& ptr = _managerMap[id];
+            osg::ref_ptr<const RefManagerMap> managerMap = getManagerMap();
+            ManagerMap::const_iterator itr = managerMap->find(id);
+            if (itr!=managerMap->end())
+                return static_cast<T*>(itr->second.get());
+
+            osg::ref_ptr<RefManagerMap> newManagerMap = new RefManagerMap;
+
+            OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_managerMapMutex);
+            *newManagerMap = *_managerMap;
+            osg::ref_ptr<osg::Referenced>& ptr = (*newManagerMap)[id];
             if (!ptr)
             {
                 ptr = new T(_contextID);
+                _managerMap = newManagerMap;
             }
             return static_cast<T*>(ptr.get());
         }
@@ -53,8 +63,9 @@ class OSG_EXPORT ContextData : public GraphicsObjectManager
         const T* get() const
         {
             const std::type_info* id(&typeid(T));
-            ManagerMap::const_iterator itr = _managerMap.find(id);
-            if (itr==_managerMap.end()) return 0;
+            osg::ref_ptr<const RefManagerMap> managerMap = getManagerMap();
+            ManagerMap::const_iterator itr = managerMap->find(id);
+            if (itr==managerMap->end()) return 0;
             else return itr->second.get();
         }
 
@@ -63,7 +74,13 @@ class OSG_EXPORT ContextData : public GraphicsObjectManager
         void set(T* ptr)
         {
             const std::type_info* id(&typeid(T));
-            _managerMap[id] = ptr;
+
+            osg::ref_ptr<RefManagerMap> newManagerMap = new RefManagerMap;
+
+            OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_managerMapMutex);
+            *newManagerMap = *_managerMap;
+            (*newManagerMap)[id] = ptr;
+            _managerMap = newManagerMap;
         }
 
         /** Signal that a new frame has started.*/
@@ -133,12 +150,17 @@ class OSG_EXPORT ContextData : public GraphicsObjectManager
     protected:
         virtual ~ContextData();
 
+        class RefManagerMap;
+        osg::ref_ptr<const RefManagerMap> getManagerMap() const;
+
         unsigned int _numContexts;
         osg::ref_ptr<osg::GraphicsContext> _compileContext;
 
         // ManagerMap contains GL Extentsions objects used by StateAttribue to call OpenGL extensions/advanced features
         typedef std::map<const std::type_info*, osg::ref_ptr<osg::Referenced> > ManagerMap;
-        ManagerMap _managerMap;
+        class RefManagerMap : public osg::Referenced, public ManagerMap {};
+        osg::ref_ptr<RefManagerMap> _managerMap;
+        mutable OpenThreads::Mutex _managerMapMutex;
 };
 
 

--- a/src/osg/ContextData.cpp
+++ b/src/osg/ContextData.cpp
@@ -26,7 +26,8 @@ static ContextData::GraphicsContexts s_registeredContexts;
 
 ContextData::ContextData(unsigned int contextID):
     GraphicsObjectManager("ContextData", contextID),
-    _numContexts(0)
+    _numContexts(0),
+    _managerMap(new RefManagerMap)
 {
 }
 
@@ -34,11 +35,18 @@ ContextData::~ContextData()
 {
 }
 
+osg::ref_ptr<const ContextData::RefManagerMap> ContextData::getManagerMap() const
+{
+    OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_managerMapMutex);
+    return _managerMap;
+}
+
 void ContextData::newFrame(osg::FrameStamp* frameStamp)
 {
     // OSG_NOTICE<<"ContextData::newFrame("<<frameStamp->getFrameNumber()<<")"<<std::endl;
-    for(ManagerMap::iterator itr = _managerMap.begin();
-        itr != _managerMap.end();
+    osg::ref_ptr<const RefManagerMap> managerMap = getManagerMap();
+    for(ManagerMap::const_iterator itr = managerMap->begin();
+        itr != managerMap->end();
         ++itr)
     {
         osg::GraphicsObjectManager* gom = dynamic_cast<osg::GraphicsObjectManager*>(itr->second.get());
@@ -48,8 +56,9 @@ void ContextData::newFrame(osg::FrameStamp* frameStamp)
 
 void ContextData::resetStats()
 {
-    for(ManagerMap::iterator itr = _managerMap.begin();
-        itr != _managerMap.end();
+    osg::ref_ptr<const RefManagerMap> managerMap = getManagerMap();
+    for(ManagerMap::const_iterator itr = managerMap->begin();
+        itr != managerMap->end();
         ++itr)
     {
         osg::GraphicsObjectManager* gom = dynamic_cast<osg::GraphicsObjectManager*>(itr->second.get());
@@ -59,8 +68,9 @@ void ContextData::resetStats()
 
 void ContextData::reportStats(std::ostream& out)
 {
-    for(ManagerMap::iterator itr = _managerMap.begin();
-        itr != _managerMap.end();
+    osg::ref_ptr<const RefManagerMap> managerMap = getManagerMap();
+    for(ManagerMap::const_iterator itr = managerMap->begin();
+        itr != managerMap->end();
         ++itr)
     {
         osg::GraphicsObjectManager* gom = dynamic_cast<osg::GraphicsObjectManager*>(itr->second.get());
@@ -70,8 +80,9 @@ void ContextData::reportStats(std::ostream& out)
 
 void ContextData::recomputeStats(std::ostream& out) const
 {
-    for(ManagerMap::const_iterator itr = _managerMap.begin();
-        itr != _managerMap.end();
+    osg::ref_ptr<const RefManagerMap> managerMap = getManagerMap();
+    for(ManagerMap::const_iterator itr = managerMap->begin();
+        itr != managerMap->end();
         ++itr)
     {
         osg::GraphicsObjectManager* gom = dynamic_cast<osg::GraphicsObjectManager*>(itr->second.get());
@@ -83,8 +94,9 @@ void ContextData::recomputeStats(std::ostream& out) const
 void ContextData::flushDeletedGLObjects(double currentTime, double& availableTime)
 {
     // OSG_NOTICE<<"ContextData::flushDeletedGLObjects("<<currentTime<<","<<availableTime<<")"<<std::endl;
-    for(ManagerMap::iterator itr = _managerMap.begin();
-        itr != _managerMap.end();
+    osg::ref_ptr<const RefManagerMap> managerMap = getManagerMap();
+    for(ManagerMap::const_iterator itr = managerMap->begin();
+        itr != managerMap->end();
         ++itr)
     {
         osg::GraphicsObjectManager* gom = dynamic_cast<osg::GraphicsObjectManager*>(itr->second.get());
@@ -95,8 +107,9 @@ void ContextData::flushDeletedGLObjects(double currentTime, double& availableTim
 void ContextData::flushAllDeletedGLObjects()
 {
     // OSG_NOTICE<<"ContextData::flushAllDeletedGLObjects()"<<std::endl;
-    for(ManagerMap::iterator itr = _managerMap.begin();
-        itr != _managerMap.end();
+    osg::ref_ptr<const RefManagerMap> managerMap = getManagerMap();
+    for(ManagerMap::const_iterator itr = managerMap->begin();
+        itr != managerMap->end();
         ++itr)
     {
         osg::GraphicsObjectManager* gom = dynamic_cast<osg::GraphicsObjectManager*>(itr->second.get());
@@ -107,8 +120,9 @@ void ContextData::flushAllDeletedGLObjects()
 void ContextData::deleteAllGLObjects()
 {
     // OSG_NOTICE<<"ContextData::deleteAllGLObjects()"<<std::endl;
-    for(ManagerMap::iterator itr = _managerMap.begin();
-        itr != _managerMap.end();
+    osg::ref_ptr<const RefManagerMap> managerMap = getManagerMap();
+    for(ManagerMap::const_iterator itr = managerMap->begin();
+        itr != managerMap->end();
         ++itr)
     {
         osg::GraphicsObjectManager* gom = dynamic_cast<osg::GraphicsObjectManager*>(itr->second.get());
@@ -119,8 +133,9 @@ void ContextData::deleteAllGLObjects()
 void ContextData::discardAllGLObjects()
 {
     // OSG_NOTICE<<"ContextData::discardAllGLObjects()"<<std::endl;
-    for(ManagerMap::iterator itr = _managerMap.begin();
-        itr != _managerMap.end();
+    osg::ref_ptr<const RefManagerMap> managerMap = getManagerMap();
+    for(ManagerMap::const_iterator itr = managerMap->begin();
+        itr != managerMap->end();
         ++itr)
     {
         osg::GraphicsObjectManager* gom = dynamic_cast<osg::GraphicsObjectManager*>(itr->second.get());


### PR DESCRIPTION
We had a crash in this line of code:
`osg::ref_ptr<osg::Referenced>& ptr = _managerMap[id];`
There was an attempt to add an element in _managerMap with an index that already existed.
As far as we understand OSG, we have not done anything illegal. In our case, during the execution of the destructor Program::PerContextProgram::~PerContextProgram(). We believe that calling this destructor simultaneously from different threads is a valid case.
In addition, in the comment to the const get-method, it is written that it can be called outwith a the graphics context thread. This means that it is quite legal to call this method from another thread and at the same time a non-const get method from the graphics context thread. Which can lead to crash.
We propose the following changes to make both get methods thread-safe.
We use COW(Copy-on-write) to minimize read time. It also makes sense to encapsulate _managerMap and COW.