### PR TITLE
fixes issues where osg can cause a crash on invalid ebo

### DIFF
--- a/src/osgText/Text.cpp
+++ b/src/osgText/Text.cpp
@@ -464,6 +464,7 @@ void Text::computeGlyphRepresentation()
     {
         _textBB.set(0,0,0,0,0,0);//no size text
         computePositions(); //to reset the origin
+        _decorationPrimitives.clear();// clear out decorations if they had been previously set
         return;
     }
 


### PR DESCRIPTION
We've been seeing crashes when an osgText with decoration is set to non-empty text string, then subsequently set to an empty string. It appears that the _decorationPrimitives contains references to primitives that are no longer valid.