### PR TITLE
Implement X11 HW-synced swapping using glXJoinSwapGroupNV, glXBindSwa…

### DIFF
--- a/include/osgViewer/api/X11/GraphicsWindowX11
+++ b/include/osgViewer/api/X11/GraphicsWindowX11
@@ -125,6 +125,9 @@ class OSGVIEWER_EXPORT GraphicsWindowX11 : public osgViewer::GraphicsWindow, pub
         /** Set mouse cursor to a specific shape.*/
         virtual void setCursor(MouseCursor cursor);
 
+        /** Set swap group. */
+        virtual void setSwapGroup(bool on, GLuint group, GLuint barrier);
+
         /** WindowData is used to pass in the X11 window handle attached the GraphicsContext::Traits structure. */
         struct WindowData : public osg::Referenced
         {


### PR DESCRIPTION
…pBarrierNV, and the existing traits

This change is meant to be analogous to commit 634344aef504 ("From Marius Heise, "here is a patch that implements Win32 HW-synced swapping using wglJoinSwapGroupNV, wglBindSwapBarrierNV and the existing traits. It was tested with multiple ATI FirePro S400 cards.") for the X11 backend. Tested using multiple NVIDIA A5000 cards. The NVIDIA driver stack requires that the swap group join and bind calls occur on the same thread context that is doing the swap buffer operation.