### PR TITLE
Allow building gdal, dae, ffmpeg and obj plugins with `/std:c++17` msvc flag 

### DIFF
--- a/src/osgPlugins/dae/ReaderWriterDAE.cpp
+++ b/src/osgPlugins/dae/ReaderWriterDAE.cpp
@@ -32,7 +32,7 @@
 
 #define SERIALIZER() OpenThreads::ScopedLock<OpenThreads::ReentrantMutex> lock(_serializerMutex)
 
-#if  __cplusplus > 199711L
+#if ((defined(_MSVC_LANG) && _MSVC_LANG > 199711L) || __cplusplus > 199711L)
     #define smart_ptr std::unique_ptr
 #else
     #define smart_ptr std::auto_ptr

--- a/src/osgPlugins/ffmpeg/FFmpegImageStream.cpp
+++ b/src/osgPlugins/ffmpeg/FFmpegImageStream.cpp
@@ -10,6 +10,11 @@
 
 #define STREAM_TIMEOUT_IN_SECONDS_TO_CONSIDER_IT_DEAD   10
 
+#if ((defined(_MSVC_LANG) && _MSVC_LANG > 199711L) || __cplusplus > 199711L)
+    #define smart_ptr std::unique_ptr
+#else
+    #define smart_ptr std::auto_ptr
+#endif
 
 namespace osgFFmpeg {
 
@@ -23,8 +28,8 @@ FFmpegImageStream::FFmpegImageStream() :
 {
     setOrigin(osg::Image::TOP_LEFT);
 
-    std::auto_ptr<FFmpegDecoder> decoder(new FFmpegDecoder);
-    std::auto_ptr<CommandQueue> commands(new CommandQueue);
+    smart_ptr<FFmpegDecoder> decoder(new FFmpegDecoder);
+    smart_ptr<CommandQueue> commands(new CommandQueue);
 
     m_decoder = decoder.release();
     m_commands = commands.release();

--- a/src/osgPlugins/gdal/ReaderWriterGDAL.cpp
+++ b/src/osgPlugins/gdal/ReaderWriterGDAL.cpp
@@ -34,6 +34,12 @@
 
 #define SERIALIZER() OpenThreads::ScopedLock<OpenThreads::ReentrantMutex> lock(_serializerMutex)
 
+#if ((defined(_MSVC_LANG) && _MSVC_LANG > 199711L) || __cplusplus > 199711L)
+    #define smart_ptr std::unique_ptr
+#else
+    #define smart_ptr std::auto_ptr
+#endif
+
 // From easyrgb.com
 float Hue_2_RGB( float v1, float v2, float vH )
 {
@@ -123,7 +129,7 @@ class ReaderWriterGDAL : public osgDB::ReaderWriter
 
             initGDAL();
 
-            std::auto_ptr<GDALDataset> dataset((GDALDataset*)GDALOpen(fileName.c_str(),GA_ReadOnly));
+            smart_ptr<GDALDataset> dataset((GDALDataset*)GDALOpen(fileName.c_str(),GA_ReadOnly));
             if (!dataset.get()) return ReadResult::FILE_NOT_HANDLED;
 
             int dataWidth = dataset->GetRasterXSize();
@@ -577,7 +583,7 @@ class ReaderWriterGDAL : public osgDB::ReaderWriter
 
             initGDAL();
 
-            std::auto_ptr<GDALDataset> dataset((GDALDataset*)GDALOpen(fileName.c_str(),GA_ReadOnly));
+            smart_ptr<GDALDataset> dataset((GDALDataset*)GDALOpen(fileName.c_str(),GA_ReadOnly));
             if (!dataset.get()) return ReadResult::FILE_NOT_HANDLED;
 
             int dataWidth = dataset->GetRasterXSize();

--- a/src/osgPlugins/obj/obj.cpp
+++ b/src/osgPlugins/obj/obj.cpp
@@ -37,10 +37,15 @@ using namespace obj;
 
 static std::string strip( const std::string& ss )
 {
-    std::string result;
-    result.assign( std::find_if( ss.begin(), ss.end(), std::not1( std::ptr_fun< int, int >( isspace ) ) ),
-                   std::find_if( ss.rbegin(), ss.rend(), std::not1( std::ptr_fun< int, int >( isspace ) ) ).base() );
-    return( result );
+    std::string::const_iterator it = ss.begin();
+    while (it != ss.end() && isspace(*it))
+        it++;
+
+    std::string::const_reverse_iterator rit = ss.rbegin();
+    while (rit.base() != it && isspace(*rit))
+        rit++;
+
+    return std::string(it, rit.base());
 }
 
 /*


### PR DESCRIPTION
`auto_ptr` is removed in C++17. This PR fixes gdal and ffmpeg plugin in a similar way than dae plugin was fixed (see https://github.com/openscenegraph/OpenSceneGraph/commit/863dee52e20f6446b9497aa4bf1bfaefc0074d1b), but also takes into account that `__cplusplus` always reports `199711L` in msvc when not using special flag `/Zc:__cplusplus` (see https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170#remarks)

`ptr_fun` is also removed in C++17. That's why I provided C++17 compatible version of `strip` function for obj plugin.