### PR TITLE
[Texture2DArray] Fix glTexStorage3D/glTexImage3D condition

### DIFF
--- a/src/osg/Texture2DArray.cpp
+++ b/src/osg/Texture2DArray.cpp
@@ -440,26 +440,29 @@ void Texture2DArray::apply(State& state) const
         // generate texture
         GLenum texStorageSizedInternalFormat = extensions->isTextureStorageEnabled ? selectSizedInternalFormat() : 0;
 
-        textureObject = generateAndAssignTextureObject(
-                contextID, GL_TEXTURE_2D_ARRAY, _numMipmapLevels,
-                texStorageSizedInternalFormat!=0 ? texStorageSizedInternalFormat :_internalFormat,
-                _textureWidth, _textureHeight, _textureDepth, 0);
-
-        textureObject->bind();
-
-        applyTexParameters(GL_TEXTURE_2D_ARRAY,state);
-
-        if (texStorageSizedInternalFormat!=0 && !textureObject->_allocated)
+        if (texStorageSizedInternalFormat != 0)
         {
-            extensions->glTexStorage3D( GL_TEXTURE_2D_ARRAY, osg::maximum(_numMipmapLevels,1), texStorageSizedInternalFormat, _textureWidth, _textureHeight, _textureDepth);
+            textureObject = generateAndAssignTextureObject(contextID, GL_TEXTURE_2D_ARRAY, _numMipmapLevels, texStorageSizedInternalFormat, _textureWidth, _textureHeight, _textureDepth, 0);
+            textureObject->bind();
+            applyTexParameters(GL_TEXTURE_2D_ARRAY, state);
+            if (!textureObject->_allocated)
+            {
+                extensions->glTexStorage3D(GL_TEXTURE_2D_ARRAY, osg::maximum(_numMipmapLevels, 1), texStorageSizedInternalFormat, 
+                    _textureWidth, _textureHeight, _textureDepth);
+            }
         }
         else
-            extensions->glTexImage3D( GL_TEXTURE_2D_ARRAY, 0, _internalFormat,
-                     _textureWidth, _textureHeight, _textureDepth,
-                     _borderWidth,
-                     _sourceFormat ? _sourceFormat : _internalFormat,
-                     _sourceType ? _sourceType : GL_UNSIGNED_BYTE,
-                     0);
+        {
+            GLenum internalFormat = _sourceFormat ? _sourceFormat : _internalFormat;
+            textureObject = generateAndAssignTextureObject(contextID, GL_TEXTURE_2D_ARRAY, _numMipmapLevels, internalFormat, _textureWidth, _textureHeight, _textureDepth, 0);
+            textureObject->bind();
+            applyTexParameters(GL_TEXTURE_2D_ARRAY, state);
+            extensions->glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _internalFormat,
+                _textureWidth, _textureHeight, _textureDepth, _borderWidth,
+                internalFormat,
+                _sourceType ? _sourceType : GL_UNSIGNED_BYTE,
+                0);
+        }
 
         textureObject->setAllocated(_numMipmapLevels, texStorageSizedInternalFormat!=0 ? texStorageSizedInternalFormat :_internalFormat, _textureWidth, _textureHeight, _textureDepth, 0);
     }


### PR DESCRIPTION
When generateAndAssignTextureObject() returns a re-used texture object with _allocated set to true, and `texStorageSizedInternalFormat != 0`, Texture2DArray calls glTexImage3D with this texture object bound. This is an error because in this case Texture2DArray has already called glTexStorage3D on this texture object the first time this re-used TextureObject was used.

This PR proposes a fix for this issue. This code is based on the corresponding code in Texture2D.cpp

edit: I think [!934](https://github.com/openscenegraph/OpenSceneGraph/pull/934) was an attempt at fixing this, but that fix doesn't work for Texture2DArray because the check against _allocated is in the wrong place.