### PR TITLE
Use sized internal format for depth and depth+stencil formats.

### DIFF
--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -52,6 +52,22 @@
 #define GL_RGB565                         0x8D62
 #endif
 
+#ifndef GL_DEPTH32F_STENCIL8
+#define GL_DEPTH32F_STENCIL8 0x8CAD
+#endif
+
+#ifndef GL_FLOAT_32_UNSIGNED_INT_24_8_REV
+#define GL_FLOAT_32_UNSIGNED_INT_24_8_REV 0x8DAD
+#endif
+
+#ifndef GL_DEPTH24_STENCIL8
+#define GL_DEPTH24_STENCIL8 0x88F0
+#endif
+
+#ifndef GL_DEPTH_STENCIL_EXT
+#define GL_DEPTH_STENCIL_EXT 0x84F9
+#endif
+
 #if 0
     #define CHECK_CONSISTENCY checkConsistency();
 #else
@@ -171,8 +187,8 @@ InternalPixelRelations sizedDepthAndStencilInternalFormats[] = {
     , { GL_DEPTH_COMPONENT24                   , GL_DEPTH_COMPONENT  , GL_UNSIGNED_INT                              }
     , { GL_DEPTH_COMPONENT32                   , GL_DEPTH_COMPONENT  , GL_UNSIGNED_INT                              }
     , { GL_DEPTH_COMPONENT32F                  , GL_DEPTH_COMPONENT  , GL_FLOAT                                     }
- // , { GL_DEPTH24_STENCIL8                    , GL_DEPTH_STENCIL    , GL_UNSIGNED_INT_24_8                         }
- // , { GL_DEPTH32F_STENCIL8                   , GL_DEPTH_STENCIL    , GL_FLOAT_32_UNSIGNED_INT_24_8_REV            }
+    , { GL_DEPTH24_STENCIL8                    , GL_DEPTH_STENCIL_EXT, GL_UNSIGNED_INT_24_8_EXT                 }
+    , { GL_DEPTH32F_STENCIL8                   , GL_DEPTH_STENCIL_EXT, GL_FLOAT_32_UNSIGNED_INT_24_8_REV        }
 };
 
 InternalPixelRelations compressedInternalFormats[] = {
@@ -239,6 +255,14 @@ bool isSizedInternalFormat(GLint internalFormat)
     for (size_t i=0; i < formatsCount; ++i)
     {
         if((GLenum)internalFormat == sizedInternalFormats[i].sizedInternalFormat)
+            return true;
+    }
+
+    const size_t depthStencilFormatsCount = sizeof(sizedDepthAndStencilInternalFormats) / sizeof(sizedDepthAndStencilInternalFormats[0]);
+
+    for (size_t i=0; i < depthStencilFormatsCount; ++i)
+    {
+        if((GLenum)internalFormat == sizedDepthAndStencilInternalFormats[i].sizedInternalFormat)
             return true;
     }
 


### PR DESCRIPTION
Currently, `isSizedInternalFormat()` will never report a depth texture format as being a sized internal format.

This PR proposes making `isSizedInternalFormat()` reporting the relevant depth formats as being sized internal formats.