### PR TITLE
Support for X1 and X2 mouse buttons.

### DIFF
--- a/include/osgGA/GUIEventAdapter
+++ b/include/osgGA/GUIEventAdapter
@@ -85,7 +85,9 @@ public:
         enum MouseButtonMask {
             LEFT_MOUSE_BUTTON    = 1<<0,
             MIDDLE_MOUSE_BUTTON  = 1<<1,
-            RIGHT_MOUSE_BUTTON   = 1<<2
+            RIGHT_MOUSE_BUTTON   = 1<<2,
+            X1_MOUSE_BUTTON      = 1<<3,
+            X2_MOUSE_BUTTON      = 1<<4
         };
 
         enum EventType {

--- a/include/osgWidget/WindowManager
+++ b/include/osgWidget/WindowManager
@@ -130,6 +130,8 @@ class OSGWIDGET_EXPORT WindowManager: public osg::Switch, public UIObjectParent<
             flag |= _leftDown ? osgGA::GUIEventAdapter::LEFT_MOUSE_BUTTON : 0;
             flag |= _middleDown ? osgGA::GUIEventAdapter::MIDDLE_MOUSE_BUTTON: 0;
             flag |= _rightDown ? osgGA::GUIEventAdapter::RIGHT_MOUSE_BUTTON : 0;
+            flag |= _x1Down ? osgGA::GUIEventAdapter::X1_MOUSE_BUTTON : 0;
+            flag |= _x2Down ? osgGA::GUIEventAdapter::X2_MOUSE_BUTTON : 0;
 
             return flag;
         }
@@ -210,6 +212,14 @@ class OSGWIDGET_EXPORT WindowManager: public osg::Switch, public UIObjectParent<
             return _rightDown;
         }
 
+        bool isX1MouseButtonDown() const {
+            return _x1Down;
+        }
+
+        bool isX2MouseButtonDown() const {
+            return _x2Down;
+        }
+
         bool isMouseScrollingUp() const {
             return _scrolling == osgGA::GUIEventAdapter::SCROLL_UP;
         }
@@ -263,6 +273,14 @@ class OSGWIDGET_EXPORT WindowManager: public osg::Switch, public UIObjectParent<
             return _handleMousePushed(x, y, _rightDown);
         }
 
+        bool mousePushedX1(float x, float y) {
+            return _handleMousePushed(x, y, _x1Down);
+        }
+
+        bool mousePushedX2(float x, float y) {
+            return _handleMousePushed(x, y, _x2Down);
+        }
+
         bool mouseReleasedLeft(float x, float y) {
             return _handleMouseReleased(x, y, _leftDown);
         }
@@ -273,6 +291,14 @@ class OSGWIDGET_EXPORT WindowManager: public osg::Switch, public UIObjectParent<
 
         bool mouseReleasedRight(float x, float y) {
             return _handleMouseReleased(x, y, _rightDown);
+        }
+
+        bool mouseReleasedX1(float x, float y) {
+            return _handleMouseReleased(x, y, _x1Down);
+        }
+
+        bool mouseReleasedX2(float x, float y) {
+            return _handleMouseReleased(x, y, _x2Down);
         }
 
         // Keyboards wrappers, as above; takes the key and key's mask code, which
@@ -320,6 +346,8 @@ class OSGWIDGET_EXPORT WindowManager: public osg::Switch, public UIObjectParent<
         bool               _leftDown;
         bool               _middleDown;
         bool               _rightDown;
+        bool               _x1Down;
+        bool               _x2Down;
 
         osgGA::GUIEventAdapter::ScrollingMotion _scrolling;
 

--- a/src/osgGA/EventQueue.cpp
+++ b/src/osgGA/EventQueue.cpp
@@ -251,6 +251,12 @@ osgGA::GUIEventAdapter* EventQueue::mouseButtonPress(float x, float y, unsigned 
         case(3):
             _accumulateEventState->setButtonMask(GUIEventAdapter::RIGHT_MOUSE_BUTTON | _accumulateEventState->getButtonMask());
             break;
+        case(4):
+            _accumulateEventState->setButtonMask(GUIEventAdapter::X1_MOUSE_BUTTON | _accumulateEventState->getButtonMask());
+            break;
+        case(5):
+            _accumulateEventState->setButtonMask(GUIEventAdapter::X2_MOUSE_BUTTON | _accumulateEventState->getButtonMask());
+            break;
     }
 
     GUIEventAdapter* event = new GUIEventAdapter(*_accumulateEventState);
@@ -267,6 +273,12 @@ osgGA::GUIEventAdapter* EventQueue::mouseButtonPress(float x, float y, unsigned 
             break;
         case(3):
             event->setButton(GUIEventAdapter::RIGHT_MOUSE_BUTTON);
+            break;
+        case(4):
+            event->setButton(GUIEventAdapter::X1_MOUSE_BUTTON);
+            break;
+        case(5):
+            event->setButton(GUIEventAdapter::X2_MOUSE_BUTTON);
             break;
     }
 
@@ -290,6 +302,12 @@ osgGA::GUIEventAdapter* EventQueue::mouseDoubleButtonPress(float x, float y, uns
             break;
         case(3):
             _accumulateEventState->setButtonMask(GUIEventAdapter::RIGHT_MOUSE_BUTTON | _accumulateEventState->getButtonMask());
+            break;
+        case(4):
+            _accumulateEventState->setButtonMask(GUIEventAdapter::X1_MOUSE_BUTTON | _accumulateEventState->getButtonMask());
+            break;
+        case(5):
+            _accumulateEventState->setButtonMask(GUIEventAdapter::X2_MOUSE_BUTTON | _accumulateEventState->getButtonMask());
             break;
     }
 
@@ -330,6 +348,12 @@ osgGA::GUIEventAdapter* EventQueue::mouseButtonRelease(float x, float y, unsigne
             break;
         case(3):
             _accumulateEventState->setButtonMask(~GUIEventAdapter::RIGHT_MOUSE_BUTTON & _accumulateEventState->getButtonMask());
+            break;
+        case(4):
+            _accumulateEventState->setButtonMask(~GUIEventAdapter::X1_MOUSE_BUTTON & _accumulateEventState->getButtonMask());
+            break;
+        case(5):
+            _accumulateEventState->setButtonMask(~GUIEventAdapter::X2_MOUSE_BUTTON & _accumulateEventState->getButtonMask());
             break;
     }
 

--- a/src/osgGA/Widget.cpp
+++ b/src/osgGA/Widget.cpp
@@ -71,6 +71,8 @@ void Widget::updateFocus(osg::NodeVisitor& nv)
                         if (ea->getButtonMask()&osgGA::GUIEventAdapter::LEFT_MOUSE_BUTTON) ++numButtonsPressed;
                         if (ea->getButtonMask()&osgGA::GUIEventAdapter::MIDDLE_MOUSE_BUTTON) ++numButtonsPressed;
                         if (ea->getButtonMask()&osgGA::GUIEventAdapter::RIGHT_MOUSE_BUTTON) ++numButtonsPressed;
+                        if (ea->getButtonMask()&osgGA::GUIEventAdapter::X1_MOUSE_BUTTON) ++numButtonsPressed;
+                        if (ea->getButtonMask()&osgGA::GUIEventAdapter::X2_MOUSE_BUTTON) ++numButtonsPressed;
 
                         if (numButtonsPressed==1)
                         {

--- a/src/osgPlugins/osc/OscSendingDevice.cpp
+++ b/src/osgPlugins/osc/OscSendingDevice.cpp
@@ -261,6 +261,12 @@ int OscSendingDevice::getButtonNum(const osgGA::GUIEventAdapter& ea)
         case osgGA::GUIEventAdapter::RIGHT_MOUSE_BUTTON:
             return 3;
             break;
+        case osgGA::GUIEventAdapter::X1_MOUSE_BUTTON:
+            return 4;
+            break;
+        case osgGA::GUIEventAdapter::X2_MOUSE_BUTTON:
+            return 5;
+            break;
         default:
             return -1;
     }

--- a/src/osgUI/Widget.cpp
+++ b/src/osgUI/Widget.cpp
@@ -81,6 +81,8 @@ void Widget::updateFocus(osg::NodeVisitor& nv)
                     if (ea->getButtonMask()&osgGA::GUIEventAdapter::LEFT_MOUSE_BUTTON) ++numButtonsPressed;
                     if (ea->getButtonMask()&osgGA::GUIEventAdapter::MIDDLE_MOUSE_BUTTON) ++numButtonsPressed;
                     if (ea->getButtonMask()&osgGA::GUIEventAdapter::RIGHT_MOUSE_BUTTON) ++numButtonsPressed;
+                    if (ea->getButtonMask()&osgGA::GUIEventAdapter::X1_MOUSE_BUTTON) ++numButtonsPressed;
+                    if (ea->getButtonMask()&osgGA::GUIEventAdapter::X2_MOUSE_BUTTON) ++numButtonsPressed;
                 }
 
                 bool previousFocus = _hasEventFocus;

--- a/src/osgWidget/ViewerEventHandlers.cpp
+++ b/src/osgWidget/ViewerEventHandlers.cpp
@@ -53,6 +53,18 @@ bool MouseHandler::_handleMousePush(float x, float y, int button) {
         &WindowManager::mousePushedMiddle
     );
 
+    else if(button == osgGA::GUIEventAdapter::X1_MOUSE_BUTTON) return _doMouseEvent(
+            x,
+            y,
+            &WindowManager::mousePushedX1
+            );
+
+    else if(button == osgGA::GUIEventAdapter::X2_MOUSE_BUTTON) return _doMouseEvent(
+            x,
+            y,
+            &WindowManager::mousePushedX2
+            );
+
     else return false;
 }
 

--- a/src/osgWidget/WindowManager.cpp
+++ b/src/osgWidget/WindowManager.cpp
@@ -38,6 +38,8 @@ _focusMode      (PFM_FOCUS),
 _leftDown       (false),
 _middleDown     (false),
 _rightDown      (false),
+_x1Down         (false),
+_x2Down         (false),
 _scrolling      (osgGA::GUIEventAdapter::SCROLL_NONE),
 _styleManager   (new StyleManager()) {
     _name = generateRandomName("WindowManager");
@@ -105,6 +107,8 @@ WindowManager::WindowManager(const WindowManager& wm, const osg::CopyOp& co):
     _leftDown       (false),
     _middleDown     (false),
     _rightDown      (false),
+    _x1Down         (false),
+    _x2Down         (false),
     _scrolling      (osgGA::GUIEventAdapter::SCROLL_NONE),
     _styleManager   (new StyleManager())
 {
@@ -517,6 +521,8 @@ bool WindowManager::pointerMove(float x, float y) {
         _leftDown   = 0;
         _middleDown = 0;
         _rightDown  = 0;
+        _x1Down     = 0;
+        _x2Down     = 0;
 
         return false;
     }


### PR DESCRIPTION
Added support for X1 and X2 mouse buttons (5-button mouse).

osgGA::GUIEventAdapter::X1_MOUSE_BUTTON and osgGA::GUIEventAdapter::X2_MOUSE_BUTTON enumeration values are added and their processing for push, release, current state , etc.