### PR TITLE
osgarchive shouldn't fail silently to add files to the archive

### DIFF
--- a/applications/osgarchive/osgarchive.cpp
+++ b/applications/osgarchive/osgarchive.cpp
@@ -143,11 +143,15 @@ int main( int argc, char **argv )
                     osg::HeightField* hf = dynamic_cast<osg::HeightField*>(obj.get());
                     osg::Node* node = dynamic_cast<osg::Node*>(obj.get());
                     osg::Shader* shader = dynamic_cast<osg::Shader*>(obj.get());
-                    if (image) archive->writeImage(*image, *itr);
-                    else if (hf) archive->writeHeightField(*hf, *itr);
-                    else if (node) archive->writeNode(*node, *itr);
-                    else if (shader) archive->writeShader(*shader, *itr);
-                    else archive->writeObject(*obj, *itr);
+                    osgDB::ReaderWriter::WriteResult result;
+                    if (image) result = archive->writeImage(*image, *itr);
+                    else if (hf) result = archive->writeHeightField(*hf, *itr);
+                    else if (node) result = archive->writeNode(*node, *itr);
+                    else if (shader) result = archive->writeShader(*shader, *itr);
+                    else result = archive->writeObject(*obj, *itr);
+                    if (result.status() != osgDB::ReaderWriter::WriteResult::WriteStatus::FILE_SAVED) {
+                        std::cout<<"  -- unable to write "<<*itr<<": "<<result.statusMessage()<<std::endl;
+                    }
                 }
             }
         }


### PR DESCRIPTION
osgarchive may fail to add files to archives for various reasons, and it used to fail silently, making you think that it worked just fine, only to realize the problem when you listed the archive and some contents weren't there. This is a very simple change to check the result and report it in case the file wasn't saved in the archive.